### PR TITLE
Fix Waze alerts disappearing, cold-start latency, and heading/type fidelity (v1.3)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -73,9 +73,13 @@ app/src/main/java/app/sabre/wzsabre/
 ├── SabreAlert.java              # Internal alert model
 │
 └── waze/                        # Waze mobile "RT" protocol (replaces the 403'd georss API)
-    ├── WazeProtocolSource.java  #   public entry point: cache + async refresh + map to SabreAlert
-    ├── WazeSession.java         #   register → login → handshake → query
-    ├── WazeRtCodec.java         #   protobuf line framing, ClientInfo, commands, parseAlerts
+    ├── WazeProtocolSource.java  #   public entry point: cache + async refresh + pre-warm + map to SabreAlert
+    ├── WazeAlertCache.java      #   persistent uuid-keyed cache: merge adds + soft-delete removals
+    ├── AlertQueryResult.java    #   one query's {newAlerts, removedIds} deltas
+    ├── GeoBoxes.java            #   shrinking-box geometry so near-driver alerts aren't thinned
+    ├── WazeConfirmTracker.java  #   infers confirm_ts from thumbs-up increases (1-hour map)
+    ├── WazeSession.java         #   register → login → handshake → queryBox
+    ├── WazeRtCodec.java         #   protobuf line framing, ClientInfo, commands, parseAlerts, parseRemovedAlertIds
     ├── WazeHttpClient.java      #   OkHttp binary POST + session cookie jar + retry
     ├── DeviceIdentity.java      #   synthetic device fingerprint pool
     ├── WazeConstants.java       #   hosts, paths, protocol/app versions
@@ -104,6 +108,15 @@ with a `uid` auth header). Because an RT query long-polls (~10s), `WazeProtocolS
 a cache and refreshes it on a background thread, and persists/reuses the account so it
 registers at most once. The protobuf schema lives at `app/src/main/proto/waze.proto` and is
 compiled with `protobuf-javalite` (gradle `com.google.protobuf` plugin).
+
+The RT `/command` endpoint is session-stateful — it sends each alert once, then a
+`"RmAlert,<uuid>"` `old_command` line when it clears — so `WazeAlertCache` **merges** query
+deltas (adds upsert, removals soft-delete for 5 min) instead of replacing the cache, which is
+what stops alerts from vanishing mid-drive. Each refresh queries a series of progressively
+smaller boxes (`GeoBoxes`, the official's shrinking-bbox path) so the server doesn't thin out
+minor alerts near the driver; the session is pre-warmed at service start from the last known
+location; and Waze subtype names are passed through to HR verbatim (no remap/whitelist), since
+HR understands the full Waze vocabulary. This mirrors the official wzsabre 2.2 `WazeAlertFetcher`.
 
 ### Caltrans LCS closures
 Lane/road closures come from the per-district Caltrans Lane Closure System feeds

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you already have wzsabre installed:
 - On Android 15: open this app first, then HR. The background service must be running before HR requests data.
 
 **CHP alerts visible but no Waze alerts**
-- Waze requires a real internet connection. On first use the plugin registers an anonymous Waze session in the background — Waze alerts can take ~10–20 seconds to appear after you start a session, then refresh continuously thereafter.
+- Waze requires a real internet connection. On the very first use the plugin registers an anonymous Waze session in the background — Waze alerts can take ~10–20 seconds to appear that first time. After that the session and a live alert cache are kept warm and pre-loaded at start, so alerts appear within a second or two on subsequent sessions.
 - Check that the app has network permission (it should request none explicitly; all network access is in the background service).
 
 **No alerts at all**
@@ -125,7 +125,7 @@ Highway Radar  ──broadcast──▶  MainBroadcastReceiver
 ```
 
 - **CHP**: fetches `https://media.chp.ca.gov/sa_xml/sa.xml`, filters by radius and incident age, applies your category settings.
-- **Waze**: emulates the Waze mobile app's binary "RT" protocol — it registers an anonymous Waze session, logs in, and queries crowd-sourced alerts over Waze's protobuf API (the older live-map/georss API is now blocked). This matches the approach in the current official wzsabre.
+- **Waze**: emulates the Waze mobile app's binary "RT" protocol — it registers an anonymous Waze session, logs in, and queries crowd-sourced alerts over Waze's protobuf API (the older live-map/georss API is now blocked). This matches the approach in the current official wzsabre. The RT feed is session-stateful (each alert is sent once, then removed when it clears), so query results are merged into a persistent alert cache rather than replacing it — this keeps alerts from disappearing as you drive. A series of progressively smaller map viewports is queried so the server doesn't thin out minor alerts near you, the session is pre-warmed at start to cut first-load latency, and Waze alert subtypes (e.g. *car stopped on shoulder*, *heavy traffic*) are passed through to Highway Radar verbatim rather than flattened.
 - **Caltrans LCS**: fetches the per-district lane-closure feeds (`https://cwwp2.dot.ca.gov/data/d<N>/lcs/lcsStatusD<NN>.xml`) for whichever districts cover your location. Only closures that are physically established (CHP code 1097 set, not picked up or canceled) are shown; shoulder-only closures are skipped. Closures longer than 2 km get a pin at each end. The ~4 MB feeds are parsed in the background and cached for 5 minutes, so they never delay a Highway Radar request.
 - **SABRE protocol**: a broadcast-intent IPC protocol defined by Highway Radar. Our plugin responds to `FETCH_REQUEST` broadcasts with a JSON payload containing `SabreFetchResponseAlert` objects.
 
