### PR TITLE
v1.5 — Waze & CHP data reliability

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -6,9 +6,9 @@
 |------|---------|
 | Android Studio | Ladybug (2024.2) or newer |
 | Android SDK | API 35 |
-| JDK | 11 (bundled with Android Studio) |
+| JDK | **17+** to run Gradle/AGP (the JBR bundled with Android Studio works). The app code itself targets Java 11. |
 
-No NDK or additional toolchains needed.
+No NDK or additional toolchains needed. The Waze protobuf classes are generated automatically on first build from `app/src/main/proto/waze.proto` — no manual protoc step. Debug builds need no keystore; only `assembleRelease` requires a `keystore.properties` at the repo root.
 
 ## Clone and build
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ All sources run in parallel and feed into the standard HR crowdsourced-alerts la
 
 ## Requirements
 
-- Android **6.0+** (API 23)
+- Android **7.0+** (API 24)
 - [Highway Radar](https://play.google.com/store/apps/details?id=com.highwayradar.app) installed
 - Sideloading enabled on your device
 
@@ -30,13 +30,15 @@ All sources run in parallel and feed into the standard HR crowdsourced-alerts la
 
 ### Option A — Download the APK (recommended for most users)
 
-1. Go to the [Releases](../../releases) page and download the latest `app-release.apk`.
-2. On your Android device, open **Settings → Security** (or *Install unknown apps*) and allow installs from your browser or file manager.
+1. Go to the [Releases](../../releases) page and download the latest APK.
+2. On your Android device, open **Settings → Security** (or *Install unknown apps*) and allow installs from your browser or file manager. If Google Play Protect warns that the app is unrecognized, tap **More details → Install anyway**.
 3. Open the downloaded APK and tap **Install**.
-4. Open the **CHP + Waze SABRE** app once — this wakes up the background service.
+4. Open the **CHP + Waze SABRE** app once. On first launch, **allow notifications** and **allow the battery-optimization exemption** when prompted — without these the background service can be frozen and alerts stop.
 5. Open **Highway Radar → Settings → SABRE** and select **CHP + Waze SABRE**.
 
-> **After a phone reboot:** Open the CHP + Waze SABRE app once before using Highway Radar, or simply tap the green start button in HR — the plugin will start automatically.
+> **Why the persistent notification?** Android requires a foreground-service notification while the plugin is feeding alerts. The plugin only runs while Highway Radar is open and stops itself shortly after you close HR, so it isn't running (or notifying) in the background the rest of the time.
+
+> **After a phone reboot:** Just open Highway Radar — the plugin starts automatically when HR sends its first request.
 
 ### Option B — Build from source
 
@@ -139,7 +141,7 @@ Pull requests welcome. Run the test suite before submitting:
 ./gradlew test
 ```
 
-184 unit tests cover the SABRE response format, alert type mapping, the Waze alert cache (delta merge + soft-delete), shrinking-box geometry, crowd-confirmation tracking, CHP XML parsing, Caltrans LCS parsing and filtering, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup.
+195 unit tests cover the SABRE response format, alert type mapping, the Waze alert cache (delta merge + soft-delete), in-band Waze error classification, shrinking-box geometry, crowd-confirmation tracking, CHP XML parsing, Caltrans LCS parsing and filtering, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup.
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 5
-        versionName = "1.4"
+        versionCode = 6
+        versionName = "1.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/AlertMapper.java
+++ b/app/src/main/java/app/sabre/wzsabre/AlertMapper.java
@@ -1,5 +1,7 @@
 package app.sabre.wzsabre;
 
+import java.util.Locale;
+
 /**
  * Maps CHP LogType strings and Waze alert types to SABRE protocol alert types.
  */
@@ -14,7 +16,7 @@ public class AlertMapper {
      */
     public static ChpCategory categoryFor(String logType) {
         if (logType == null) return null;
-        String t = logType.toUpperCase();
+        String t = logType.toUpperCase(Locale.US);
         if (t.contains("SILVER") || t.contains("MISSING")) return null;
 
         // Injury / fatal collisions. 1180 (major inj), 1181 (minor inj), 1183
@@ -47,7 +49,7 @@ public class AlertMapper {
 
     public static String fromChpLogType(String logType) {
         if (logType == null) return null;
-        String t = logType.toUpperCase();
+        String t = logType.toUpperCase(Locale.US);
 
         // Injury / fatal collisions (any injury = major; see categoryFor)
         if (t.contains("1179") || t.contains("1141")) return "ACCIDENT_MAJOR";
@@ -94,8 +96,8 @@ public class AlertMapper {
 
     public static String fromWazeType(String type, String subtype) {
         if (type == null) return null;
-        String t = type.toUpperCase();
-        String s = subtype != null ? subtype.toUpperCase() : "";
+        String t = type.toUpperCase(Locale.US);
+        String s = subtype != null ? subtype.toUpperCase(Locale.US) : "";
 
         switch (t) {
             case "POLICE":

--- a/app/src/main/java/app/sabre/wzsabre/CHPSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/CHPSource.java
@@ -1,6 +1,5 @@
 package app.sabre.wzsabre;
 
-import android.net.Network;
 import android.util.Log;
 
 import org.xmlpull.v1.XmlPullParser;
@@ -16,31 +15,69 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.net.ssl.HttpsURLConnection;
 
 /**
  * Fetches and parses the CHP statewide live incident XML feed.
  * Filters by radius, incident age, and the per-category settings in ChpConfig.
+ *
+ * <p>Like the Waze and LCS sources, CHP is served from a background-refreshed cache
+ * and NEVER fetched on the Highway Radar request path. Earlier this was a blocking
+ * network call: a slow/hung CHP fetch (the feed sits behind a flaky load balancer)
+ * could occupy the shared fetch thread pool and starve Waze/LCS, and any single
+ * failure returned zero CHP alerts for that cycle — so incidents flapped in and out
+ * while driving through cell dead zones. Now {@link #fetchAlerts} returns the last
+ * good parse instantly and a stale fetch only affects freshness, never availability.
  */
 public class CHPSource {
     private static final String TAG     = "CHPSource";
     private static final String CHP_URL = "https://media.chp.ca.gov/sa_xml/sa.xml";
-    private static final int TIMEOUT_MS = 12_000;
+    // Background thread, so the timeouts don't gate the HR response — but still bounded
+    // so a hung fetch can't pin the refresh thread indefinitely.
+    private static final int CONNECT_TIMEOUT_MS = 8_000;
+    private static final int READ_TIMEOUT_MS    = 8_000;
+
+    private static final long CACHE_TTL_MS       = 60_000L;       // CHP updates ~1/min
+    private static final long CACHE_MAX_SERVE_MS = 10 * 60_000L;  // never serve staler than this
 
     // CHP times are Pacific; parse in that zone so age comparisons are correct
     private static final TimeZone TZ_PACIFIC = TimeZone.getTimeZone("America/Los_Angeles");
 
+    // ── Parsed statewide incident (pre-radius, pre-config) ────────────────────
+
+    static final class Incident {
+        final String logId, logType, logTime, location, area;
+        final double lat, lon;
+        Incident(String logId, String logType, String logTime, String location, String area,
+                 double lat, double lon) {
+            this.logId = logId; this.logType = logType; this.logTime = logTime;
+            this.location = location; this.area = area; this.lat = lat; this.lon = lon;
+        }
+    }
+
+    private final ExecutorService refreshExec = Executors.newSingleThreadExecutor();
+    private final AtomicBoolean refreshing = new AtomicBoolean(false);
+    private volatile List<Incident> cache = null;
+    private volatile long cacheTimeMs = 0L;
+    // Conditional-GET validators so an unchanged feed isn't re-downloaded (~300KB).
+    private volatile String etag = null;
+    private volatile String lastModified = null;
+
+    /**
+     * Returns CHP incidents within the radius from the cache, filtered by config.
+     * Never blocks on the network; a stale/first cache triggers a background refresh.
+     */
     public List<SabreAlert> fetchAlerts(double centerLat, double centerLon,
                                          double radiusMeters, ChpConfig config) {
-        List<SabreAlert> results = new ArrayList<>();
-        try {
-            String xml = fetchXml(null);
-            results = parseXml(xml, centerLat, centerLon, radiusMeters, config);
-            Log.d(TAG, "CHP: " + results.size() + " alerts within radius");
-        } catch (Exception e) {
-            Log.e(TAG, "Failed to fetch CHP data: " + e.getMessage());
+        triggerRefreshIfStale();
+        List<Incident> snap = cache;
+        if (snap == null || (System.currentTimeMillis() - cacheTimeMs) > CACHE_MAX_SERVE_MS) {
+            return new ArrayList<>();
         }
-        return results;
+        return filter(snap, centerLat, centerLon, radiusMeters, config);
     }
 
     /** Overload kept for tests that don't use config (passes null → all defaults). */
@@ -49,29 +86,72 @@ public class CHPSource {
         return fetchAlerts(centerLat, centerLon, radiusMeters, null);
     }
 
-    private String fetchXml(Network network) throws Exception {
+    /** Warm the cache at service start so HR's first request isn't empty. */
+    public void prewarm() {
+        triggerRefreshIfStale();
+    }
+
+    /** Release the background refresh thread when the owning service is destroyed. */
+    public void shutdown() {
+        refreshExec.shutdownNow();
+    }
+
+    private void triggerRefreshIfStale() {
+        boolean stale = cache == null || (System.currentTimeMillis() - cacheTimeMs) > CACHE_TTL_MS;
+        if (stale && refreshing.compareAndSet(false, true)) {
+            refreshExec.submit(() -> {
+                try {
+                    List<Incident> parsed = fetchAndParse();
+                    if (parsed != null) {   // null = 304 Not Modified → keep last good
+                        cache = parsed;
+                        cacheTimeMs = System.currentTimeMillis();
+                        Log.d(TAG, "CHP refreshed: " + parsed.size() + " statewide incidents");
+                    } else {
+                        cacheTimeMs = System.currentTimeMillis();   // fresh enough, unchanged
+                    }
+                } catch (Exception e) {
+                    // Keep serving the last good parse — a transient failure must not
+                    // blank CHP for the whole cycle.
+                    Log.w(TAG, "CHP refresh failed (serving cache): "
+                            + e.getClass().getSimpleName() + ": " + e.getMessage());
+                } finally {
+                    refreshing.set(false);
+                }
+            });
+        }
+    }
+
+    /** @return parsed incidents, or {@code null} when the server replies 304 Not Modified. */
+    private List<Incident> fetchAndParse() throws Exception {
         URL url = new URL(CHP_URL);
-        HttpsURLConnection conn = network != null
-                ? (HttpsURLConnection) network.openConnection(url)
-                : (HttpsURLConnection) url.openConnection();
-        conn.setConnectTimeout(TIMEOUT_MS);
-        conn.setReadTimeout(TIMEOUT_MS);
+        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+        conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        conn.setReadTimeout(READ_TIMEOUT_MS);
         conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Linux; Android 14)");
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(conn.getInputStream(), "UTF-8"))) {
+        if (etag != null)         conn.setRequestProperty("If-None-Match", etag);
+        if (lastModified != null) conn.setRequestProperty("If-Modified-Since", lastModified);
+        try {
+            if (conn.getResponseCode() == HttpsURLConnection.HTTP_NOT_MODIFIED) return null;
+            etag         = conn.getHeaderField("ETag");
+            lastModified = conn.getHeaderField("Last-Modified");
             StringBuilder sb = new StringBuilder();
-            char[] buf = new char[4096];
-            int n;
-            while ((n = reader.read(buf)) != -1) sb.append(buf, 0, n);
-            return sb.toString();
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(conn.getInputStream(), "UTF-8"))) {
+                char[] buf = new char[4096];
+                int n;
+                while ((n = reader.read(buf)) != -1) sb.append(buf, 0, n);
+            }
+            return parseAll(sb.toString());
         } finally {
             conn.disconnect();
         }
     }
 
-    List<SabreAlert> parseXml(String xml, double centerLat, double centerLon,
-                               double radiusMeters, ChpConfig config) throws Exception {
-        List<SabreAlert> alerts = new ArrayList<>();
+    // ── Parsing ───────────────────────────────────────────────────────────────
+
+    /** Parse every complete statewide incident with valid coordinates (no filtering). */
+    static List<Incident> parseAll(String xml) throws Exception {
+        List<Incident> incidents = new ArrayList<>();
         XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
         XmlPullParser parser = factory.newPullParser();
         parser.setInput(new StringReader(xml));
@@ -114,11 +194,8 @@ public class CHPSource {
                         else if ("LATLON".equals(endTag))   latlon    = value;
                     }
                     if ("Log".equals(endTag)) {
-                        if (logId != null && latlon != null) {
-                            SabreAlert alert = buildAlert(logId, logType, logTime, location, area,
-                                    latlon, centerLat, centerLon, radiusMeters, config);
-                            if (alert != null) alerts.add(alert);
-                        }
+                        Incident inc = toIncident(logId, logType, logTime, location, area, latlon);
+                        if (inc != null) incidents.add(inc);
                         currentTag = null;
                     }
                     break;
@@ -126,65 +203,84 @@ public class CHPSource {
             try {
                 eventType = parser.next();
             } catch (Exception e) {
-                // CHP's IIS server caps the feed at ~80KB (Content-Length: 81920) and
-                // truncates mid-record when statewide incident volume is high, leaving
-                // malformed XML at the end. Salvage every complete <Log> parsed so far
-                // instead of dropping all of them (which would yield zero alerts exactly
-                // when the roads are busiest).
-                Log.w(TAG, "CHP feed truncated mid-stream — salvaged " + alerts.size()
+                // CHP's IIS server caps the feed (~80KB historically, but the size now
+                // varies) and truncates mid-record when statewide incident volume is
+                // high, leaving malformed XML at the end. Salvage every complete <Log>
+                // parsed so far instead of dropping all of them (which would yield zero
+                // alerts exactly when the roads are busiest).
+                Log.w(TAG, "CHP feed truncated mid-stream — salvaged " + incidents.size()
                         + " complete records before the cut");
                 break;
             }
         }
-        return alerts;
+        return incidents;
     }
 
-    /** Kept for tests that call the old 4-arg overload. */
-    List<SabreAlert> parseXml(String xml, double centerLat, double centerLon,
-                               double radiusMeters) throws Exception {
-        return parseXml(xml, centerLat, centerLon, radiusMeters, null);
-    }
-
-    private SabreAlert buildAlert(String logId, String logType, String logTime,
-                                   String location, String area, String latlon,
-                                   double centerLat, double centerLon, double radiusMeters,
-                                   ChpConfig config) {
-        // ── coordinate validation ───────────────────────────────────────────
-        if (latlon == null || latlon.equals("0:0") || latlon.startsWith("0:")) return null;
+    /** Build an Incident from raw fields, or null if coordinates are missing/invalid. */
+    private static Incident toIncident(String logId, String logType, String logTime,
+                                       String location, String area, String latlon) {
+        if (logId == null || latlon == null) return null;
+        if (latlon.equals("0:0") || latlon.startsWith("0:")) return null;
         double[] coords;
         try { coords = parseLatLon(latlon); } catch (Exception e) { return null; }
-        double lat = coords[0], lon = coords[1];
-        if (lat == 0.0 && lon == 0.0) return null;
-        if (haversineMeters(centerLat, centerLon, lat, lon) > radiusMeters) return null;
+        if (coords[0] == 0.0 && coords[1] == 0.0) return null;
+        return new Incident(logId, logType, logTime, location, area, coords[0], coords[1]);
+    }
+
+    // ── Filtering (radius + config) ───────────────────────────────────────────
+
+    private static List<SabreAlert> filter(List<Incident> incidents, double centerLat,
+                                            double centerLon, double radiusMeters, ChpConfig config) {
+        List<SabreAlert> out = new ArrayList<>();
+        long nowSec = System.currentTimeMillis() / 1000;
+        for (Incident inc : incidents) {
+            SabreAlert a = buildAlert(inc, centerLat, centerLon, radiusMeters, config, nowSec);
+            if (a != null) out.add(a);
+        }
+        return out;
+    }
+
+    private static SabreAlert buildAlert(Incident inc, double centerLat, double centerLon,
+                                         double radiusMeters, ChpConfig config, long nowSec) {
+        if (haversineMeters(centerLat, centerLon, inc.lat, inc.lon) > radiusMeters) return null;
 
         // ── always-excluded types (admin, not traffic-relevant) ──────────────
-        ChpCategory category = AlertMapper.categoryFor(logType);
+        ChpCategory category = AlertMapper.categoryFor(inc.logType);
         if (category == null) return null;  // SILVER / MISSING
 
         // ── incident age filter ──────────────────────────────────────────────
-        long reportTs = parseLogTime(logTime);  // 0 if unparseable
-        if (reportTs == 0) reportTs = System.currentTimeMillis() / 1000;
+        long reportTs = parseLogTime(inc.logTime);   // 0 if unparseable
+        if (reportTs == 0) reportTs = nowSec;
 
         if (config != null && config.maxAgeMinutes > 0) {
-            long cutoffSecs = System.currentTimeMillis() / 1000 - config.maxAgeMinutes * 60L;
-            if (reportTs > 0 && reportTs < cutoffSecs) return null;  // too old
+            long cutoffSecs = nowSec - config.maxAgeMinutes * 60L;
+            if (reportTs < cutoffSecs) return null;  // too old
         }
 
         // ── category filter + type resolution ────────────────────────────────
-        String naturalType = AlertMapper.fromChpLogType(logType);
-        String finalType;
-        if (config != null) {
-            finalType = config.resolveType(category, naturalType);
-        } else {
-            finalType = (category.defaultType != null) ? category.defaultType : naturalType;
-        }
+        String naturalType = AlertMapper.fromChpLogType(inc.logType);
+        String finalType = (config != null)
+                ? config.resolveType(category, naturalType)
+                : (category.defaultType != null ? category.defaultType : naturalType);
         if (finalType == null) return null;  // category disabled
 
-        String streetName = buildStreetName(location, area);
+        String streetName = buildStreetName(inc.location, inc.area);
         return new SabreAlert(
-                "chp_" + logId,
+                "chp_" + inc.logId,
                 SabreResponseBuilder.SOURCE_CHP,
-                finalType, lat, lon, SabreResponseBuilder.HEADING_UNKNOWN, streetName, reportTs);
+                finalType, inc.lat, inc.lon, SabreResponseBuilder.HEADING_UNKNOWN, streetName, reportTs);
+    }
+
+    // ── Test-facing parse+filter entry points (kept for CHPSourceTest) ────────
+
+    List<SabreAlert> parseXml(String xml, double centerLat, double centerLon,
+                              double radiusMeters, ChpConfig config) throws Exception {
+        return filter(parseAll(xml), centerLat, centerLon, radiusMeters, config);
+    }
+
+    List<SabreAlert> parseXml(String xml, double centerLat, double centerLon,
+                              double radiusMeters) throws Exception {
+        return parseXml(xml, centerLat, centerLon, radiusMeters, null);
     }
 
     // ── Time parsing ──────────────────────────────────────────────────────────

--- a/app/src/main/java/app/sabre/wzsabre/LcsSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/LcsSource.java
@@ -274,7 +274,10 @@ public class LcsSource {
         String l = c.lanesClosed;
         if (l == null || l.isEmpty()) return false;
         String lower = l.toLowerCase(Locale.US);
-        if (lower.contains("all") || lower.contains("hov") || lower.contains("turn")) return false;
+        // "aux" (Auxiliary) is a travel lane — closing it is a real lane closure even
+        // when the value carries no digit (e.g. "Median, LShoulder, Auxiliary").
+        if (lower.contains("all") || lower.contains("hov") || lower.contains("turn")
+                || lower.contains("aux")) return false;
         for (int i = 0; i < l.length(); i++) {
             if (Character.isDigit(l.charAt(i))) return false;
         }
@@ -289,6 +292,9 @@ public class LcsSource {
     static List<SabreAlert> toAlerts(Closure c) {
         List<SabreAlert> out = new ArrayList<>(2);
         long reportTs = c.epoch1097 > 0 ? c.epoch1097 : c.startEpoch;
+        // Both epochs missing/unparseable → fall back to now, not 0 (a "1970" report_ts
+        // that HR would age-filter away or render absurdly).
+        if (reportTs <= 0) reportTs = System.currentTimeMillis() / 1000L;
         String street = describe(c);
         out.add(new SabreAlert("lcs_" + c.index, SabreResponseBuilder.SOURCE_LCS,
                 "HAZARD_ON_ROAD_CONGESTION", c.beginLat, c.beginLon,

--- a/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
@@ -170,8 +170,10 @@ public class SabreResponseBuilder {
             if (a == null || !isValidType(a.type)) continue;
             try {
                 alertsArray.put(buildAlert(a));
-            } catch (RuntimeException ignored) {
-                // invalid coords / report_ts — skip this alert only
+            } catch (RuntimeException | JSONException ignored) {
+                // invalid coords / report_ts / NaN heading — skip this alert only.
+                // JSONException is caught too: JSONObject.put(double) throws it (a
+                // checked exception, not a RuntimeException) on a NaN/Infinite value.
             }
         }
         responseData.put("alerts", alertsArray);
@@ -191,6 +193,9 @@ public class SabreResponseBuilder {
         }
         if (Double.isNaN(a.lon) || Double.isInfinite(a.lon)) {
             throw new IllegalArgumentException("lon is NaN/Infinite for alert " + a.alertId);
+        }
+        if (Double.isNaN(a.headingDeg) || Double.isInfinite(a.headingDeg)) {
+            throw new IllegalArgumentException("heading_deg is NaN/Infinite for alert " + a.alertId);
         }
 
         JSONObject obj = new JSONObject();

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -20,7 +20,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class SabreService extends Service {
     private static final String TAG = "SABREService";
@@ -74,8 +73,9 @@ public class SabreService extends Service {
         wazeSource = new app.sabre.wzsabre.waze.WazeProtocolSource(this);
         createNotificationChannel();
         startForeground(NOTIFICATION_ID, buildForegroundNotification());
-        prewarmFromLastLocation();
-        armIdleStop();   // stop if no HR activity arrives
+        chpSource.prewarm();          // statewide feed — no location needed
+        prewarmFromLastLocation();    // Waze — needs last known location
+        armIdleStop();                // stop if no HR activity arrives
         Log.d(TAG, "Service started");
     }
 
@@ -158,6 +158,7 @@ public class SabreService extends Service {
         if (fetchExecutor   != null) fetchExecutor.shutdownNow();
         if (wazeSource != null) wazeSource.shutdown();
         if (lcsSource  != null) lcsSource.shutdown();
+        if (chpSource  != null) chpSource.shutdown();
         super.onDestroy();
     }
 
@@ -186,8 +187,8 @@ public class SabreService extends Service {
                 // Load config fresh on each request so changes take effect immediately
                 ChpConfig chpConfig = ChpConfig.load(SabreService.this);
 
-                // All sources run in parallel. Waze and LCS serve from caches and
-                // return in milliseconds; CHP is the only real network call here.
+                // All three sources serve from background-refreshed caches and return
+                // in milliseconds; none blocks on the network on the HR request path.
                 Future<List<SabreAlert>> chpFuture  = fetchExecutor.submit(() -> chpSource.fetchAlerts(lat, lon, radius, chpConfig));
                 Future<List<SabreAlert>> wazeFuture = fetchExecutor.submit(() -> wazeSource.fetchAlerts(lat, lon, radius));
                 Future<List<SabreAlert>> lcsFuture  = chpConfig.lcsEnabled
@@ -196,12 +197,15 @@ public class SabreService extends Service {
 
                 List<SabreAlert> allAlerts = new ArrayList<>();
 
-                // CHP is always fast (~0.5 s); give it up to 5 s just in case
+                // Each source serves from cache and returns in ms. Any failure of one
+                // source (timeout OR an unexpected error) must never discard the
+                // alerts already collected from the others, so each get() is guarded
+                // independently and only that source is dropped on failure.
                 try {
                     allAlerts.addAll(chpFuture.get(5, TimeUnit.SECONDS));
                     Log.d(TAG, "CHP: " + allAlerts.size() + " alerts");
-                } catch (TimeoutException e) {
-                    Log.w(TAG, "CHP timed out");
+                } catch (Exception e) {
+                    Log.w(TAG, "CHP unavailable this cycle: " + e.getClass().getSimpleName());
                     chpFuture.cancel(true);
                 }
 
@@ -212,8 +216,8 @@ public class SabreService extends Service {
                         List<SabreAlert> wazeAlerts = wazeFuture.get(wazeMs, TimeUnit.MILLISECONDS);
                         allAlerts.addAll(wazeAlerts);
                         Log.d(TAG, "Waze: " + wazeAlerts.size() + " alerts");
-                    } catch (TimeoutException e) {
-                        Log.w(TAG, "Waze exceeded budget — sending without Waze data");
+                    } catch (Exception e) {
+                        Log.w(TAG, "Waze unavailable this cycle: " + e.getClass().getSimpleName());
                         wazeFuture.cancel(true);
                     }
                 } else {
@@ -227,8 +231,8 @@ public class SabreService extends Service {
                         List<SabreAlert> lcsAlerts = lcsFuture.get(1, TimeUnit.SECONDS);
                         allAlerts.addAll(lcsAlerts);
                         Log.d(TAG, "LCS: " + lcsAlerts.size() + " alerts");
-                    } catch (TimeoutException e) {
-                        Log.w(TAG, "LCS timed out");
+                    } catch (Exception e) {
+                        Log.w(TAG, "LCS unavailable this cycle: " + e.getClass().getSimpleName());
                         lcsFuture.cancel(true);
                     }
                 }

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
@@ -2,6 +2,7 @@ package app.sabre.wzsabre.waze;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.SystemClock;
 import android.util.Log;
 
 import java.util.ArrayList;
@@ -55,6 +56,14 @@ public final class WazeProtocolSource {
     private static final int  SHRINK_STEPS    = 5;
     private static final long QUERY_BUDGET_MS = 10_000L;
 
+    // Backoff after a Waze account/login rejection so a persistent 4xx (purged
+    // account, rate-limit, IP flag) can't spin the register→login loop and burn the
+    // anonymous-account daily cap in seconds. Exponential 30s→10min; combined with
+    // MAX_ACCOUNTS_PER_DAY this hard-caps how fast/often we mint new accounts.
+    private static final long BACKOFF_BASE_MS = 30_000L;
+    private static final long BACKOFF_MAX_MS  = 10 * 60_000L;
+    private static final long DAY_MS          = 24 * 3600_000L;
+
     private final Context ctx;
     private final ExecutorService refreshExec = Executors.newSingleThreadExecutor();
     private final AtomicBoolean refreshing = new AtomicBoolean(false);
@@ -63,8 +72,13 @@ public final class WazeProtocolSource {
     private final WazeAlertCache alertCache = new WazeAlertCache();
     private final WazeConfirmTracker confirmTracker = new WazeConfirmTracker();
 
+    // elapsedRealtime-based so a wall-clock/NTP step can't freeze refreshes.
     private volatile long   cacheTimeMs = 0L;
     private volatile double cacheLat, cacheLon;
+
+    // Rejection backoff state — touched only on the single refresh thread.
+    private int  consecutiveRejections = 0;
+    private long backoffUntilMs        = 0L;
 
     public WazeProtocolSource(Context ctx) {
         this.ctx = ctx.getApplicationContext();
@@ -77,7 +91,7 @@ public final class WazeProtocolSource {
     public List<SabreAlert> fetchAlerts(double lat, double lon, double radiusMeters) {
         triggerRefreshIfStale(lat, lon, radiusMeters);
 
-        long now = System.currentTimeMillis();
+        long now = SystemClock.elapsedRealtime();
         if (cacheTimeMs == 0
                 || (now - cacheTimeMs) > CACHE_MAX_SERVE_AGE_MS
                 || haversineKm(lat, lon, cacheLat, cacheLon) > CACHE_DISCARD_KM) {
@@ -109,7 +123,8 @@ public final class WazeProtocolSource {
     }
 
     private void triggerRefreshIfStale(double lat, double lon, double radiusMeters) {
-        long now = System.currentTimeMillis();
+        long now = SystemClock.elapsedRealtime();
+        if (now < backoffUntilMs) return;   // in rejection backoff — don't hammer Waze
         boolean moved = cacheTimeMs != 0 && haversineKm(lat, lon, cacheLat, cacheLon) > REFRESH_MOVE_KM;
         boolean stale = cacheTimeMs == 0 || (now - cacheTimeMs) > CACHE_TTL_MS || moved;
         if (stale && refreshing.compareAndSet(false, true)) {
@@ -122,7 +137,7 @@ public final class WazeProtocolSource {
                 try {
                     if (discard) alertCache.clear();
                     refresh(lat, lon, radius);
-                    cacheTimeMs = System.currentTimeMillis();
+                    cacheTimeMs = SystemClock.elapsedRealtime();
                     cacheLat = lat;
                     cacheLon = lon;
                 } catch (Exception e) {
@@ -139,18 +154,65 @@ public final class WazeProtocolSource {
         try {
             queryArea(ensureSession(lat, lon), lat, lon, radiusMeters);
         } catch (WazeExceptions.AccountRejectedException e) {
-            Log.w(TAG, "Account rejected — re-registering: " + e.getMessage());
-            session = null;
-            clearPersisted();
-            queryArea(ensureSession(lat, lon), lat, lon, radiusMeters);
+            handleAccountRejected(e, lat, lon, radiusMeters);
         } catch (WazeExceptions.SessionExpiredException e) {
             Log.w(TAG, "Session expired — re-logging in: " + e.getMessage());
-            session = null;                 // keep credentials, just re-login
+            if (session != null) session.invalidateSession();   // keep creds, just re-login
             queryArea(ensureSession(lat, lon), lat, lon, radiusMeters);
         }
-        persist();
+        // Reached only on a fully successful refresh — clear any rejection backoff.
+        consecutiveRejections = 0;
+        backoffUntilMs = 0L;
         Log.d(TAG, "Waze cache: " + alertCache.size() + " alerts near "
                 + String.format(Locale.US, "%.4f,%.4f", lat, lon));
+    }
+
+    /**
+     * Recover from a rejected account. Backs off before the next refresh regardless,
+     * and only mints a replacement account while under the per-day cap — so a
+     * persistent rejection can't burn the anonymous-account quota. Once the cap or
+     * the consecutive-rejection ceiling is hit, gives up this cycle (cache unchanged)
+     * and lets the growing backoff throttle retries.
+     */
+    private void handleAccountRejected(Exception e, double lat, double lon, double radiusMeters)
+            throws Exception {
+        consecutiveRejections++;
+        setBackoff();
+        if (!canRegisterToday() || consecutiveRejections > WazeConstants.MAX_CONSECUTIVE_REJECTIONS) {
+            Log.w(TAG, "Account rejected; registration cap/limit reached (" + consecutiveRejections
+                    + " consecutive) — backing off without re-registering: " + e.getMessage());
+            throw e;
+        }
+        Log.w(TAG, "Account rejected — re-registering (attempt " + consecutiveRejections + "): "
+                + e.getMessage());
+        session = null;
+        clearPersisted();
+        recordRegistration();
+        queryArea(ensureSession(lat, lon), lat, lon, radiusMeters);
+    }
+
+    private void setBackoff() {
+        int step = Math.min(Math.max(consecutiveRejections, 1), 5);
+        long delay = Math.min(BACKOFF_MAX_MS, BACKOFF_BASE_MS * (1L << (step - 1)));
+        backoffUntilMs = SystemClock.elapsedRealtime() + delay;
+        Log.d(TAG, "Waze refresh backing off " + (delay / 1000) + "s");
+    }
+
+    private boolean canRegisterToday() {
+        SharedPreferences p = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+        long now = System.currentTimeMillis();
+        long windowStart = p.getLong("reg_window_start", 0L);
+        if (now - windowStart > DAY_MS) return true;   // 24h window rolled over
+        return p.getInt("reg_count", 0) < WazeConstants.MAX_ACCOUNTS_PER_DAY;
+    }
+
+    private void recordRegistration() {
+        SharedPreferences p = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+        long now = System.currentTimeMillis();
+        long windowStart = p.getLong("reg_window_start", 0L);
+        int count = p.getInt("reg_count", 0);
+        if (now - windowStart > DAY_MS) { windowStart = now; count = 0; }
+        p.edit().putLong("reg_window_start", windowStart).putInt("reg_count", count + 1).apply();
     }
 
     /**
@@ -162,11 +224,22 @@ public final class WazeProtocolSource {
      * thinning that drops minor/near-driver alerts from a single large query.
      */
     private void queryArea(WazeSession s, double lat, double lon, double radiusMeters) throws Exception {
+        long sessionBefore = s.currentServerSessionId();
         s.prepareForArea(lat, lon);
+        // Credentials exist now (register/login just ran) — persist immediately so a
+        // failure in the box loop below can't lose a freshly minted account and force
+        // a wasteful re-register on the next run.
+        persist();
+        if (s.currentServerSessionId() != sessionBefore) {
+            // A new server session re-sends all currently-active alerts for the area
+            // but sends no RmAlert for alerts that cleared while we were logged out.
+            // Drop the stale cache so those don't linger in Highway Radar as ghosts.
+            alertCache.clear();
+        }
         double[][] zoomBoxes = GeoBoxes.shrinkingBoxes(lon, lat, radiusMeters, SHRINK_STEPS);
-        long deadline = System.currentTimeMillis() + QUERY_BUDGET_MS;
+        long deadline = SystemClock.elapsedRealtime() + QUERY_BUDGET_MS;
         for (double[] zoom : zoomBoxes) {
-            if (System.currentTimeMillis() >= deadline) break;   // best-effort, like the official
+            if (SystemClock.elapsedRealtime() >= deadline) break;   // best-effort, like the official
             WazeProto.Batch batch = s.queryBox(GeoBoxes.shrink(zoom, 0.75));
             alertCache.submit(new AlertQueryResult(
                     WazeRtCodec.parseAlerts(batch), WazeRtCodec.parseRemovedAlertIds(batch)));
@@ -235,8 +308,14 @@ public final class WazeProtocolSource {
                 .apply();
     }
 
+    /** Clear only the credential/device keys — the registration-rate counter
+     *  (reg_count / reg_window_start) must survive so the per-day cap still holds. */
     private void clearPersisted() {
-        ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit().clear().apply();
+        ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()
+                .remove("community").remove("secret")
+                .remove("dev_mfr").remove("dev_model").remove("dev_os")
+                .remove("dev_w").remove("dev_h").remove("dev_iid")
+                .apply();
     }
 
     private static double haversineKm(double lat1, double lon1, double lat2, double lon2) {

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -44,6 +45,51 @@ final class WazeSession {
     WazeCredentials getCredentials() { return credentials; }
     DeviceIdentity  getDevice()      { return device; }
 
+    /** Server session id (0 if not logged in) — lets the caller detect a re-login. */
+    long currentServerSessionId() { return session != null ? session.serverSessionId : 0L; }
+
+    /** Drop the logged-in session but KEEP credentials, so the next call re-logs in
+     *  (with the in-memory account) instead of registering a brand-new one. */
+    void invalidateSession() { session = null; }
+
+    /**
+     * Inspect a parsed response batch for in-band errors the server returns with an
+     * HTTP 200: a {@code ServerError} element, or a {@code LoginError}. Without this,
+     * a server that invalidates the session but replies 200 looks like success and
+     * the session zombies — {@code lastRequestMs} keeps updating so it never idles
+     * out, and no alerts are ever merged again. Mirrors the official's checkErrors.
+     */
+    static void checkErrors(WazeProto.Batch batch)
+            throws WazeExceptions.AccountRejectedException,
+                   WazeExceptions.SessionExpiredException,
+                   WazeExceptions.WazeOperationException {
+        for (WazeProto.Element el : batch.getElementList()) {
+            if (el.hasError()) {
+                WazeProto.ServerError err = el.getError();
+                int code = err.getCode();
+                String desc = err.getDescription().toLowerCase(Locale.US);
+                if (desc.contains("relogin") || desc.contains("unknown userid")
+                        || desc.contains("secretkey") || desc.contains("secret key"))
+                    throw new WazeExceptions.SessionExpiredException(
+                            "server error: " + err.getDescription());
+                if (code >= 400 && code < 500)
+                    throw new WazeExceptions.AccountRejectedException(
+                            "server error " + code + ": " + err.getDescription());
+                throw new WazeExceptions.WazeOperationException(
+                        "server error " + code + ": " + err.getDescription());
+            }
+            if (el.hasLoginError()) {
+                WazeProto.LoginError.AuthErrorType t = el.getLoginError().getErrorType();
+                // Transient server-side problems must NOT nuke a good account; only
+                // genuine credential/authorization failures trigger a re-register.
+                if (t == WazeProto.LoginError.AuthErrorType.INTERNAL_ISSUES
+                        || t == WazeProto.LoginError.AuthErrorType.UNKNOWN_ERROR)
+                    throw new WazeExceptions.WazeOperationException("login error: " + t);
+                throw new WazeExceptions.AccountRejectedException("login error: " + t);
+            }
+        }
+    }
+
     private String url(String path) { return "https://" + WazeConstants.rtHost(region) + path; }
     private String nextSeq() { return String.valueOf(seqCount++); }
 
@@ -69,6 +115,7 @@ final class WazeSession {
         if (r.body.length == 0) throw new WazeExceptions.WazeOperationException("empty register response");
 
         WazeProto.Batch batch = WazeProto.Batch.parseFrom(r.body);
+        checkErrors(batch);
         for (WazeProto.Element el : batch.getElementList()) {
             if (el.hasRegisterSuccessful()) {
                 WazeProto.RegisterSuccessful rs = el.getRegisterSuccessful();
@@ -111,6 +158,7 @@ final class WazeSession {
         if (r.body.length == 0) throw new WazeExceptions.WazeOperationException("empty login response");
 
         WazeProto.Batch batch = WazeProto.Batch.parseFrom(r.body);
+        checkErrors(batch);   // in-band LoginError → specific exception, not blanket reject
         for (WazeProto.Element el : batch.getElementList()) {
             if (el.hasLoginResponse() && el.getLoginResponse().hasLoginSuccess()) {
                 WazeProto.LoginSuccess s = el.getLoginResponse().getLoginSuccess();
@@ -148,8 +196,17 @@ final class WazeSession {
         }
         if (r.code >= 500) throw new WazeExceptions.WazeOperationException("command HTTP " + r.code);
         if (r.body.length == 0) throw new WazeExceptions.WazeOperationException("empty command response");
+        WazeProto.Batch batch = WazeProto.Batch.parseFrom(r.body);
+        // Check for an in-band error BEFORE marking the session healthy, so a zombie
+        // session (HTTP 200 + "please relogin") doesn't keep refreshing lastRequestMs.
+        try {
+            checkErrors(batch);
+        } catch (WazeExceptions.SessionExpiredException e) {
+            session = null;   // force ensureReady to re-login next time
+            throw e;
+        }
         lastRequestMs = SystemClock.elapsedRealtime();
-        return WazeProto.Batch.parseFrom(r.body);
+        return batch;
     }
 
     /** Register (if no creds) and log in (if no valid session). */

--- a/app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java
@@ -1,6 +1,9 @@
 package app.sabre.wzsabre;
 
 import org.junit.Test;
+
+import java.util.Locale;
+
 import static org.junit.Assert.*;
 
 /** Tests that CHP and Waze alert types map to valid SABRE type constants. */
@@ -45,6 +48,27 @@ public class AlertMapperTest {
     @Test public void waze_roadClosed()      { assertEquals("HAZARD_ON_ROAD_CONGESTION", AlertMapper.fromWazeType("ROAD_CLOSED", "")); }
     @Test public void waze_unknown_returnsNull() { assertNull(AlertMapper.fromWazeType("WEATHERHAZARD", "")); }
     @Test public void waze_null_returnsNull()    { assertNull(AlertMapper.fromWazeType(null, "")); }
+
+    // ── locale independence ───────────────────────────────────────────────────
+
+    @Test
+    public void mapping_isLocaleIndependent_turkish() {
+        // On a Turkish/Azeri device, default-locale "silver".toUpperCase() dots the i
+        // (→ "SİLVER"), so contains("SILVER") would silently fail — un-suppressing
+        // Silver Alerts and misrouting other 'i'-bearing types. Mapping must uppercase
+        // with Locale.US. These inputs carry a lowercase i, the trigger condition.
+        Locale prev = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("tr", "TR"));
+            assertNull("Silver Alert must still be excluded under tr-TR",
+                    AlertMapper.categoryFor("Silver Alert"));
+            assertEquals(ChpCategory.WEATHER, AlertMapper.categoryFor("High wind advisory"));
+            assertEquals("ACCIDENT_MAJOR", AlertMapper.fromChpLogType("Sig alert issued"));
+            assertEquals("POLICE_HIDDEN", AlertMapper.fromWazeType("police", "police_hiding"));
+        } finally {
+            Locale.setDefault(prev);
+        }
+    }
 
     @Test
     public void waze_allMappedTypesAreValid() {

--- a/app/src/test/java/app/sabre/wzsabre/LcsSourceTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/LcsSourceTest.java
@@ -199,6 +199,17 @@ public class LcsSourceTest {
         assertTrue(LcsSource.isShoulderOnly(c));
     }
 
+    @Test
+    public void auxiliaryLane_isKept() {
+        // "Auxiliary" is a travel lane; a digit-less value that includes it must not
+        // be classified shoulder-only (real D3 feed: "Median, LShoulder, Auxiliary").
+        LcsSource.Closure c = activeClosure();
+        c.lanesClosed = "Median, LShoulder, Auxiliary, RShoulder";
+        assertFalse(LcsSource.isShoulderOnly(c));
+        c.lanesClosed = "Auxiliary";
+        assertFalse(LcsSource.isShoulderOnly(c));
+    }
+
     // ── SABRE mapping ─────────────────────────────────────────────────────────
 
     @Test
@@ -215,6 +226,19 @@ public class LcsSourceTest {
         assertTrue(a.reportTs <= Integer.MAX_VALUE);
         assertEquals("closures are directionless → -720 heading sentinel",
                 SabreResponseBuilder.HEADING_UNKNOWN, a.headingDeg, 0.0);
+    }
+
+    @Test
+    public void toAlerts_missingEpochs_fallsBackToNow() {
+        // Neither code1097Epoch nor closureStartEpoch present → report_ts must be a
+        // fresh "now", never 0 (which HR would render as a 1970 timestamp).
+        LcsSource.Closure c = activeClosure();
+        c.epoch1097 = 0;
+        c.startEpoch = 0;
+        SabreAlert a = LcsSource.toAlerts(c).get(0);
+        long nowSec = System.currentTimeMillis() / 1000L;
+        assertTrue("report_ts must fall back to ~now",
+                a.reportTs > nowSec - 60 && a.reportTs <= nowSec + 1);
     }
 
     @Test

--- a/app/src/test/java/app/sabre/wzsabre/SabreProtocolTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/SabreProtocolTest.java
@@ -233,6 +233,18 @@ public class SabreProtocolTest {
     }
 
     @Test
+    public void build_dropsNaNHeading_keepsValidAlerts() throws Exception {
+        // JSONObject.put(double) throws a *checked* JSONException on a NaN heading;
+        // that must be caught so one bad alert can't blank the whole batch.
+        SabreAlert bad = new SabreAlert("bad", "chp", "POLICE_VISIBLE",
+                34.0, -118.0, Double.NaN, null, NOW_SECONDS);
+        JSONObject root = new JSONObject(SabreResponseBuilder.build("r",
+                java.util.Arrays.asList(bad, chpAlert())));
+        assertEquals("NaN-heading alert dropped, valid alert kept", 1,
+                root.getJSONObject("response").getJSONArray("alerts").length());
+    }
+
+    @Test
     public void build_dropsUnknownType_keepsValidAlerts() throws Exception {
         // An unknown SABRE type string would crash HR's renderer — never send it.
         SabreAlert bad = new SabreAlert("bad", "chp", "TOTALLY_BOGUS_TYPE",

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeSessionErrorTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeSessionErrorTest.java
@@ -1,0 +1,100 @@
+package app.sabre.wzsabre.waze;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+/**
+ * WazeSession.checkErrors classifies in-band (HTTP-200) errors so a zombie session
+ * recovers instead of silently dropping all Waze data. Without it, a "please relogin"
+ * arriving with a 200 status looked like success and the feed went quiet forever.
+ */
+public class WazeSessionErrorTest {
+
+    private static WazeProto.Batch serverError(int code, String desc) {
+        return WazeProto.Batch.newBuilder()
+                .addElement(WazeProto.Element.newBuilder()
+                        .setError(WazeProto.ServerError.newBuilder()
+                                .setCode(code).setDescription(desc)))
+                .build();
+    }
+
+    private static WazeProto.Batch loginError(WazeProto.LoginError.AuthErrorType t) {
+        return WazeProto.Batch.newBuilder()
+                .addElement(WazeProto.Element.newBuilder()
+                        .setLoginError(WazeProto.LoginError.newBuilder().setErrorType(t)))
+                .build();
+    }
+
+    @Test
+    public void reloginDescription_isSessionExpired() {
+        try {
+            WazeSession.checkErrors(serverError(500, "Session invalid, please relogin"));
+            fail("expected SessionExpiredException");
+        } catch (Exception e) {
+            assertTrue(e instanceof WazeExceptions.SessionExpiredException);
+        }
+    }
+
+    @Test
+    public void unknownUserId_isSessionExpired() {
+        try {
+            WazeSession.checkErrors(serverError(0, "unknown userid"));
+            fail("expected SessionExpiredException");
+        } catch (Exception e) {
+            assertTrue(e instanceof WazeExceptions.SessionExpiredException);
+        }
+    }
+
+    @Test
+    public void clientErrorCode_isAccountRejected() {
+        try {
+            WazeSession.checkErrors(serverError(403, "forbidden"));
+            fail("expected AccountRejectedException");
+        } catch (Exception e) {
+            assertTrue(e instanceof WazeExceptions.AccountRejectedException);
+        }
+    }
+
+    @Test
+    public void serverErrorCode_isOperationError() {
+        try {
+            WazeSession.checkErrors(serverError(500, "internal failure"));
+            fail("expected WazeOperationException");
+        } catch (Exception e) {
+            assertTrue(e instanceof WazeExceptions.WazeOperationException);
+        }
+    }
+
+    @Test
+    public void loginInternalIssues_isTransient_notReject() {
+        // A transient server issue must NOT nuke a good account (that would burn the
+        // anonymous-account quota re-registering for nothing).
+        try {
+            WazeSession.checkErrors(loginError(WazeProto.LoginError.AuthErrorType.INTERNAL_ISSUES));
+            fail("expected WazeOperationException");
+        } catch (Exception e) {
+            assertTrue("transient login error must not be AccountRejected",
+                    e instanceof WazeExceptions.WazeOperationException);
+        }
+    }
+
+    @Test
+    public void loginWrongPassword_isAccountRejected() {
+        try {
+            WazeSession.checkErrors(loginError(WazeProto.LoginError.AuthErrorType.WRONG_USER_PASSWORD));
+            fail("expected AccountRejectedException");
+        } catch (Exception e) {
+            assertTrue(e instanceof WazeExceptions.AccountRejectedException);
+        }
+    }
+
+    @Test
+    public void cleanBatch_doesNotThrow() throws Exception {
+        WazeSession.checkErrors(WazeProto.Batch.newBuilder()
+                .addElement(WazeProto.Element.newBuilder().setOldCommand("SomeCmd,x"))
+                .build());
+        // no exception = pass
+    }
+}


### PR DESCRIPTION
Data-integrity release. Fixes the ways Waze and CHP alerts could silently go wrong — a self-inflicted account ban, a session that dies without recovering, ghost alerts, and CHP flapping in and out on a flaky network.

## Fixes
- **Protect the Waze account quota (critical).** A persistent login/account rejection used to re-register a brand-new anonymous account on every ~1-2s poll, burning Waze's ~10/day cap in under a minute (and risking an IP flag). Now rejections apply an exponential 30s→10min backoff and re-registrations are capped per rolling 24h (using the previously-dead `MAX_ACCOUNTS_PER_DAY`/`MAX_CONSECUTIVE_REJECTIONS` constants).
- **Recover zombie sessions (high).** The RT server can invalidate a session while replying HTTP 200 + an in-band error; we only checked HTTP status, so the session looked healthy and Waze went dark forever. Now `checkErrors` parses in-band `ServerError`/`LoginError` after every register/login/command and recovers (re-login vs re-register) appropriately — a transient error no longer nukes a good account.
- **No ghost alerts (high).** After a session change the server re-sends active alerts but no removal for ones that cleared while logged out. The cache is now cleared on a detected session-id change, so stale alerts don't linger.
- **Don't waste accounts on first run (high).** Credentials are persisted right after register, and a session expiry re-logs in with the in-memory account instead of registering a new one.
- **CHP served from a last-good cache (high).** CHP is no longer fetched on the request path; a background thread refreshes a parsed cache (with conditional GETs), a failure keeps serving the last good data, and a hung fetch can't starve Waze/LCS. One source failing never discards the others' alerts.
- **Data-quality hardening:** NaN heading can't blank a batch (#12); locale-independent type matching fixes Turkish-device misrouting (#13); `Auxiliary`-lane closures are reported (#17); LCS never emits a 1970 timestamp (#19).

195 unit tests pass (11 new), `lintDebug` clean. Also uses `elapsedRealtime` for cache/backoff timing so a clock step can't freeze refreshes. Docs updated (Android 7.0, JDK 17, first-run steps). Signed APK attached to the v1.5 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)