@@ -139,7 +139,7 @@ Pull requests welcome. Run the test suite before submitting:
 ./gradlew test
 ```
 
-162 unit tests cover the SABRE response format, alert type mapping, CHP XML parsing, Caltrans LCS parsing and filtering, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup.
+184 unit tests cover the SABRE response format, alert type mapping, the Waze alert cache (delta merge + soft-delete), shrinking-box geometry, crowd-confirmation tracking, CHP XML parsing, Caltrans LCS parsing and filtering, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup.
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "app.sabre.wzsabre"
         minSdk = 23
         targetSdk = 35
-        versionCode = 3
-        versionName = "1.2"
+        versionCode = 4
+        versionName = "1.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/CHPSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/CHPSource.java
@@ -184,7 +184,7 @@ public class CHPSource {
         return new SabreAlert(
                 "chp_" + logId,
                 SabreResponseBuilder.SOURCE_CHP,
-                finalType, lat, lon, 0.0, streetName, reportTs);
+                finalType, lat, lon, SabreResponseBuilder.HEADING_UNKNOWN, streetName, reportTs);
     }
 
     // ── Time parsing ──────────────────────────────────────────────────────────

--- a/app/src/main/java/app/sabre/wzsabre/LcsSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/LcsSource.java
@@ -286,13 +286,14 @@ public class LcsSource {
         long reportTs = c.epoch1097 > 0 ? c.epoch1097 : c.startEpoch;
         String street = describe(c);
         out.add(new SabreAlert("lcs_" + c.index, SabreResponseBuilder.SOURCE_LCS,
-                "HAZARD_ON_ROAD_CONGESTION", c.beginLat, c.beginLon, 0.0, street, reportTs));
+                "HAZARD_ON_ROAD_CONGESTION", c.beginLat, c.beginLon,
+                SabreResponseBuilder.HEADING_UNKNOWN, street, reportTs));
         if (hasEndPoint(c)
                 && CHPSource.haversineMeters(c.beginLat, c.beginLon, c.endLat, c.endLon)
                         > END_PIN_MIN_METERS) {
             out.add(new SabreAlert("lcs_" + c.index + "_end", SabreResponseBuilder.SOURCE_LCS,
-                    "HAZARD_ON_ROAD_CONGESTION", c.endLat, c.endLon, 0.0,
-                    "End: " + street, reportTs));
+                    "HAZARD_ON_ROAD_CONGESTION", c.endLat, c.endLon,
+                    SabreResponseBuilder.HEADING_UNKNOWN, "End: " + street, reportTs));
         }
         return out;
     }

--- a/app/src/main/java/app/sabre/wzsabre/SabreAlert.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreAlert.java
@@ -11,11 +11,14 @@ public class SabreAlert {
     public final double lon;
     public final double headingDeg;
     public final String streetName;
-    public final long reportTs;  // seconds since epoch
+    public final long reportTs;       // seconds since epoch
+    public final Long confirmTs;      // seconds since epoch, or null if never confirmed
+    public final int  confirmCount;   // crowd confirmations (Waze thumbs-up); 0 for CHP/LCS
 
     public SabreAlert(String alertId, String alertSource, String type,
                       double lat, double lon, double headingDeg,
-                      String streetName, long reportTs) {
+                      String streetName, long reportTs,
+                      Long confirmTs, int confirmCount) {
         this.alertId = alertId;
         this.alertSource = alertSource;
         this.type = type;
@@ -24,5 +27,14 @@ public class SabreAlert {
         this.headingDeg = headingDeg;
         this.streetName = streetName;
         this.reportTs = reportTs;
+        this.confirmTs = confirmTs;
+        this.confirmCount = confirmCount;
+    }
+
+    /** Convenience for sources with no crowd-confirmation data (CHP, LCS). */
+    public SabreAlert(String alertId, String alertSource, String type,
+                      double lat, double lon, double headingDeg,
+                      String streetName, long reportTs) {
+        this(alertId, alertSource, type, lat, lon, headingDeg, streetName, reportTs, null, 0);
     }
 }

--- a/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
@@ -27,6 +27,16 @@ public class SabreResponseBuilder {
     public static final String SOURCE_WAZE = "waze";
     public static final String SOURCE_LCS  = "lcs";
 
+    /**
+     * heading_deg value for an alert with no known travel direction. The official
+     * wzsabre sends -720.0 when an alert's magvar is unknown; HR treats this
+     * out-of-range bearing as "directionless" and shows the alert regardless of
+     * which way the driver is travelling. Sending 0.0 instead would claim the alert
+     * faces due north, which can make HR direction-filter it away. CHP incidents
+     * and LCS closures never carry a direction, so they use this.
+     */
+    public static final double HEADING_UNKNOWN = -720.0;
+
     // USER_ID_REGEX matches Waze alert IDs of the form "alert-<digits>/..."
     private static final Pattern USER_ID_PATTERN = Pattern.compile("alert-(\\d*)/.*");
 

--- a/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
@@ -179,8 +179,12 @@ public class SabreResponseBuilder {
         obj.put("heading_deg",   a.headingDeg);
         obj.put("street_name",   a.streetName != null ? a.streetName : JSONObject.NULL);
         obj.put("report_ts",     (int) a.reportTs);
-        obj.put("confirm_ts",    JSONObject.NULL);          // nullable Int
-        obj.put("confirm_count", 0);
+        // confirm_ts is a nullable Int (epoch seconds); present but null unless the
+        // alert has been crowd-confirmed and the timestamp fits in Int.
+        boolean confirmTsFits = a.confirmTs != null
+                && a.confirmTs >= 0 && a.confirmTs <= Integer.MAX_VALUE;
+        obj.put("confirm_ts",    confirmTsFits ? (int) (long) a.confirmTs : JSONObject.NULL);
+        obj.put("confirm_count", Math.max(0, a.confirmCount));
         return obj;
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
@@ -41,18 +41,60 @@ public class SabreResponseBuilder {
     private static final Pattern USER_ID_PATTERN = Pattern.compile("alert-(\\d*)/.*");
 
     /**
-     * Every alert type HR's SabreFetchResponseAlert deserializer accepts. An alert
-     * with any other type string would crash HR's renderer, so unknown types are
-     * dropped in {@link #build} rather than sent.
+     * Alert type strings HR's renderer accepts. This is the union of (a) the
+     * canonical SABRE types our CHP/LCS sources emit and (b) the full Waze alert
+     * type + subtype vocabulary, which the official wzsabre passes through raw to
+     * the same HR app — so HR is known to handle every string here. An alert whose
+     * type is outside this set can only be a bug in our own mapping, so {@link
+     * #build} drops it rather than risk HR's renderer on an unexpected string.
+     *
+     * <p>The Waze entries are the exact enum names the official's ALERT_TYPE_NAMES /
+     * ALERT_SUBTYPE_NAMES maps produce (see WazeRtCodec.typeName/subTypeName).
      */
     private static final java.util.Set<String> VALID_TYPES = new java.util.HashSet<>(
             java.util.Arrays.asList(
+                    // ── canonical SABRE types emitted by the CHP and LCS sources ──
                     "POLICE_VISIBLE", "POLICE_HIDDEN",
                     "ACCIDENT_MAJOR", "ACCIDENT_MINOR",
                     "HAZARD_ON_ROAD_DEBRIS", "HAZARD_ON_ROAD_CONGESTION",
                     "HAZARD_ON_ROAD_SLIPPERY", "HAZARD_ON_ROAD_POT_HOLE",
                     "HAZARD_WEATHER_FOG", "HAZARD_WEATHER_RAIN", "HAZARD_WEATHER_SNOW",
-                    "HAZARD_WEATHER_WIND", "HAZARD_WEATHER_STORM", "HAZARD_WEATHER_HAIL"));
+                    "HAZARD_WEATHER_WIND", "HAZARD_WEATHER_STORM", "HAZARD_WEATHER_HAIL",
+                    // ── Waze alert type names (subtype empty → type passed through) ──
+                    "CHIT_CHAT", "POLICE", "ACCIDENT", "JAM", "TRAFFIC_INFO", "HAZARD",
+                    "MISC", "CONSTRUCTION", "PARKING", "DYNAMIC", "CAMERA",
+                    "ROAD_CLOSED", "SYSTEM_ROAD_CLOSED", "UNKNOWN_ALERT", "SOS",
+                    "CRASH_PRONE", "TURN_CLOSED", "NEW_BAD_WEATHER", "NEW_LANE_CLOSED",
+                    "PERMANENT_HAZARD", "PERSONAL_SAFETY", "UNKNOWN",
+                    // ── Waze alert subtype names ──
+                    "POLICE_HIDING", "POLICE_WITH_MOBILE_CAMERA",
+                    "JAM_MODERATE_TRAFFIC", "JAM_HEAVY_TRAFFIC",
+                    "JAM_STAND_STILL_TRAFFIC", "JAM_LIGHT_TRAFFIC",
+                    "HAZARD_ON_ROAD", "HAZARD_ON_SHOULDER", "HAZARD_WEATHER",
+                    "HAZARD_ON_ROAD_OBJECT", "HAZARD_ON_ROAD_ROAD_KILL",
+                    "HAZARD_ON_SHOULDER_CAR_STOPPED", "HAZARD_ON_SHOULDER_ANIMALS",
+                    "HAZARD_ON_SHOULDER_MISSING_SIGN",
+                    "HAZARD_WEATHER_HEAVY_RAIN", "HAZARD_WEATHER_HEAVY_SNOW",
+                    "HAZARD_WEATHER_FLOOD", "HAZARD_WEATHER_MONSOON",
+                    "HAZARD_WEATHER_TORNADO", "HAZARD_WEATHER_HEAT_WAVE",
+                    "HAZARD_WEATHER_HURRICANE", "HAZARD_WEATHER_FREEZING_RAIN",
+                    "HAZARD_ON_ROAD_LANE_CLOSED", "HAZARD_ON_ROAD_OIL",
+                    "HAZARD_ON_ROAD_ICE", "HAZARD_ON_ROAD_CONSTRUCTION",
+                    "HAZARD_ON_ROAD_CAR_STOPPED", "HAZARD_ON_ROAD_TRAFFIC_LIGHT_FAULT",
+                    "HAZARD_ON_ROAD_EMERGENCY_VEHICLE",
+                    "ROAD_CLOSED_HAZARD", "ROAD_CLOSED_CONSTRUCTION", "ROAD_CLOSED_EVENT",
+                    "SOS_FLAT_TIRE", "SOS_NO_FUEL", "SOS_MEDICAL_HELP",
+                    "SOS_MECHANICAL_PROBLEM", "SOS_OTHER", "SOS_BATTERY_ISSUE",
+                    "CRASH_PRONE_SHORT_ALERT_LENGTH", "CRASH_PRONE_LONG_ALERT_LENGTH",
+                    "TURN_CLOSED_EVENT", "BAD_WEATHER_DEFAULT", "BAD_WEATHER_SLIPPERY_ROAD",
+                    "LANE_CLOSURE_BLOCKED_LANES", "LANE_CLOSURE_LEFT_LANE",
+                    "LANE_CLOSURE_RIGHT_LANE", "LANE_CLOSURE_CENTER_LANE",
+                    "PERMANENT_HAZARD_SPEED_BUMP", "PERMANENT_HAZARD_TOPES",
+                    "PERMANENT_HAZARD_TOLL_BOOTH", "PERMANENT_HAZARD_DANGEROUS_CURVE",
+                    "PERMANENT_HAZARD_DANGEROUS_INTERSECTION",
+                    "PERMANENT_HAZARD_DANGEROUS_SPLIT", "PERMANENT_HAZARD_DANGEROUS_MERGE",
+                    "PERMANENT_HAZARD_SCHOOL_ZONE",
+                    "DEFAULT_PERSONAL_SAFETY", "DEFAULT_CAMERA"));
 
     public static boolean isValidType(String type) {
         return type != null && VALID_TYPES.contains(type);

--- a/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
@@ -37,6 +37,9 @@ public class SabreResponseBuilder {
      */
     public static final double HEADING_UNKNOWN = -720.0;
 
+    /** Max alerts per response batch — matches the official wzsabre (200). */
+    public static final int MAX_ALERTS_PER_BATCH = 200;
+
     // USER_ID_REGEX matches Waze alert IDs of the form "alert-<digits>/..."
     private static final Pattern USER_ID_PATTERN = Pattern.compile("alert-(\\d*)/.*");
 
@@ -131,13 +134,26 @@ public class SabreResponseBuilder {
      * </pre>
      */
     public static String build(String requestId, List<SabreAlert> alerts) throws JSONException {
+        return build(requestId, alerts, 1, 0);
+    }
+
+    /**
+     * Build one batch of a multi-batch response. HR's wire format carries
+     * {@code n_batches} (total) and {@code batch_id} (0-based); the official
+     * wzsabre splits a fetch response into batches of {@value #MAX_ALERTS_PER_BATCH}
+     * alerts, each sent as a separate broadcast. {@code batchAlerts} is the slice
+     * for this batch.
+     */
+    public static String build(String requestId, List<SabreAlert> batchAlerts,
+                               int nBatches, int batchId) throws JSONException {
         JSONObject root = new JSONObject();
         root.put("request_id",    requestId);
         root.put("error_message", JSONObject.NULL);
 
         JSONObject responseData = new JSONObject();
-        responseData.put("n_batches", 1);
-        responseData.put("batch_id",  0);
+        responseData.put("n_batches", nBatches);
+        responseData.put("batch_id",  batchId);
+        List<SabreAlert> alerts = batchAlerts;
 
         // One malformed alert must never take down the whole response (HR would
         // get nothing and show "plugin not responding") — drop it and keep the rest.

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -35,6 +35,13 @@ public class SabreService extends Service {
     private LcsSource lcsSource;
     private app.sabre.wzsabre.waze.WazeProtocolSource wazeSource;
 
+    // Last fetch location, persisted so the Waze session can be pre-warmed at the
+    // next service start (HR's handshake starts the service before its first
+    // FETCH_REQUEST). Without this, a cold start has to register/login/query Waze
+    // while HR is already waiting, so police alerts took 10-15s to appear vs the
+    // official's <2s. See WazeProtocolSource.prewarm.
+    private static final String STATE_PREFS = "sabre_state";
+
     @Override
     public void onCreate() {
         super.onCreate();
@@ -45,7 +52,29 @@ public class SabreService extends Service {
         wazeSource = new app.sabre.wzsabre.waze.WazeProtocolSource(this);
         createNotificationChannel();
         startForeground(NOTIFICATION_ID, buildForegroundNotification());
+        prewarmFromLastLocation();
         Log.d(TAG, "Service started");
+    }
+
+    /** Kick off a Waze refresh for the last known location so the cache is warm
+     *  by the time HR sends its first FETCH_REQUEST after a (re)start. */
+    private void prewarmFromLastLocation() {
+        android.content.SharedPreferences p = getSharedPreferences(STATE_PREFS, MODE_PRIVATE);
+        if (!p.contains("last_lat")) return;
+        double lat = Double.longBitsToDouble(p.getLong("last_lat", 0));
+        double lon = Double.longBitsToDouble(p.getLong("last_lon", 0));
+        double radius = Double.longBitsToDouble(p.getLong("last_radius", 0));
+        if (radius <= 0) radius = 80_000;
+        Log.d(TAG, String.format("Pre-warming Waze for last location %.4f,%.4f", lat, lon));
+        wazeSource.prewarm(lat, lon, radius);
+    }
+
+    private void saveLastLocation(double lat, double lon, double radius) {
+        getSharedPreferences(STATE_PREFS, MODE_PRIVATE).edit()
+                .putLong("last_lat", Double.doubleToRawLongBits(lat))
+                .putLong("last_lon", Double.doubleToRawLongBits(lon))
+                .putLong("last_radius", Double.doubleToRawLongBits(radius))
+                .apply();
     }
 
     @Override
@@ -86,6 +115,7 @@ public class SabreService extends Service {
                 double radius = req.has("radius_m") ? req.getDouble("radius_m") : req.getDouble("radius");
 
                 Log.d(TAG, String.format("Fetch: lat=%.4f lon=%.4f radius=%.0fm", lat, lon, radius));
+                saveLastLocation(lat, lon, radius);
 
                 long deadline = System.currentTimeMillis() + RESPONSE_BUDGET_MS;
 

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -238,12 +238,23 @@ public class SabreService extends Service {
 
     private void sendFetchResponse(String responseAction, String requestId,
                                     List<SabreAlert> alerts) throws JSONException {
-        String responseJson = SabreResponseBuilder.build(requestId, alerts);
-        Intent intent = new Intent(responseAction);
-        intent.putExtra("data", responseJson);
-        sendBroadcast(intent);
-        Log.d(TAG, "Response sent to: " + responseAction);
-        Log.d(TAG, "Response JSON: " + responseJson);
+        // Split into batches of MAX_ALERTS_PER_BATCH, each its own broadcast, with
+        // n_batches/batch_id set — mirrors the official wzsabre. Always ≥1 batch
+        // (an empty list still sends one empty batch so HR sees a response).
+        int n = alerts.size();
+        int batchSize = SabreResponseBuilder.MAX_ALERTS_PER_BATCH;
+        int nBatches = Math.max(1, (n + batchSize - 1) / batchSize);
+        for (int i = 0; i < nBatches; i++) {
+            int from = i * batchSize;
+            int to = Math.min(n, from + batchSize);
+            String responseJson = SabreResponseBuilder.build(
+                    requestId, alerts.subList(from, to), nBatches, i);
+            Intent intent = new Intent(responseAction);
+            intent.putExtra("data", responseJson);
+            sendBroadcast(intent);
+            Log.d(TAG, "Response batch " + (i + 1) + "/" + nBatches + " sent to: " + responseAction);
+            Log.d(TAG, "Response JSON: " + responseJson);
+        }
     }
 
     private void createNotificationChannel() {

--- a/app/src/main/java/app/sabre/wzsabre/waze/AlertQueryResult.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/AlertQueryResult.java
@@ -1,0 +1,23 @@
+package app.sabre.wzsabre.waze;
+
+import java.util.List;
+
+/**
+ * The result of one Waze RT area query: the alerts the server added (as
+ * AddAlertAction elements) and the uuids it removed (as "RmAlert," old_command
+ * lines). Mirrors wzsabre 2.2 wazemo.AlertQueryResult.
+ *
+ * The RT /command endpoint is session-stateful — it only sends an alert once per
+ * session, then a removal when it clears — so callers must MERGE these deltas into
+ * a persistent cache rather than treat each result as a full snapshot. See
+ * {@link WazeAlertCache}.
+ */
+final class AlertQueryResult {
+    final List<WazeAlert> newAlerts;
+    final List<String> removedIds;
+
+    AlertQueryResult(List<WazeAlert> newAlerts, List<String> removedIds) {
+        this.newAlerts = newAlerts;
+        this.removedIds = removedIds;
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/waze/GeoBoxes.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/GeoBoxes.java
@@ -1,0 +1,48 @@
+package app.sabre.wzsabre.waze;
+
+/**
+ * Bounding-box geometry for Waze RT area queries, ported from wzsabre 2.2
+ * {@code GeoUtils} (circleToBox / shrinkBox) and {@code WazeAlertFetcher}
+ * (getShrinkingBboxes).
+ *
+ * <p>A single MapDisplayed query over the full HR radius is thinned server-side by
+ * viewport size, so minor/near-driver alerts (e.g. a car stopped on the shoulder)
+ * get dropped. The official queries a series of progressively smaller boxes around
+ * the driver; the smaller the viewport the less the server thins it, so the inner
+ * detail comes through. Each box is shrunk to 0.75 before querying, exactly as the
+ * official's {@code scanBoxes} does for the primary slot.
+ *
+ * <p>Boxes are {@code [lonMin, latMin, lonMax, latMax]}.
+ */
+final class GeoBoxes {
+    private GeoBoxes() {}
+
+    /** {@code GeoUtils.circleToBox}: a lon/lat box of half-width radiusM around the point. */
+    static double[] circleToBox(double lon, double lat, double radiusM) {
+        double dLat = radiusM / WazeConstants.M_PER_DEG_LAT;
+        double dLon = radiusM / WazeConstants.mPerDegLon(lat);
+        return new double[]{lon - dLon, lat - dLat, lon + dLon, lat + dLat};
+    }
+
+    /** {@code GeoUtils.shrinkBox}: same center, half-extent scaled by {@code factor}. */
+    static double[] shrink(double[] box, double factor) {
+        double cx = (box[0] + box[2]) / 2.0;
+        double cy = (box[1] + box[3]) / 2.0;
+        double hx = ((box[2] - box[0]) / 2.0) * factor;
+        double hy = ((box[3] - box[1]) / 2.0) * factor;
+        return new double[]{cx - hx, cy - hy, cx + hx, cy + hy};
+    }
+
+    /**
+     * {@code WazeAlertFetcher.getShrinkingBboxes}: the full-radius box, then each
+     * successive box halved, for {@code steps} zoom levels in all.
+     */
+    static double[][] shrinkingBoxes(double lon, double lat, double radiusM, int steps) {
+        double[][] out = new double[steps][];
+        out[0] = circleToBox(lon, lat, radiusM);
+        for (int i = 1; i < steps; i++) {
+            out[i] = shrink(out[i - 1], 0.5);
+        }
+        return out;
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeAlertCache.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeAlertCache.java
@@ -1,0 +1,86 @@
+package app.sabre.wzsabre.waze;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Persistent uuid-keyed alert cache with soft-delete — ported verbatim from the
+ * official wzsabre 2.2 {@code WazeAlertFetcher} (alertCache + softDeleted +
+ * submitAlerts + purgeExpiredSoftDeletes + isSoftDeleteExpired + return filter).
+ *
+ * <p>WHY this exists: the Waze RT {@code /command} endpoint is session-stateful.
+ * It returns each alert as an {@code AddAlertAction} only ONCE per session, then a
+ * {@code "RmAlert,<uuid>"} removal line when the alert clears. The previous source
+ * replaced its cache with every response, so after the first query the cache went
+ * near-empty and alerts vanished from Highway Radar mid-drive. This class instead
+ * accumulates adds and soft-deletes removals (kept {@link #SOFT_DELETE_MS} before
+ * purge), so the merged view stays complete.
+ */
+final class WazeAlertCache {
+    /** wzsabre uses PeriodicWorkRequest.MIN_PERIODIC_FLEX_MILLIS (5 minutes). */
+    static final long SOFT_DELETE_MS = 5 * 60_000L;
+
+    private final Map<String, WazeAlert> alertCache = new LinkedHashMap<>();
+    private final Map<String, Long> softDeleted = new LinkedHashMap<>();
+
+    /** Apply one query's deltas: upsert adds, soft-delete removals still cached. */
+    synchronized void submit(AlertQueryResult result) {
+        for (WazeAlert a : result.newAlerts) {
+            if (a.uuid != null && a.uuid.length() != 0) {
+                alertCache.put(a.uuid, a);
+                softDeleted.remove(a.uuid);
+            }
+        }
+        long now = System.currentTimeMillis();
+        for (String id : result.removedIds) {
+            if (alertCache.containsKey(id) && !softDeleted.containsKey(id)) {
+                softDeleted.put(id, now);
+            }
+        }
+    }
+
+    private void purgeExpiredSoftDeletes() {
+        long now = System.currentTimeMillis();
+        List<String> expired = new ArrayList<>();
+        for (Map.Entry<String, Long> e : softDeleted.entrySet()) {
+            if (now - e.getValue() >= SOFT_DELETE_MS) expired.add(e.getKey());
+        }
+        for (String id : expired) {
+            alertCache.remove(id);
+            softDeleted.remove(id);
+        }
+    }
+
+    private boolean isSoftDeleteExpired(String uuid) {
+        Long t = softDeleted.get(uuid);
+        return t != null && System.currentTimeMillis() - t >= SOFT_DELETE_MS;
+    }
+
+    /**
+     * Live view of the cache: purge expired soft-deletes, then return every cached
+     * alert that is not currently soft-deleted. Mirrors the tail of
+     * {@code WazeAlertFetcher.fetchArea}.
+     */
+    synchronized List<WazeAlert> snapshot() {
+        purgeExpiredSoftDeletes();
+        List<WazeAlert> out = new ArrayList<>();
+        for (WazeAlert a : alertCache.values()) {
+            if (!(softDeleted.containsKey(a.uuid) && !isSoftDeleteExpired(a.uuid))) {
+                out.add(a);
+            }
+        }
+        return out;
+    }
+
+    synchronized void clear() {
+        alertCache.clear();
+        softDeleted.clear();
+    }
+
+    synchronized int size() {
+        return alertCache.size();
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeConfirmTracker.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeConfirmTracker.java
@@ -1,0 +1,62 @@
+package app.sabre.wzsabre.waze;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Derives an alert's {@code confirm_ts} the way the official wzsabre does
+ * (WazeAlertJsonAlert.confirmMillis): the Waze RT feed has no explicit
+ * confirmation timestamp, so it is inferred as the moment an alert's thumbs-up
+ * count was last seen to INCREASE. State is held per alert id in a map whose
+ * entries expire an hour after they were last touched (the official's 1-hour
+ * TtlMap), so it self-trims for alerts that scroll out of view.
+ *
+ * <p>{@code confirm_count} is simply the thumbs-up count and is read directly off
+ * the alert; only the timestamp needs this history.
+ */
+final class WazeConfirmTracker {
+    private static final long TTL_MS = 60 * 60_000L;
+
+    private static final class Meta {
+        Long confirmMs;   // null until the thumbs-up count first increases
+        int  thumbs;
+        long expiry;
+    }
+
+    private final Map<String, Meta> seen = new HashMap<>();
+
+    /**
+     * Records this sighting's thumbs-up count and returns the confirm timestamp in
+     * SECONDS (nullable). First sighting → null; later sighting with a higher count
+     * → now; otherwise the previously recorded time (which may be null).
+     */
+    synchronized Long confirmTsSeconds(String id, Integer nThumbsUp) {
+        long now = System.currentTimeMillis();
+        purge(now);
+        int thumbs = nThumbsUp != null ? nThumbsUp : 0;
+        Meta m = seen.get(id);
+        if (m == null) {
+            m = new Meta();
+            m.confirmMs = null;
+            m.thumbs = thumbs;
+            m.expiry = now + TTL_MS;
+            seen.put(id, m);
+            return null;
+        }
+        m.expiry = now + TTL_MS;   // touched → refresh TTL, like TtlMap.set
+        if (thumbs > m.thumbs) {
+            m.confirmMs = now;
+            m.thumbs = thumbs;
+            return now / 1000L;
+        }
+        return m.confirmMs != null ? m.confirmMs / 1000L : null;
+    }
+
+    private void purge(long now) {
+        Iterator<Map.Entry<String, Meta>> it = seen.entrySet().iterator();
+        while (it.hasNext()) {
+            if (it.next().getValue().expiry <= now) it.remove();
+        }
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
@@ -61,6 +61,7 @@ public final class WazeProtocolSource {
 
     private WazeSession session;
     private final WazeAlertCache alertCache = new WazeAlertCache();
+    private final WazeConfirmTracker confirmTracker = new WazeConfirmTracker();
 
     private volatile long   cacheTimeMs = 0L;
     private volatile double cacheLat, cacheLon;
@@ -178,8 +179,11 @@ public final class WazeProtocolSource {
         String type = (wa.subtype != null && !wa.subtype.isEmpty()) ? wa.subtype : wa.type;
         if (type == null || type.isEmpty()) return null;
         String id = "alert-" + wa.id + "/" + wa.uuid;   // user_id is parsed from this
+        int confirmCount = wa.nThumbsUp != null ? wa.nThumbsUp : 0;
+        Long confirmTs = confirmTracker.confirmTsSeconds(wa.uuid, wa.nThumbsUp);
         return new SabreAlert(id, SabreResponseBuilder.SOURCE_WAZE, type,
-                wa.lat, wa.lon, wa.magvar, wa.street, wa.pubMillis / 1000L);
+                wa.lat, wa.lon, wa.magvar, wa.street, wa.pubMillis / 1000L,
+                confirmTs, confirmCount);
     }
 
     static String region(double lat, double lon) {

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
@@ -21,14 +21,21 @@ import app.sabre.wzsabre.SabreResponseBuilder;
  * approach Waze now blocks with HTTP 403). Mints an anonymous Waze account, logs
  * in, and queries crowd-sourced alerts.
  *
- * Because an RT query long-polls (up to ~10.5s) — longer than HR's response budget
- * — fetches are served from a cache that is refreshed asynchronously in the
+ * <p>Because an RT query long-polls (up to ~10.5s) — longer than HR's response
+ * budget — fetches are served from a cache that is refreshed asynchronously in the
  * background. The first HR request after a cold start returns no Waze data; once
  * the background refresh completes (~10s) every subsequent request is served
- * instantly from the warm cache.
+ * instantly from the warm cache. {@link #prewarm} kicks that refresh off at
+ * service start so HR's first real fetch is already warm.
  *
- * The account credentials + device fingerprint are persisted and the live session
- * is reused, so we register at most once (Waze caps anonymous accounts per day).
+ * <p>The RT {@code /command} endpoint is session-stateful (each alert is sent once
+ * per session, then a "RmAlert," removal when it clears), so query results are
+ * MERGED into a persistent {@link WazeAlertCache} rather than replacing it — see
+ * that class for why the previous replace-each-time behaviour lost alerts mid-drive.
+ *
+ * <p>The account credentials + device fingerprint are persisted and the live
+ * session is reused, so we register at most once (Waze caps anonymous accounts
+ * per day).
  */
 public final class WazeProtocolSource {
     private static final String TAG   = "WazeRT";
@@ -36,7 +43,7 @@ public final class WazeProtocolSource {
 
     private static final long   CACHE_TTL_MS      = 12_000L;  // refresh if older than this
     private static final double REFRESH_MOVE_KM   = 4.0;      // ...or if the center moved this far
-    private static final double CACHE_DISCARD_KM  = 25.0;     // don't serve a cache from far away
+    private static final double CACHE_DISCARD_KM  = 25.0;     // don't serve (or keep) a cache from far away
     // Don't serve a cache that hasn't been refreshable for this long (e.g. network
     // outage / Waze down) — stale police/accident alerts presented as current are
     // worse than no Waze data.
@@ -47,8 +54,8 @@ public final class WazeProtocolSource {
     private final AtomicBoolean refreshing = new AtomicBoolean(false);
 
     private WazeSession session;
+    private final WazeAlertCache alertCache = new WazeAlertCache();
 
-    private volatile List<SabreAlert> cache = new ArrayList<>();
     private volatile long   cacheTimeMs = 0L;
     private volatile double cacheLat, cacheLon;
 
@@ -61,16 +68,48 @@ public final class WazeProtocolSource {
      * if the cache is stale or the center moved. Never blocks on the network.
      */
     public List<SabreAlert> fetchAlerts(double lat, double lon, double radiusMeters) {
+        triggerRefreshIfStale(lat, lon, radiusMeters);
+
         long now = System.currentTimeMillis();
-        boolean stale = cacheTimeMs == 0
-                || (now - cacheTimeMs) > CACHE_TTL_MS
-                || haversineKm(lat, lon, cacheLat, cacheLon) > REFRESH_MOVE_KM;
+        if (cacheTimeMs == 0
+                || (now - cacheTimeMs) > CACHE_MAX_SERVE_AGE_MS
+                || haversineKm(lat, lon, cacheLat, cacheLon) > CACHE_DISCARD_KM) {
+            return new ArrayList<>();
+        }
+        // Serve the merged cache, mapped to SABRE and clipped to the request radius.
+        List<SabreAlert> out = new ArrayList<>();
+        for (WazeAlert wa : alertCache.snapshot()) {
+            if (haversineKm(lat, lon, wa.lat, wa.lon) * 1000.0 > radiusMeters) continue;
+            SabreAlert sa = toSabreAlert(wa);
+            if (sa != null) out.add(sa);
+        }
+        return out;
+    }
+
+    /**
+     * Warm the session + cache ahead of HR's first fetch (called at service start
+     * with the last known fetch location). Mirrors the official's pre-warmed
+     * session pool, which is why wzsabre shows alerts in &lt;2s while a cold start
+     * here used to take 10-15s.
+     */
+    public void prewarm(double lat, double lon, double radiusMeters) {
+        triggerRefreshIfStale(lat, lon, radiusMeters);
+    }
+
+    private void triggerRefreshIfStale(double lat, double lon, double radiusMeters) {
+        long now = System.currentTimeMillis();
+        boolean moved = cacheTimeMs != 0 && haversineKm(lat, lon, cacheLat, cacheLon) > REFRESH_MOVE_KM;
+        boolean stale = cacheTimeMs == 0 || (now - cacheTimeMs) > CACHE_TTL_MS || moved;
         if (stale && refreshing.compareAndSet(false, true)) {
             final double radius = Math.max(radiusMeters, 8000);
+            // A large jump (app reopened in a new area) invalidates the whole cache;
+            // start fresh rather than show alerts from the old location.
+            final boolean discard = cacheTimeMs != 0
+                    && haversineKm(lat, lon, cacheLat, cacheLon) > CACHE_DISCARD_KM;
             refreshExec.submit(() -> {
                 try {
-                    List<SabreAlert> fresh = refresh(lat, lon, radius);
-                    cache = fresh;
+                    if (discard) alertCache.clear();
+                    refresh(lat, lon, radius);
                     cacheTimeMs = System.currentTimeMillis();
                     cacheLat = lat;
                     cacheLon = lon;
@@ -81,42 +120,49 @@ public final class WazeProtocolSource {
                 }
             });
         }
-        if (cacheTimeMs == 0
-                || (now - cacheTimeMs) > CACHE_MAX_SERVE_AGE_MS
-                || haversineKm(lat, lon, cacheLat, cacheLon) > CACHE_DISCARD_KM) {
-            return new ArrayList<>();
-        }
-        return new ArrayList<>(cache);
     }
 
-    /** Synchronous register/login/query + map to SabreAlert. Runs off the HR path. */
-    private synchronized List<SabreAlert> refresh(double lat, double lon, double radiusMeters) throws Exception {
-        List<WazeAlert> raw;
+    /** Synchronous prepare + query + merge into the cache. Runs off the HR path. */
+    private synchronized void refresh(double lat, double lon, double radiusMeters) throws Exception {
         try {
-            raw = ensureSession(lat, lon).fetchArea(lat, lon, radiusMeters);
+            queryArea(ensureSession(lat, lon), lat, lon, radiusMeters);
         } catch (WazeExceptions.AccountRejectedException e) {
             Log.w(TAG, "Account rejected — re-registering: " + e.getMessage());
             session = null;
             clearPersisted();
-            raw = ensureSession(lat, lon).fetchArea(lat, lon, radiusMeters);
+            queryArea(ensureSession(lat, lon), lat, lon, radiusMeters);
         } catch (WazeExceptions.SessionExpiredException e) {
             Log.w(TAG, "Session expired — re-logging in: " + e.getMessage());
             session = null;                 // keep credentials, just re-login
-            raw = ensureSession(lat, lon).fetchArea(lat, lon, radiusMeters);
+            queryArea(ensureSession(lat, lon), lat, lon, radiusMeters);
         }
         persist();
-
-        List<SabreAlert> out = new ArrayList<>();
-        for (WazeAlert wa : raw) {
-            String type = AlertMapper.fromWazeType(wa.type, wa.subtype);
-            if (type == null) continue;
-            String id = "alert-" + wa.id + "/" + wa.uuid;   // user_id is parsed from this
-            out.add(new SabreAlert(id, SabreResponseBuilder.SOURCE_WAZE, type,
-                    wa.lat, wa.lon, wa.magvar, wa.street, wa.pubMillis / 1000L));
-        }
-        Log.d(TAG, "Waze refresh: " + out.size() + " alerts near "
+        Log.d(TAG, "Waze cache: " + alertCache.size() + " alerts near "
                 + String.format(Locale.US, "%.4f,%.4f", lat, lon));
-        return out;
+    }
+
+    /**
+     * Prepare the session, query the area, and merge the deltas into the cache.
+     * Single box for now; {@link #shrinkingBoxes} (added with the multi-zoom fix)
+     * widens coverage.
+     */
+    private void queryArea(WazeSession s, double lat, double lon, double radiusMeters) throws Exception {
+        s.prepareForArea(lat, lon);
+        double latDelta = radiusMeters / WazeConstants.M_PER_DEG_LAT;
+        double lonDelta = radiusMeters / WazeConstants.mPerDegLon(lat);
+        WazeProto.Batch batch = s.queryBox(new double[]{
+                lon - lonDelta, lat - latDelta, lon + lonDelta, lat + latDelta});
+        alertCache.submit(new AlertQueryResult(
+                WazeRtCodec.parseAlerts(batch), WazeRtCodec.parseRemovedAlertIds(batch)));
+    }
+
+    /** Map a cached Waze alert to a SABRE alert, or null for a type we don't carry. */
+    private SabreAlert toSabreAlert(WazeAlert wa) {
+        String type = AlertMapper.fromWazeType(wa.type, wa.subtype);
+        if (type == null) return null;
+        String id = "alert-" + wa.id + "/" + wa.uuid;   // user_id is parsed from this
+        return new SabreAlert(id, SabreResponseBuilder.SOURCE_WAZE, type,
+                wa.lat, wa.lon, wa.magvar, wa.street, wa.pubMillis / 1000L);
     }
 
     static String region(double lat, double lon) {

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
@@ -12,7 +12,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import app.sabre.wzsabre.AlertMapper;
 import app.sabre.wzsabre.SabreAlert;
 import app.sabre.wzsabre.SabreResponseBuilder;
 
@@ -168,10 +167,16 @@ public final class WazeProtocolSource {
         }
     }
 
-    /** Map a cached Waze alert to a SABRE alert, or null for a type we don't carry. */
+    /**
+     * Map a cached Waze alert to a SABRE alert. Mirrors the official's request():
+     * the SABRE type is the raw Waze subtype name, or the type name when the
+     * subtype is empty — HR natively understands the full Waze vocabulary, so no
+     * remap/whitelist is applied (the old remap silently dropped whole categories
+     * like SOS/stopped-vehicle and flattened "car stopped" into generic debris).
+     */
     private SabreAlert toSabreAlert(WazeAlert wa) {
-        String type = AlertMapper.fromWazeType(wa.type, wa.subtype);
-        if (type == null) return null;
+        String type = (wa.subtype != null && !wa.subtype.isEmpty()) ? wa.subtype : wa.type;
+        if (type == null || type.isEmpty()) return null;
         String id = "alert-" + wa.id + "/" + wa.uuid;   // user_id is parsed from this
         return new SabreAlert(id, SabreResponseBuilder.SOURCE_WAZE, type,
                 wa.lat, wa.lon, wa.magvar, wa.street, wa.pubMillis / 1000L);

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
@@ -49,6 +49,13 @@ public final class WazeProtocolSource {
     // worse than no Waze data.
     private static final long   CACHE_MAX_SERVE_AGE_MS = 10 * 60_000L;
 
+    // Zoom levels queried per refresh (WazeAlertFetcher default maxSteps=5) and the
+    // total wall-clock budget for the box loop (mirrors the official's per-slot
+    // withTimeout of ~10s — whatever boxes complete in time are merged, the rest
+    // wait for the next refresh).
+    private static final int  SHRINK_STEPS    = 5;
+    private static final long QUERY_BUDGET_MS = 10_000L;
+
     private final Context ctx;
     private final ExecutorService refreshExec = Executors.newSingleThreadExecutor();
     private final AtomicBoolean refreshing = new AtomicBoolean(false);
@@ -142,18 +149,23 @@ public final class WazeProtocolSource {
     }
 
     /**
-     * Prepare the session, query the area, and merge the deltas into the cache.
-     * Single box for now; {@link #shrinkingBoxes} (added with the multi-zoom fix)
-     * widens coverage.
+     * Prepare the session, then query a series of progressively smaller boxes
+     * around the driver, merging each into the cache. Mirrors the official's
+     * one-account path: getShrinkingBboxes (full radius, then halved each step),
+     * each box shrunk to 0.75 as scanBoxes does, queried big→small on one session
+     * within a total time budget. The smaller viewports defeat the server-side
+     * thinning that drops minor/near-driver alerts from a single large query.
      */
     private void queryArea(WazeSession s, double lat, double lon, double radiusMeters) throws Exception {
         s.prepareForArea(lat, lon);
-        double latDelta = radiusMeters / WazeConstants.M_PER_DEG_LAT;
-        double lonDelta = radiusMeters / WazeConstants.mPerDegLon(lat);
-        WazeProto.Batch batch = s.queryBox(new double[]{
-                lon - lonDelta, lat - latDelta, lon + lonDelta, lat + latDelta});
-        alertCache.submit(new AlertQueryResult(
-                WazeRtCodec.parseAlerts(batch), WazeRtCodec.parseRemovedAlertIds(batch)));
+        double[][] zoomBoxes = GeoBoxes.shrinkingBoxes(lon, lat, radiusMeters, SHRINK_STEPS);
+        long deadline = System.currentTimeMillis() + QUERY_BUDGET_MS;
+        for (double[] zoom : zoomBoxes) {
+            if (System.currentTimeMillis() >= deadline) break;   // best-effort, like the official
+            WazeProto.Batch batch = s.queryBox(GeoBoxes.shrink(zoom, 0.75));
+            alertCache.submit(new AlertQueryResult(
+                    WazeRtCodec.parseAlerts(batch), WazeRtCodec.parseRemovedAlertIds(batch)));
+        }
     }
 
     /** Map a cached Waze alert to a SABRE alert, or null for a type we don't carry. */

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java
@@ -131,6 +131,25 @@ final class WazeRtCodec {
 
     // ── Response parsing ─────────────────────────────────────────────────────
 
+    /**
+     * Extracts removed-alert uuids from a batch. The RT server signals a cleared
+     * alert with an {@code old_command} line of the form {@code "RmAlert,<uuid>"}
+     * (NOT a RemoveAlertAction message — verified in wzsabre 2.2
+     * WazeProto.parseRemovedAlertIds). Strip the prefix and trim to get the uuid.
+     */
+    static List<String> parseRemovedAlertIds(WazeProto.Batch batch) {
+        List<String> out = new ArrayList<>();
+        for (WazeProto.Element el : batch.getElementList()) {
+            String oc = el.getOldCommand();
+            if (oc == null) continue;
+            oc = oc.trim();
+            if (oc.startsWith("RmAlert,")) {
+                out.add(oc.substring("RmAlert,".length()).trim());
+            }
+        }
+        return out;
+    }
+
     static List<WazeAlert> parseAlerts(WazeProto.Batch batch) {
         List<WazeAlert> out = new ArrayList<>();
         for (WazeProto.Element el : batch.getElementList()) {

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java
@@ -168,8 +168,8 @@ final class WazeRtCodec {
             double lon = lonRaw / 1_000_000.0;
             double lat = c.getLatTimes1000000() / 1_000_000.0;
 
-            String type    = info.getType().name();
-            String subtype = info.getSubType().name();
+            String type    = typeName(info.getType());
+            String subtype = subTypeName(info.getSubType());
             int    magvar  = info.getAzymuth();
 
             long reportTime = 0L;
@@ -190,5 +190,27 @@ final class WazeRtCodec {
                     lon, lat, magvar, pubMillis, thumbs, street, city));
         }
         return out;
+    }
+
+    /**
+     * Type-enum → wire name, matching the official's ALERT_TYPE_NAMES map: the
+     * generated enum constant name, except types not in that map (UNKNOWN_TYPE and
+     * the reserved __NOT_IN_USE__ values) collapse to "UNKNOWN".
+     */
+    private static String typeName(WazeProto.AlertType t) {
+        String n = t.name();
+        if (n.equals("UNKNOWN_TYPE") || n.startsWith("__NOT_IN_USE")) return "UNKNOWN";
+        return n;
+    }
+
+    /**
+     * Subtype-enum → wire name, matching the official's ALERT_SUBTYPE_NAMES map:
+     * the enum constant name, except NO_SUBTYPE and the reserved __NOT_IN_USE__
+     * values map to "" so the caller falls back to the type name.
+     */
+    private static String subTypeName(WazeProto.AlertSubType s) {
+        String n = s.name();
+        if (n.equals("NO_SUBTYPE") || n.startsWith("__NOT_IN_USE")) return "";
+        return n;
     }
 }

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
@@ -158,15 +158,33 @@ final class WazeSession {
         if (!sessionValid())     login(lon, lat);
     }
 
-    /** Full flow: ensure ready, handshake, then query the area around (lat,lon). */
-    List<WazeAlert> fetchArea(double lat, double lon, double radiusMeters) throws Exception {
+    /**
+     * Register (if no credentials) + log in (if no valid session) + run the
+     * SeeMe/SetMood/Location/MapDisplayed handshake. Call once before a run of
+     * {@link #queryBox} calls — mirrors the official, which handshakes per login,
+     * not per query.
+     */
+    void prepareForArea(double lat, double lon) throws Exception {
         ensureReady(lon, lat);
-        command(WazeRtCodec.handshakePayload(lon, lat));   // SeeMe / SetMood / Location / MapDisplayed
+        command(WazeRtCodec.handshakePayload(lon, lat));
+    }
 
+    /**
+     * One MapDisplayed query for a bbox {@code [lonMin, latMin, lonMax, latMax]};
+     * returns the raw batch so the caller can parse both added alerts and removed
+     * ids from it (the RT response carries both).
+     */
+    WazeProto.Batch queryBox(double[] bbox) throws Exception {
+        return command(WazeRtCodec.mapDisplayedCommand(bbox[0], bbox[1], bbox[2], bbox[3]));
+    }
+
+    /** Full flow for a single box: prepare + one query. Used by the debug selfTest. */
+    List<WazeAlert> fetchArea(double lat, double lon, double radiusMeters) throws Exception {
+        prepareForArea(lat, lon);
         double latDelta = radiusMeters / WazeConstants.M_PER_DEG_LAT;
         double lonDelta = radiusMeters / WazeConstants.mPerDegLon(lat);
-        WazeProto.Batch batch = command(WazeRtCodec.mapDisplayedCommand(
-                lon - lonDelta, lat - latDelta, lon + lonDelta, lat + latDelta));
+        WazeProto.Batch batch = queryBox(new double[]{
+                lon - lonDelta, lat - latDelta, lon + lonDelta, lat + latDelta});
         return WazeRtCodec.parseAlerts(batch);
     }
 }

--- a/app/src/test/java/app/sabre/wzsabre/CHPSourceTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/CHPSourceTest.java
@@ -136,6 +136,14 @@ public class CHPSourceTest {
     }
 
     @Test
+    public void alert_headingIsDirectionlessSentinel() throws Exception {
+        // CHP incidents have no travel direction; they must use the -720 sentinel
+        // so HR shows them regardless of which way the driver is heading.
+        List<SabreAlert> alerts = callParseXml(new CHPSource(), XML_ONE_INCIDENT);
+        assertEquals(SabreResponseBuilder.HEADING_UNKNOWN, alerts.get(0).headingDeg, 0.0);
+    }
+
+    @Test
     public void parseLatLon_sfCoords() {
         double[] coords = CHPSource.parseLatLon("37774567:122419400");
         assertEquals(37.774567, coords[0], 0.0001);

--- a/app/src/test/java/app/sabre/wzsabre/LcsSourceTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/LcsSourceTest.java
@@ -213,6 +213,8 @@ public class LcsSourceTest {
         assertEquals(37.329044, a.lat, 1e-6);
         assertTrue("report_ts should be the 1097 epoch", a.reportTs > 0);
         assertTrue(a.reportTs <= Integer.MAX_VALUE);
+        assertEquals("closures are directionless → -720 heading sentinel",
+                SabreResponseBuilder.HEADING_UNKNOWN, a.headingDeg, 0.0);
     }
 
     @Test

--- a/app/src/test/java/app/sabre/wzsabre/SabreProtocolTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/SabreProtocolTest.java
@@ -245,15 +245,76 @@ public class SabreProtocolTest {
     }
 
     @Test
-    public void isValidType_acceptsAllSabreTypes() {
-        String[] all = {"POLICE_VISIBLE", "POLICE_HIDDEN", "ACCIDENT_MAJOR", "ACCIDENT_MINOR",
+    public void isValidType_acceptsCanonicalAndWazeVocabulary() {
+        // Canonical SABRE types emitted by CHP/LCS.
+        String[] canonical = {"POLICE_VISIBLE", "POLICE_HIDDEN", "ACCIDENT_MAJOR", "ACCIDENT_MINOR",
                 "HAZARD_ON_ROAD_DEBRIS", "HAZARD_ON_ROAD_CONGESTION", "HAZARD_ON_ROAD_SLIPPERY",
                 "HAZARD_ON_ROAD_POT_HOLE", "HAZARD_WEATHER_FOG", "HAZARD_WEATHER_RAIN",
                 "HAZARD_WEATHER_SNOW", "HAZARD_WEATHER_WIND", "HAZARD_WEATHER_STORM",
                 "HAZARD_WEATHER_HAIL"};
-        for (String t : all) assertTrue(t, SabreResponseBuilder.isValidType(t));
-        assertFalse(SabreResponseBuilder.isValidType("POLICE"));
+        for (String t : canonical) assertTrue(t, SabreResponseBuilder.isValidType(t));
+        // Raw Waze type/subtype names now pass through (the official ships these to HR).
+        String[] waze = {"POLICE", "ACCIDENT", "HAZARD", "JAM", "SOS",
+                "POLICE_HIDING", "POLICE_WITH_MOBILE_CAMERA", "JAM_HEAVY_TRAFFIC",
+                "HAZARD_ON_SHOULDER_CAR_STOPPED", "HAZARD_ON_ROAD_CAR_STOPPED",
+                "SOS_MECHANICAL_PROBLEM", "DEFAULT_CAMERA"};
+        for (String t : waze) assertTrue(t, SabreResponseBuilder.isValidType(t));
+        // A garbage string or null is still rejected.
+        assertFalse(SabreResponseBuilder.isValidType("TOTALLY_BOGUS_TYPE"));
         assertFalse(SabreResponseBuilder.isValidType(null));
+    }
+
+    @Test
+    public void build_passesThroughWazeSubtypeStrings() throws Exception {
+        // A stopped-vehicle-on-shoulder alert (previously dropped/flattened) survives.
+        SabreAlert stopped = new SabreAlert("waze_alert-7/uuid", SabreResponseBuilder.SOURCE_WAZE,
+                "HAZARD_ON_SHOULDER_CAR_STOPPED", 38.0, -122.0, 90.0, "I-80", NOW_SECONDS);
+        JSONObject a = firstAlert(parseResponse(Collections.singletonList(stopped)));
+        assertEquals("HAZARD_ON_SHOULDER_CAR_STOPPED", a.getString("type"));
+    }
+
+    // ── confirm fields ────────────────────────────────────────────────────────
+
+    @Test
+    public void alert_confirmFieldsForWaze() throws Exception {
+        SabreAlert confirmed = new SabreAlert("waze_alert-5/uuid", SabreResponseBuilder.SOURCE_WAZE,
+                "POLICE_VISIBLE", 38.0, -122.0, 0.0, "US-101", NOW_SECONDS,
+                NOW_SECONDS, 4);
+        JSONObject a = firstAlert(parseResponse(Collections.singletonList(confirmed)));
+        assertEquals(4, a.getInt("confirm_count"));
+        assertFalse("confirm_ts must be present and non-null when set", a.isNull("confirm_ts"));
+        assertEquals((int) NOW_SECONDS, a.getInt("confirm_ts"));
+    }
+
+    @Test
+    public void alert_confirmTsNullWhenOutOfIntRange() throws Exception {
+        // A confirm_ts that doesn't fit in Int must be sent as null, not overflowed.
+        SabreAlert a = new SabreAlert("waze_alert-6/uuid", SabreResponseBuilder.SOURCE_WAZE,
+                "POLICE_VISIBLE", 38.0, -122.0, 0.0, null, NOW_SECONDS,
+                ((long) Integer.MAX_VALUE) + 100L, 2);
+        JSONObject obj = firstAlert(parseResponse(Collections.singletonList(a)));
+        assertTrue("oversized confirm_ts must be null", obj.isNull("confirm_ts"));
+        assertEquals(2, obj.getInt("confirm_count"));
+    }
+
+    // ── batching ──────────────────────────────────────────────────────────────
+
+    @Test
+    public void build_singleBatchDefaults() throws Exception {
+        JSONObject data = parseResponse(Collections.singletonList(chpAlert()))
+                .getJSONObject("response");
+        assertEquals(1, data.getInt("n_batches"));
+        assertEquals(0, data.getInt("batch_id"));
+    }
+
+    @Test
+    public void build_batchCarriesNBatchesAndBatchId() throws Exception {
+        JSONObject root = new JSONObject(SabreResponseBuilder.build(
+                "req-1", Collections.singletonList(chpAlert()), 3, 2));
+        JSONObject data = root.getJSONObject("response");
+        assertEquals(3, data.getInt("n_batches"));
+        assertEquals(2, data.getInt("batch_id"));
+        assertEquals(1, data.getJSONArray("alerts").length());
     }
 
     // ── nullable fields: must be present but may be null ─────────────────────

--- a/app/src/test/java/app/sabre/wzsabre/waze/GeoBoxesTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/GeoBoxesTest.java
@@ -1,0 +1,53 @@
+package app.sabre.wzsabre.waze;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/** Shrinking-box geometry that widens Waze coverage so near-driver alerts aren't thinned. */
+public class GeoBoxesTest {
+
+    private static final double EPS = 1e-9;
+
+    @Test
+    public void circleToBoxIsCenteredAndSized() {
+        double lon = -122.0, lat = 38.0, r = 8000;
+        double[] b = GeoBoxes.circleToBox(lon, lat, r);
+        // centered on the point
+        assertEquals(lon, (b[0] + b[2]) / 2.0, EPS);
+        assertEquals(lat, (b[1] + b[3]) / 2.0, EPS);
+        // half-height = r / metersPerDegLat
+        assertEquals(r / WazeConstants.M_PER_DEG_LAT, (b[3] - b[1]) / 2.0, EPS);
+        // box ordering is [lonMin, latMin, lonMax, latMax]
+        assertTrue(b[0] < b[2]);
+        assertTrue(b[1] < b[3]);
+    }
+
+    @Test
+    public void shrinkHalvesExtentAroundSameCenter() {
+        double[] box = {-122.1, 37.9, -121.9, 38.1};
+        double[] s = GeoBoxes.shrink(box, 0.5);
+        assertEquals(-122.0, (s[0] + s[2]) / 2.0, EPS);
+        assertEquals(38.0, (s[1] + s[3]) / 2.0, EPS);
+        assertEquals((box[2] - box[0]) * 0.5, s[2] - s[0], EPS);
+        assertEquals((box[3] - box[1]) * 0.5, s[3] - s[1], EPS);
+    }
+
+    @Test
+    public void shrinkingBoxesProduceProgressivelySmallerZooms() {
+        double[][] boxes = GeoBoxes.shrinkingBoxes(-122.0, 38.0, 8000, 5);
+        assertEquals(5, boxes.length);
+        double prevWidth = Double.MAX_VALUE;
+        for (double[] b : boxes) {
+            double w = b[2] - b[0];
+            assertTrue("each zoom is smaller than the last", w < prevWidth);
+            // all centered on the driver
+            assertEquals(-122.0, (b[0] + b[2]) / 2.0, EPS);
+            assertEquals(38.0, (b[1] + b[3]) / 2.0, EPS);
+            prevWidth = w;
+        }
+        // each step is half the previous
+        assertEquals((boxes[0][2] - boxes[0][0]) * 0.5, boxes[1][2] - boxes[1][0], EPS);
+    }
+}

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeAlertCacheTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeAlertCacheTest.java
@@ -1,0 +1,82 @@
+package app.sabre.wzsabre.waze;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The cache is the core fix for "Waze alerts vanish mid-drive": the RT server
+ * sends each alert once per session then a removal, so query results MUST be
+ * merged, not replaced.
+ */
+public class WazeAlertCacheTest {
+
+    private static WazeAlert alert(String uuid, int thumbs) {
+        return new WazeAlert(uuid, 1L, "POLICE", "POLICE_VISIBLE",
+                -122.0, 38.0, 0, 1_700_000_000_000L,
+                thumbs > 0 ? thumbs : null, "I-80", "Vallejo");
+    }
+
+    private static AlertQueryResult adds(WazeAlert... a) {
+        return new AlertQueryResult(new ArrayList<>(Arrays.asList(a)), new ArrayList<>());
+    }
+
+    private static List<String> uuids(List<WazeAlert> alerts) {
+        List<String> out = new ArrayList<>();
+        for (WazeAlert a : alerts) out.add(a.uuid);
+        Collections.sort(out);
+        return out;
+    }
+
+    @Test
+    public void mergesDeltasAcrossQueries() {
+        WazeAlertCache cache = new WazeAlertCache();
+        cache.submit(adds(alert("A", 0), alert("B", 0)));
+        // Second query is a DELTA — only the new alert. A and B must survive.
+        cache.submit(adds(alert("C", 0)));
+        assertEquals(Arrays.asList("A", "B", "C"), uuids(cache.snapshot()));
+    }
+
+    @Test
+    public void removalSoftDeletesButKeepsOthers() {
+        WazeAlertCache cache = new WazeAlertCache();
+        cache.submit(adds(alert("A", 0), alert("B", 0)));
+        cache.submit(new AlertQueryResult(new ArrayList<>(), new ArrayList<>(Collections.singletonList("A"))));
+        List<String> visible = uuids(cache.snapshot());
+        assertFalse("A is soft-deleted", visible.contains("A"));
+        assertTrue("B remains", visible.contains("B"));
+        assertEquals("soft-delete keeps the entry cached", 2, cache.size());
+    }
+
+    @Test
+    public void reAddUndoesSoftDelete() {
+        WazeAlertCache cache = new WazeAlertCache();
+        cache.submit(adds(alert("A", 0)));
+        cache.submit(new AlertQueryResult(new ArrayList<>(), new ArrayList<>(Collections.singletonList("A"))));
+        assertTrue(cache.snapshot().isEmpty());
+        cache.submit(adds(alert("A", 1)));   // server re-sends it
+        assertEquals(Collections.singletonList("A"), uuids(cache.snapshot()));
+    }
+
+    @Test
+    public void removalOfUnknownIdIsIgnored() {
+        WazeAlertCache cache = new WazeAlertCache();
+        cache.submit(adds(alert("A", 0)));
+        cache.submit(new AlertQueryResult(new ArrayList<>(), new ArrayList<>(Collections.singletonList("ZZZ"))));
+        assertEquals(Collections.singletonList("A"), uuids(cache.snapshot()));
+    }
+
+    @Test
+    public void emptyUuidIsNotCached() {
+        WazeAlertCache cache = new WazeAlertCache();
+        cache.submit(adds(alert("", 0)));
+        assertTrue(cache.snapshot().isEmpty());
+    }
+}

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeConfirmTrackerTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeConfirmTrackerTest.java
@@ -1,0 +1,51 @@
+package app.sabre.wzsabre.waze;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/** confirm_ts is inferred as the moment an alert's thumbs-up count last increased. */
+public class WazeConfirmTrackerTest {
+
+    @Test
+    public void firstSightingHasNoConfirmTs() {
+        WazeConfirmTracker t = new WazeConfirmTracker();
+        assertNull(t.confirmTsSeconds("a", 3));
+    }
+
+    @Test
+    public void unchangedCountStaysNull() {
+        WazeConfirmTracker t = new WazeConfirmTracker();
+        t.confirmTsSeconds("a", 3);
+        assertNull("count did not increase", t.confirmTsSeconds("a", 3));
+    }
+
+    @Test
+    public void increasedCountSetsConfirmTs() {
+        WazeConfirmTracker t = new WazeConfirmTracker();
+        t.confirmTsSeconds("a", 3);
+        Long ts = t.confirmTsSeconds("a", 5);
+        assertNotNull("count increased → confirm_ts set", ts);
+        assertTrue("confirm_ts is plausible epoch seconds", ts > 1_600_000_000L);
+    }
+
+    @Test
+    public void confirmTsStickyAfterIncrease() {
+        WazeConfirmTracker t = new WazeConfirmTracker();
+        t.confirmTsSeconds("a", 1);
+        Long first = t.confirmTsSeconds("a", 2);
+        Long again = t.confirmTsSeconds("a", 2);   // no further increase
+        assertNotNull(first);
+        assertNotNull("keeps the last confirm time", again);
+    }
+
+    @Test
+    public void nullThumbsTreatedAsZero() {
+        WazeConfirmTracker t = new WazeConfirmTracker();
+        assertNull(t.confirmTsSeconds("a", null));
+        assertNull("still zero, no increase", t.confirmTsSeconds("a", null));
+        assertNotNull("0 → 2 is an increase", t.confirmTsSeconds("a", 2));
+    }
+}

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeRtCodecTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeRtCodecTest.java
@@ -1,0 +1,31 @@
+package app.sabre.wzsabre.waze;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** Removals arrive as "RmAlert,&lt;uuid&gt;" old_command lines, not a protobuf message. */
+public class WazeRtCodecTest {
+
+    @Test
+    public void parsesRmAlertRemovalsAndIgnoresOthers() {
+        WazeProto.Batch batch = WazeProto.Batch.newBuilder()
+                .addElement(WazeProto.Element.newBuilder().setOldCommand("RmAlert,uuid-1").build())
+                .addElement(WazeProto.Element.newBuilder().setOldCommand("RmAlert, uuid-2 ").build())
+                .addElement(WazeProto.Element.newBuilder().setOldCommand("SomeOtherCmd,x").build())
+                .addElement(WazeProto.Element.newBuilder().build())   // no old_command
+                .build();
+        List<String> removed = WazeRtCodec.parseRemovedAlertIds(batch);
+        assertEquals(Arrays.asList("uuid-1", "uuid-2"), removed);
+    }
+
+    @Test
+    public void emptyBatchHasNoRemovals() {
+        assertTrue(WazeRtCodec.parseRemovedAlertIds(
+                WazeProto.Batch.newBuilder().build()).isEmpty());
+    }
+}


### PR DESCRIPTION
Fixes the user-reported issues where real Waze events (e.g. a car stopped on the shoulder) showed up in the Waze app but never appeared in Highway Radar, plus the 10–15s cold-start delay before police alerts loaded. Audited our Waze path line-by-line against the decompiled official wzsabre 2.2 and ported its behaviour faithfully; the only intentional divergence is that our plugin also carries CHP and Caltrans LCS sources, not just Waze.

## Root causes & fixes (one commit each)

1. **Alerts vanished mid-drive** — the RT `/command` endpoint is session-stateful (each alert sent once, then a `RmAlert,<uuid>` removal when it clears). We replaced the cache on every query, so it went near-empty after the first response. Now we merge deltas into a persistent uuid-keyed cache with 5-minute soft-delete, ported from `WazeAlertFetcher`. Removals are read from `old_command` lines (not a `RemoveAlertAction` message — verified in smali).
2. **Minor/near-driver alerts thinned out** — one big-radius query is thinned server-side by viewport. Now we query the official's series of progressively smaller boxes so the inner detail comes through.
3. **10–15s cold-start latency** — the session/cache only started warming on HR's first fetch. Now we pre-warm at service start from the last known location, so the first fetch is already warm (validated: ~1.2s after restart).
4. **Wrong-direction filtering** — CHP/LCS alerts have no heading but were sent as `0.0` (= due north). Now they use the official's `-720.0` directionless sentinel so HR shows them regardless of travel direction; Waze keeps its real azymuth.
5. **Whole categories dropped** — our remap flattened every Waze alert into 14 types, silently dropping SOS/stopped-vehicle/construction and turning "car stopped on shoulder" into generic debris. Now we pass the raw Waze subtype through to HR exactly as the official does (HR understands the full vocabulary).
6. **Missing crowd-confirmation** — now emit `confirm_count` (thumbs-up) and `confirm_ts` (inferred from thumbs-up increases) like the official.
7. **Unbounded response** — split the response into batches of 200 with `n_batches`/`batch_id`, matching the official.

## Validation

184 unit tests (was 162), all green. Validated end-to-end on an Android 15 emulator against the **real Highway Radar v3.2**: it discovered the plugin, fetched every ~15s, and rendered our alerts (Police card + map pins) with **no crash** across many cycles. Confirmed in the live response: the Waze cache accumulates (46→48, 38→58) instead of collapsing; a `HAZARD_ON_SHOULDER_CAR_STOPPED` alert (the user's missing shoulder case) now reaches HR; `confirm_count` carries real values (1/18/99); CHP heading is `-720` while Waze carries real azymuth; pre-warm makes the first post-restart fetch warm in ~1.2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)