### PR TITLE
v1.6 — wildfires, update checking, diagnostics, dedupe, release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,23 +19,23 @@ jobs:
     name: Unit tests + lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run unit tests
         run: ./gradlew test lintDebug --no-daemon
 
       - name: Upload test & lint reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: reports
           path: |
@@ -47,22 +47,22 @@ jobs:
     name: Debug APK
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Assemble debug APK
         run: ./gradlew assembleDebug --no-daemon
 
       - name: Upload debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: app-debug
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,27 @@ permissions:
   contents: write
 
 jobs:
+  # Skip cleanly (with a warning) when signing secrets aren't configured, so a
+  # manual/tag release doesn't produce a failed workflow run.
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      signable: ${{ steps.check.outputs.signable }}
+    steps:
+      - id: check
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          if [ -n "$KEYSTORE_BASE64" ]; then
+            echo "signable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "signable=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No KEYSTORE_BASE64 secret set — skipping automated release. Release manually or add signing secrets (see BUILDING.md)."
+          fi
+
   release:
+    needs: guard
+    if: needs.guard.outputs.signable == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release
+
+# Cutting a release is now one command: push a version tag (e.g. `git tag v1.6 &&
+# git push origin v1.6`) and this builds a signed APK and publishes the GitHub
+# release with it attached.
+#
+# Requires these repository secrets (Settings → Secrets and variables → Actions):
+#   KEYSTORE_BASE64    - base64 of the signing keystore (base64 -w0 app/caltrans-sabre.keystore)
+#   KEYSTORE_PASSWORD  - store password
+#   KEY_ALIAS          - key alias
+#   KEY_PASSWORD       - key password
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Decode signing keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: echo "$KEYSTORE_BASE64" | base64 -d > app/release.keystore
+
+      - name: Write keystore.properties
+        env:
+          STORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          {
+            echo "storeFile=release.keystore"
+            echo "storePassword=$STORE_PASSWORD"
+            echo "keyAlias=$KEY_ALIAS"
+            echo "keyPassword=$KEY_PASSWORD"
+          } > keystore.properties
+
+      - name: Build signed release APK
+        run: ./gradlew assembleRelease --no-daemon
+
+      - name: Stage APK asset
+        run: cp app/build/outputs/apk/release/app-release.apk "CHP-Waze-SABRE-${GITHUB_REF_NAME}.apk"
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            "CHP-Waze-SABRE-${GITHUB_REF_NAME}.apk" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes
+
+      - name: Clean up secrets
+        if: always()
+        run: rm -f app/release.keystore keystore.properties

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -39,17 +39,40 @@ JAVA_HOME="/c/Program Files/Android/Android Studio/jbr" ./gradlew assembleDebug
 ./gradlew test
 ```
 
-All tests are JVM unit tests (no emulator required). Results land in `app/build/reports/tests/`.
+All tests are JVM unit tests (no emulator required). Results land in `app/build/reports/tests/`. CI (`.github/workflows/ci.yml`) runs `test` + `lintDebug` and builds a debug APK on every push and PR.
+
+## Cutting a release (maintainer)
+
+Releases are automated. Push a version tag and `.github/workflows/release.yml` builds a signed APK and publishes the GitHub release with it attached:
+
+```bash
+git tag v1.6 && git push origin v1.6
+```
+
+This requires four repository secrets (**Settings → Secrets and variables → Actions**), set once:
+
+| Secret | Value |
+|--------|-------|
+| `KEYSTORE_BASE64` | `base64 -w0 app/caltrans-sabre.keystore` |
+| `KEYSTORE_PASSWORD` | keystore store password |
+| `KEY_ALIAS` | key alias |
+| `KEY_PASSWORD` | key password |
+
+To build a signed APK **locally** instead, put a `keystore.properties` at the repo root (`storeFile`/`storePassword`/`keyAlias`/`keyPassword`; `storeFile` resolves under `app/`) and run `./gradlew assembleRelease`. Without it, `assembleRelease` produces an unsigned APK and warns.
 
 Current test suites:
 
 | Suite | Tests | What it covers |
 |-------|-------|----------------|
-| `AlertMapperTest` | 46 | Every CHP log type and Waze type maps to the correct SABRE type (incl. injury-collision codes) |
+| `AlertMapperTest` | 47 | Every CHP log type and Waze type maps to the correct SABRE type (incl. injury-collision codes, locale independence) |
 | `ChpConfigTest` | 42 | Category toggles, type overrides, age filter, LogTime parsing (both CHP feed formats) |
-| `SabreProtocolTest` | 32 | HR JSON schema — all 11 required alert fields, type whitelist, nullability, drop-bad-alert semantics |
-| `LcsSourceTest` | 25 | Caltrans LCS parsing, 1097/1098/1022 state filtering, shoulder skip, span pins, district selection |
-| `CHPSourceTest` | 17 | XML parsing (incl. entity refs + real feed shape), radius filter, coordinate parsing, haversine |
+| `SabreProtocolTest` | 38 | HR JSON schema — all 11 required alert fields, type whitelist, nullability, drop-bad-alert semantics |
+| `LcsSourceTest` | 27 | Caltrans LCS parsing, 1097/1098/1022 state filtering, shoulder/aux skip, span pins, district selection |
+| `CHPSourceTest` | 18 | XML parsing (incl. entity refs + real feed shape), radius filter, coordinate parsing, haversine |
+| `WildfireSourceTest` | 5 | WFIGS ArcGIS JSON parse + SABRE mapping |
+| `AlertDeduperTest` | 5 | Cross-source pin de-duplication (family + proximity, confirm-fold) |
+| `UpdateCheckerTest` | 4 | Version-comparison logic for the update check |
+| Waze suites | 23 | RT cache delta-merge/soft-delete, in-band error classification, shrinking-box geometry, confirm-ts, RmAlert parsing |
 
 ## Project structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.6] — 2026-07-02
+
+New data source, in-app updates, and quality-of-life.
+
+### Added
+- **Wildfires** — active California wildfires (name, size, containment) from the interagency WFIGS feed, shown as road hazards near the fire. New settings toggle (on by default).
+- **Update checking** — the settings screen shows an "update available" banner, and you get a single notification per new version (no spam). README documents an Obtainium option for hands-off auto-update.
+- **Diagnostics panel** — the settings screen shows each source's last update time, item count, and last error.
+- **Automated releases** — pushing a version tag builds a signed APK and publishes the GitHub release via CI.
+
+### Changed
+- Duplicate pins reported by more than one source (e.g. a CHP and a Waze accident at the same spot) are now merged into one.
+- CI actions updated; the debug/release build is unchanged.
+
 ## [1.5.1] — 2026-07-01
 
 Follow-up hardening from an independent post-release review of 1.5, plus repo hygiene.
@@ -63,6 +77,7 @@ Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrot
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
+[1.6]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.6
 [1.5.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.5.1
 [1.5]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.5
 [1.4]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.4

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A drop-in replacement for **wzsabre** that brings CHP live incident alerts and W
 | **CHP Live Feed** | Accidents, road closures, debris, officer on road, weather hazards — directly from the California Highway Patrol statewide XML feed | Every HR map refresh |
 | **Waze** | Crowdsourced police, accidents, hazards, road closures | Every HR map refresh |
 | **Caltrans Closures (LCS)** | Lane and road closures that are physically in place right now (CHP code 1097), from the per-district Caltrans Lane Closure System feeds | Cached, refreshed every 5 min |
+| **Wildfires** | Active California wildfires (name, size, containment) from the interagency WFIGS feed, shown as road hazards near the fire | Cached, refreshed every 5 min |
 
 All sources run in parallel and feed into the standard HR crowdsourced-alerts layer — the same map overlay that wzsabre used to power.
 
@@ -149,6 +150,7 @@ Highway Radar  ──broadcast──▶  MainBroadcastReceiver
 - **CHP**: fetches `https://media.chp.ca.gov/sa_xml/sa.xml`, filters by radius and incident age, applies your category settings.
 - **Waze**: emulates the Waze mobile app's binary "RT" protocol — it registers an anonymous Waze session, logs in, and queries crowd-sourced alerts over Waze's protobuf API (the older live-map/georss API is now blocked). The RT feed is session-stateful (each alert is sent once, then removed when it clears), so query results are merged into a persistent alert cache rather than replacing it — this keeps alerts from disappearing as you drive. A series of progressively smaller map viewports is queried so the server doesn't thin out minor alerts near you, the session is pre-warmed at start to cut first-load latency, and Waze alert subtypes (e.g. *car stopped on shoulder*, *heavy traffic*) are passed through to Highway Radar verbatim rather than flattened.
 - **Caltrans LCS**: fetches the per-district lane-closure feeds (`https://cwwp2.dot.ca.gov/data/d<N>/lcs/lcsStatusD<NN>.xml`) for whichever districts cover your location. Only closures that are physically established (CHP code 1097 set, not picked up or canceled) are shown; shoulder-only closures are skipped. Closures longer than 2 km get a pin at each end. The ~4 MB feeds are parsed in the background and cached for 5 minutes, so they never delay a Highway Radar request.
+- **Wildfires**: active California wildfires from the interagency WFIGS "Current Wildland Fire Incident Locations" feed (NIFC-hosted ArcGIS), filtered to active wildfires in California. Each is shown as a road hazard at the fire's location with its name, size, and containment. Background-cached like the other sources.
 - **SABRE protocol**: a broadcast-intent IPC protocol defined by Highway Radar. Our plugin responds to `FETCH_REQUEST` broadcasts with a JSON payload containing `SabreFetchResponseAlert` objects.
 
 ---
@@ -161,7 +163,7 @@ Pull requests welcome. Run the test suite before submitting:
 ./gradlew test
 ```
 
-195 unit tests cover the SABRE response format, alert type mapping, the Waze alert cache (delta merge + soft-delete), in-band Waze error classification, shrinking-box geometry, crowd-confirmation tracking, CHP XML parsing, Caltrans LCS parsing and filtering, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup, and [CHANGELOG.md](CHANGELOG.md) for release history.
+209 unit tests cover the SABRE response format, alert type mapping, the Waze alert cache (delta merge + soft-delete), in-band Waze error classification, shrinking-box geometry, crowd-confirmation tracking, CHP XML parsing, Caltrans LCS parsing and filtering, wildfire (WFIGS) parsing, cross-source de-duplication, the update-check version compare, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup, and [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ All sources run in parallel and feed into the standard HR crowdsourced-alerts la
 
 > **After a phone reboot:** Just open Highway Radar — the plugin starts automatically when HR sends its first request.
 
-### Option B — Build from source
+### Option B — Auto-update with Obtainium
+
+For hands-off updates, install via [Obtainium](https://github.com/ImranR98/Obtainium): add this repo's URL (`https://github.com/nicglazkov/caltrans-sabre`) as an app source and Obtainium will check GitHub Releases and install new versions for you. (The app also shows an in-app banner and a one-time notification when an update is available.)
+
+### Option C — Build from source
 
 See [BUILDING.md](BUILDING.md).
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 7
-        versionName = "1.5.1"
+        versionCode = 8
+        versionName = "1.6"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/AlertDeduper.java
+++ b/app/src/main/java/app/sabre/wzsabre/AlertDeduper.java
@@ -1,0 +1,81 @@
+package app.sabre.wzsabre;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Collapses duplicate pins that different sources report for the same real-world
+ * event — e.g. a CHP accident and a Waze accident at the same intersection, or a
+ * CHP closure and a Caltrans LCS closure on the same segment.
+ *
+ * <p>Two alerts are treated as duplicates when they share an alert "family"
+ * (accident / police / closure-congestion / weather / hazard / fire) AND fall in
+ * the same ~100&nbsp;m grid cell. The higher-priority source's alert is kept (CHP >
+ * LCS > Fire > Waze), and the dropped alert's crowd-confirmation count is folded in
+ * so that signal isn't lost.
+ *
+ * <p>Deliberately conservative: grid bucketing under-merges across cell boundaries
+ * (it never merges two events that are actually distinct), and fires get their own
+ * family so a real wildfire is never hidden by a co-located generic hazard.
+ */
+final class AlertDeduper {
+    private AlertDeduper() {}
+
+    /** ~0.001° ≈ 111 m of latitude (a bit less in longitude at CA latitudes). */
+    private static final double CELL_DEG = 0.001;
+
+    static List<SabreAlert> dedupe(List<SabreAlert> alerts) {
+        if (alerts == null || alerts.size() < 2) {
+            return alerts == null ? new ArrayList<>() : new ArrayList<>(alerts);
+        }
+        Map<String, SabreAlert> kept = new LinkedHashMap<>();
+        for (SabreAlert a : alerts) {
+            if (a == null) continue;
+            String key = family(a) + "@" + Math.round(a.lat / CELL_DEG)
+                    + "," + Math.round(a.lon / CELL_DEG);
+            SabreAlert prev = kept.get(key);
+            if (prev == null) {
+                kept.put(key, a);
+            } else {
+                SabreAlert winner = priority(a) >= priority(prev) ? a : prev;
+                SabreAlert loser  = winner == a ? prev : a;
+                kept.put(key, foldConfirmations(winner, loser));
+            }
+        }
+        return new ArrayList<>(kept.values());
+    }
+
+    private static String family(SabreAlert a) {
+        // Fires are their own family so a wildfire is never merged with a co-located
+        // generic HAZARD_ON_ROAD (which is the same type string).
+        if (SabreResponseBuilder.SOURCE_FIRE.equals(a.alertSource)) return "fire";
+        String t = a.type == null ? "?" : a.type;
+        if (t.startsWith("POLICE"))   return "police";
+        if (t.startsWith("ACCIDENT")) return "accident";
+        if (t.contains("CONGESTION") || t.startsWith("JAM") || t.contains("CLOS")
+                || t.contains("LANE_CLOSURE")) return "closure";
+        if (t.startsWith("HAZARD_WEATHER") || t.contains("BAD_WEATHER")) return "weather";
+        return "hazard";
+    }
+
+    /** Source trust order for which duplicate to keep. */
+    private static int priority(SabreAlert a) {
+        if (SabreResponseBuilder.SOURCE_CHP.equals(a.alertSource))  return 4;
+        if (SabreResponseBuilder.SOURCE_LCS.equals(a.alertSource))  return 3;
+        if (SabreResponseBuilder.SOURCE_FIRE.equals(a.alertSource)) return 2;
+        if (SabreResponseBuilder.SOURCE_WAZE.equals(a.alertSource)) return 1;
+        return 0;
+    }
+
+    /** Keep the winner, but carry over the higher crowd-confirmation signal. */
+    private static SabreAlert foldConfirmations(SabreAlert w, SabreAlert l) {
+        int cc = Math.max(w.confirmCount, l.confirmCount);
+        Long cts = w.confirmTs != null ? w.confirmTs : l.confirmTs;
+        boolean sameCts = (cts == null) ? (w.confirmTs == null) : cts.equals(w.confirmTs);
+        if (cc == w.confirmCount && sameCts) return w;   // nothing to change
+        return new SabreAlert(w.alertId, w.alertSource, w.type, w.lat, w.lon, w.headingDeg,
+                w.streetName, w.reportTs, cts, cc);
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/CHPSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/CHPSource.java
@@ -109,11 +109,15 @@ public class CHPSource {
                     } else {
                         cacheTimeMs = System.currentTimeMillis();   // fresh enough, unchanged
                     }
+                    SourceStatus.success(SabreResponseBuilder.SOURCE_CHP,
+                            cache == null ? 0 : cache.size());
                 } catch (Exception e) {
                     // Keep serving the last good parse — a transient failure must not
                     // blank CHP for the whole cycle.
                     Log.w(TAG, "CHP refresh failed (serving cache): "
                             + e.getClass().getSimpleName() + ": " + e.getMessage());
+                    SourceStatus.failure(SabreResponseBuilder.SOURCE_CHP,
+                            e.getClass().getSimpleName());
                 } finally {
                     refreshing.set(false);
                 }

--- a/app/src/main/java/app/sabre/wzsabre/ChpConfig.java
+++ b/app/src/main/java/app/sabre/wzsabre/ChpConfig.java
@@ -38,6 +38,10 @@ public class ChpConfig {
     public boolean lcsEnabled;
     private static final String KEY_LCS_ENABLED = "lcs_enabled";
 
+    // ── Wildfires (WFIGS) ─────────────────────────────────────────────────────
+    public boolean fireEnabled;
+    private static final String KEY_FIRE_ENABLED = "fire_enabled";
+
     // ── Constructor (defaults) ───────────────────────────────────────────────
     private ChpConfig() {
         for (ChpCategory cat : ChpCategory.values()) {
@@ -46,6 +50,7 @@ public class ChpConfig {
         }
         maxAgeMinutes = 60;  // 1 hour default
         lcsEnabled = true;
+        fireEnabled = true;
     }
 
     // ── Accessors ─────────────────────────────────────────────────────────────
@@ -100,6 +105,7 @@ public class ChpConfig {
         }
         cfg.maxAgeMinutes = prefs.getInt(KEY_MAX_AGE, 60);
         cfg.lcsEnabled    = prefs.getBoolean(KEY_LCS_ENABLED, true);
+        cfg.fireEnabled   = prefs.getBoolean(KEY_FIRE_ENABLED, true);
         return cfg;
     }
 
@@ -116,6 +122,7 @@ public class ChpConfig {
         }
         ed.putInt(KEY_MAX_AGE, maxAgeMinutes);
         ed.putBoolean(KEY_LCS_ENABLED, lcsEnabled);
+        ed.putBoolean(KEY_FIRE_ENABLED, fireEnabled);
         ed.apply();
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/LcsSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/LcsSource.java
@@ -147,9 +147,14 @@ public class LcsSource {
                 List<Closure> parsed = fetchDistrict(district);
                 cache.put(district, new CacheEntry(parsed, System.currentTimeMillis()));
                 Log.d(TAG, "D" + district + " refreshed: " + parsed.size() + " closure records");
+                int total = 0;
+                for (CacheEntry ce : cache.values()) total += ce.closures.size();
+                SourceStatus.success(SabreResponseBuilder.SOURCE_LCS, total);
             } catch (Exception e) {
                 Log.w(TAG, "D" + district + " refresh failed: "
                         + e.getClass().getSimpleName() + ": " + e.getMessage());
+                SourceStatus.failure(SabreResponseBuilder.SOURCE_LCS,
+                        "D" + district + " " + e.getClass().getSimpleName());
             } finally {
                 flag.set(false);
             }

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -50,6 +50,7 @@ public class MainActivity extends Activity {
         updateServiceStatus();
         buildCategoryRows();
         buildLcsSwitch();
+        buildFireSwitch();
         buildAgeSpinner();
     }
 
@@ -58,6 +59,15 @@ public class MainActivity extends Activity {
         sw.setChecked(config.lcsEnabled);
         sw.setOnCheckedChangeListener((CompoundButton btn, boolean isChecked) -> {
             config.lcsEnabled = isChecked;
+            config.save(this);
+        });
+    }
+
+    private void buildFireSwitch() {
+        Switch sw = findViewById(R.id.fireSwitch);
+        sw.setChecked(config.fireEnabled);
+        sw.setOnCheckedChangeListener((CompoundButton btn, boolean isChecked) -> {
+            config.fireEnabled = isChecked;
             config.save(this);
         });
     }

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -52,6 +52,55 @@ public class MainActivity extends Activity {
         buildLcsSwitch();
         buildFireSwitch();
         buildAgeSpinner();
+        buildDiagnostics();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        // Sources refresh in the background after the service starts, so re-render the
+        // diagnostics each time the screen is shown to pick up fresh numbers.
+        buildDiagnostics();
+    }
+
+    // ── Diagnostics panel ─────────────────────────────────────────────────────
+
+    private void buildDiagnostics() {
+        LinearLayout container = findViewById(R.id.diagnosticsContainer);
+        container.removeAllViews();
+        String[][] sources = {
+                {SabreResponseBuilder.SOURCE_CHP,  "CHP incidents"},
+                {SabreResponseBuilder.SOURCE_WAZE, "Waze alerts"},
+                {SabreResponseBuilder.SOURCE_LCS,  "Caltrans closures"},
+                {SabreResponseBuilder.SOURCE_FIRE, "Wildfires"},
+        };
+        for (String[] s : sources) {
+            SourceStatus.Entry e = SourceStatus.get(s[0]);
+            TextView row = new TextView(this);
+            row.setTextSize(13f);
+            row.setPadding(0, 6, 0, 6);
+            row.setText(formatStatus(s[1], e));
+            row.setTextColor(e != null && e.lastError != null ? 0xFFD32F2F : 0xFF424242);
+            container.addView(row);
+        }
+    }
+
+    private static String formatStatus(String label, SourceStatus.Entry e) {
+        if (e == null || !e.ran) return label + ": not fetched yet";
+        StringBuilder sb = new StringBuilder(label).append(": ");
+        if (e.lastUpdateMs > 0) sb.append(e.count).append(" · ").append(ago(e.lastUpdateMs));
+        else sb.append("no data yet");
+        if (e.lastError != null) sb.append(" · error: ").append(e.lastError);
+        return sb.toString();
+    }
+
+    /** Human "N ago" for a wall-clock timestamp. */
+    private static String ago(long whenMs) {
+        long s = Math.max(0, (System.currentTimeMillis() - whenMs) / 1000L);
+        if (s < 10)   return "just now";
+        if (s < 60)   return s + "s ago";
+        if (s < 3600) return (s / 60) + "m ago";
+        return (s / 3600) + "h ago";
     }
 
     private void buildLcsSwitch() {

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -53,6 +53,32 @@ public class MainActivity extends Activity {
         buildFireSwitch();
         buildAgeSpinner();
         buildDiagnostics();
+        checkForUpdate();
+    }
+
+    // ── Update banner ─────────────────────────────────────────────────────────
+
+    private void checkForUpdate() {
+        new Thread(() -> {
+            UpdateChecker.Result r = UpdateChecker.fetchLatest();
+            boolean newer = r != null
+                    && UpdateChecker.isNewer(r.latestVersion, BuildConfig.VERSION_NAME);
+            runOnUiThread(() -> showUpdateCard(newer ? r : null));
+        }).start();
+    }
+
+    private void showUpdateCard(UpdateChecker.Result r) {
+        View card = findViewById(R.id.updateCard);
+        if (r == null) { card.setVisibility(View.GONE); return; }
+        ((TextView) findViewById(R.id.updateText))
+                .setText("Update available: v" + r.latestVersion + " (you have v"
+                        + BuildConfig.VERSION_NAME + ")");
+        findViewById(R.id.updateButton).setOnClickListener(v -> {
+            try {
+                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(r.htmlUrl)));
+            } catch (Exception ignored) {}
+        });
+        card.setVisibility(View.VISIBLE);
     }
 
     @Override

--- a/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
@@ -91,6 +91,7 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
         JSONObject s1 = new JSONObject(); s1.put("id", "chp");  s1.put("name", "CHP Live Feed");      sources.put(s1);
         JSONObject s2 = new JSONObject(); s2.put("id", "waze"); s2.put("name", "Waze");               sources.put(s2);
         JSONObject s3 = new JSONObject(); s3.put("id", "lcs");  s3.put("name", "Caltrans Closures");  sources.put(s3);
+        JSONObject s4 = new JSONObject(); s4.put("id", "fire"); s4.put("name", "Wildfires");          sources.put(s4);
         response.put("supported_sources", sources);
         response.put("request_action",  "app.sabre.wzsabre.FETCH_REQUEST");
         response.put("report_action",   "app.sabre.wzsabre.SUBMIT_REPORT");

--- a/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
@@ -26,6 +26,7 @@ public class SabreResponseBuilder {
     public static final String SOURCE_CHP  = "chp";
     public static final String SOURCE_WAZE = "waze";
     public static final String SOURCE_LCS  = "lcs";
+    public static final String SOURCE_FIRE = "fire";
 
     /**
      * Highway Radar's package. Every reply broadcast is explicitly targeted at it

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -262,8 +262,12 @@ public class SabreService extends Service {
                     allAlerts.addAll(buildTestAlerts(testLat, testLon));
                 }
 
-                Log.d(TAG, "Sending " + allAlerts.size() + " total alerts");
-                sendFetchResponse(responseAction, requestId, allAlerts);
+                // Collapse duplicate pins across sources (e.g. CHP + Waze accident at
+                // the same spot) before sending.
+                int rawCount = allAlerts.size();
+                List<SabreAlert> finalAlerts = AlertDeduper.dedupe(allAlerts);
+                Log.d(TAG, "Sending " + finalAlerts.size() + " alerts (" + rawCount + " before dedupe)");
+                sendFetchResponse(responseAction, requestId, finalAlerts);
             } catch (Exception e) {
                 Log.e(TAG, "Error handling fetch request", e);
                 if (requestId != null && responseAction != null) {

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -54,6 +54,7 @@ public class SabreService extends Service {
     private ExecutorService fetchExecutor;
     private CHPSource chpSource;
     private LcsSource lcsSource;
+    private WildfireSource fireSource;
     private app.sabre.wzsabre.waze.WazeProtocolSource wazeSource;
 
     // Last fetch location, persisted so the Waze session can be pre-warmed at the
@@ -68,13 +69,15 @@ public class SabreService extends Service {
         super.onCreate();
         RUNNING = true;
         requestExecutor = Executors.newSingleThreadExecutor();
-        fetchExecutor   = Executors.newFixedThreadPool(3);
+        fetchExecutor   = Executors.newFixedThreadPool(4);
         chpSource  = new CHPSource();
         lcsSource  = new LcsSource();
+        fireSource = new WildfireSource();
         wazeSource = new app.sabre.wzsabre.waze.WazeProtocolSource(this);
         createNotificationChannel();
         startForeground(NOTIFICATION_ID, buildForegroundNotification());
         chpSource.prewarm();          // statewide feed — no location needed
+        fireSource.prewarm();         // statewide feed — no location needed
         prewarmFromLastLocation();    // Waze — needs last known location
         armIdleStop();                // stop if no HR activity arrives
         Log.d(TAG, "Service started");
@@ -161,6 +164,7 @@ public class SabreService extends Service {
         if (wazeSource != null) wazeSource.shutdown();
         if (lcsSource  != null) lcsSource.shutdown();
         if (chpSource  != null) chpSource.shutdown();
+        if (fireSource != null) fireSource.shutdown();
         super.onDestroy();
     }
 
@@ -195,6 +199,9 @@ public class SabreService extends Service {
                 Future<List<SabreAlert>> wazeFuture = fetchExecutor.submit(() -> wazeSource.fetchAlerts(lat, lon, radius));
                 Future<List<SabreAlert>> lcsFuture  = chpConfig.lcsEnabled
                         ? fetchExecutor.submit(() -> lcsSource.fetchAlerts(lat, lon, radius))
+                        : null;
+                Future<List<SabreAlert>> fireFuture = chpConfig.fireEnabled
+                        ? fetchExecutor.submit(() -> fireSource.fetchAlerts(lat, lon, radius))
                         : null;
 
                 List<SabreAlert> allAlerts = new ArrayList<>();
@@ -236,6 +243,18 @@ public class SabreService extends Service {
                     } catch (Exception e) {
                         Log.w(TAG, "LCS unavailable this cycle: " + e.getClass().getSimpleName());
                         lcsFuture.cancel(true);
+                    }
+                }
+
+                // Wildfires serve from cache and never block; 1s is generous
+                if (fireFuture != null) {
+                    try {
+                        List<SabreAlert> fireAlerts = fireFuture.get(1, TimeUnit.SECONDS);
+                        allAlerts.addAll(fireAlerts);
+                        Log.d(TAG, "Wildfire: " + fireAlerts.size() + " alerts");
+                    } catch (Exception e) {
+                        Log.w(TAG, "Wildfire unavailable this cycle: " + e.getClass().getSimpleName());
+                        fireFuture.cancel(true);
                     }
                 }
 

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -3,6 +3,7 @@ package app.sabre.wzsabre;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Intent;
 import android.os.Build;
@@ -25,6 +26,12 @@ public class SabreService extends Service {
     private static final String TAG = "SABREService";
     private static final String CHANNEL_ID = "SabreServiceChannel";
     private static final int NOTIFICATION_ID = 1;
+
+    // Update-check (sideloaded app, no Play auto-update): at most once/day, and a
+    // notification at most once per new version — deliberately not spammy.
+    private static final String UPDATE_CHANNEL_ID = "SabreUpdateChannel";
+    private static final int    UPDATE_NOTIFICATION_ID = 2;
+    private static final long   UPDATE_CHECK_INTERVAL_MS = 24 * 3600_000L;
 
     /** Live while the service exists — lets MainBroadcastReceiver decide whether a
      *  SHUTDOWN needs forwarding (no point starting the service just to stop it). */
@@ -79,6 +86,7 @@ public class SabreService extends Service {
         chpSource.prewarm();          // statewide feed — no location needed
         fireSource.prewarm();         // statewide feed — no location needed
         prewarmFromLastLocation();    // Waze — needs last known location
+        maybeCheckForUpdate();        // throttled; notifies once per new version
         armIdleStop();                // stop if no HR activity arrives
         Log.d(TAG, "Service started");
     }
@@ -110,6 +118,47 @@ public class SabreService extends Service {
                 .putLong("last_lon", Double.doubleToRawLongBits(lon))
                 .putLong("last_radius", Double.doubleToRawLongBits(radius))
                 .apply();
+    }
+
+    /** At most once per day, check GitHub for a newer release and, if there is one we
+     *  haven't already flagged, post a single low-importance notification. */
+    private void maybeCheckForUpdate() {
+        android.content.SharedPreferences p = getSharedPreferences(STATE_PREFS, MODE_PRIVATE);
+        if (System.currentTimeMillis() - p.getLong("update_check_ms", 0) < UPDATE_CHECK_INTERVAL_MS) return;
+        new Thread(() -> {
+            UpdateChecker.Result r = UpdateChecker.fetchLatest();
+            android.content.SharedPreferences pp = getSharedPreferences(STATE_PREFS, MODE_PRIVATE);
+            pp.edit().putLong("update_check_ms", System.currentTimeMillis()).apply();
+            if (r == null) return;
+            if (!UpdateChecker.isNewer(r.latestVersion, BuildConfig.VERSION_NAME)) return;
+            if (r.latestVersion.equals(pp.getString("update_notified_version", null))) return;
+            postUpdateNotification(r);
+            pp.edit().putString("update_notified_version", r.latestVersion).apply();
+        }).start();
+    }
+
+    private void postUpdateNotification(UpdateChecker.Result r) {
+        NotificationManager nm = getSystemService(NotificationManager.class);
+        if (nm == null) return;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel ch = new NotificationChannel(UPDATE_CHANNEL_ID,
+                    "Plugin updates", NotificationManager.IMPORTANCE_LOW);
+            ch.setSound(null, null);
+            ch.enableVibration(false);
+            nm.createNotificationChannel(ch);
+        }
+        PendingIntent pi = PendingIntent.getActivity(this, 0,
+                new Intent(Intent.ACTION_VIEW, android.net.Uri.parse(r.htmlUrl)),
+                PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
+        Notification.Builder b = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                ? new Notification.Builder(this, UPDATE_CHANNEL_ID)
+                : new Notification.Builder(this);
+        b.setSmallIcon(android.R.drawable.stat_sys_download_done)
+         .setContentTitle("CHP + Waze SABRE update available")
+         .setContentText("Version " + r.latestVersion + " — tap to download")
+         .setAutoCancel(true)
+         .setContentIntent(pi);
+        nm.notify(UPDATE_NOTIFICATION_ID, b.build());
     }
 
     @Override

--- a/app/src/main/java/app/sabre/wzsabre/SourceStatus.java
+++ b/app/src/main/java/app/sabre/wzsabre/SourceStatus.java
@@ -1,0 +1,48 @@
+package app.sabre.wzsabre;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Process-wide, in-memory health record for each data source, so the settings
+ * screen can show a diagnostics panel (last update, item count, last error) even
+ * though the sources live inside {@link SabreService}. Both run in the same
+ * process, so plain statics are sufficient; state is lost on process death, which
+ * is fine — it reflects the current session.
+ */
+public final class SourceStatus {
+    private SourceStatus() {}
+
+    public static final class Entry {
+        public volatile boolean ran;          // attempted at least one refresh
+        public volatile long    lastUpdateMs; // wall-clock of last SUCCESSFUL refresh
+        public volatile int     count;        // items the source currently holds
+        public volatile String  lastError;    // non-null if the most recent refresh failed
+    }
+
+    private static final ConcurrentHashMap<String, Entry> MAP = new ConcurrentHashMap<>();
+
+    private static Entry entry(String source) {
+        return MAP.computeIfAbsent(source, k -> new Entry());
+    }
+
+    /** Record a successful refresh holding {@code count} items. */
+    public static void success(String source, int count) {
+        Entry e = entry(source);
+        e.ran = true;
+        e.count = count;
+        e.lastUpdateMs = System.currentTimeMillis();
+        e.lastError = null;
+    }
+
+    /** Record a failed refresh (keeps the previous count / lastUpdateMs). */
+    public static void failure(String source, String error) {
+        Entry e = entry(source);
+        e.ran = true;
+        e.lastError = error;
+    }
+
+    /** @return the entry for a source, or null if it has never run. */
+    public static Entry get(String source) {
+        return MAP.get(source);
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/UpdateChecker.java
+++ b/app/src/main/java/app/sabre/wzsabre/UpdateChecker.java
@@ -1,0 +1,94 @@
+package app.sabre.wzsabre;
+
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+
+import javax.net.ssl.HttpsURLConnection;
+
+/**
+ * Checks GitHub Releases for a newer version. Since the app is sideloaded (no Play
+ * Store auto-update), this powers both the in-app "update available" card and a
+ * once-per-version notification. No auth needed — the public releases endpoint is
+ * used within GitHub's unauthenticated rate limit.
+ */
+public final class UpdateChecker {
+    private UpdateChecker() {}
+
+    static final String RELEASES_API =
+            "https://api.github.com/repos/nicglazkov/caltrans-sabre/releases/latest";
+    public static final String RELEASES_PAGE =
+            "https://github.com/nicglazkov/caltrans-sabre/releases/latest";
+
+    public static final class Result {
+        public final String latestVersion;   // normalized, e.g. "1.6"
+        public final String htmlUrl;
+        Result(String latestVersion, String htmlUrl) {
+            this.latestVersion = latestVersion;
+            this.htmlUrl = htmlUrl;
+        }
+    }
+
+    /** Blocking network call — returns null on any failure. Must run off the main thread. */
+    public static Result fetchLatest() {
+        HttpsURLConnection conn = null;
+        try {
+            conn = (HttpsURLConnection) new URL(RELEASES_API).openConnection();
+            conn.setConnectTimeout(6000);
+            conn.setReadTimeout(6000);
+            conn.setRequestProperty("Accept", "application/vnd.github+json");
+            conn.setRequestProperty("User-Agent", "caltrans-sabre-app");
+            if (conn.getResponseCode() != 200) return null;
+            StringBuilder sb = new StringBuilder();
+            try (BufferedReader r = new BufferedReader(
+                    new InputStreamReader(conn.getInputStream(), "UTF-8"))) {
+                char[] buf = new char[2048];
+                int n;
+                while ((n = r.read(buf)) != -1) sb.append(buf, 0, n);
+            }
+            JSONObject o = new JSONObject(sb.toString());
+            String tag = o.optString("tag_name", "");
+            if (tag.isEmpty()) return null;
+            String htmlUrl = o.optString("html_url", RELEASES_PAGE);
+            return new Result(stripV(tag), htmlUrl);
+        } catch (Exception e) {
+            return null;
+        } finally {
+            if (conn != null) conn.disconnect();
+        }
+    }
+
+    static String stripV(String t) {
+        if (t == null) return null;
+        return (t.startsWith("v") || t.startsWith("V")) ? t.substring(1) : t;
+    }
+
+    /** True if {@code latest} is a strictly higher version than {@code current} (numeric, dot-separated). */
+    public static boolean isNewer(String latest, String current) {
+        if (latest == null) return false;
+        int[] a = parse(latest), b = parse(current);
+        int n = Math.max(a.length, b.length);
+        for (int i = 0; i < n; i++) {
+            int x = i < a.length ? a[i] : 0;
+            int y = i < b.length ? b[i] : 0;
+            if (x != y) return x > y;
+        }
+        return false;
+    }
+
+    private static int[] parse(String v) {
+        if (v == null) return new int[0];
+        String[] parts = stripV(v).split("\\.");
+        int[] out = new int[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            try {
+                out[i] = Integer.parseInt(parts[i].replaceAll("[^0-9].*$", ""));
+            } catch (Exception e) {
+                out[i] = 0;
+            }
+        }
+        return out;
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
@@ -1,0 +1,193 @@
+package app.sabre.wzsabre;
+
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.net.ssl.HttpsURLConnection;
+
+/**
+ * Active California wildfires, from the interagency WFIGS "Current Wildland Fire
+ * Incident Locations" ArcGIS feature service (hosted by NIFC). Each fire is a point
+ * (point of origin) with name, size, and containment — shown as a road hazard so a
+ * driver gets a heads-up that there's an active fire near the route.
+ *
+ * <p>Like the CHP and LCS sources, this is served from a background-refreshed cache
+ * and never fetched on the Highway Radar request path. The CAL FIRE incidents feed
+ * is Akamai-blocked to non-browser clients, so WFIGS is used instead — it is the
+ * authoritative interagency source and is openly queryable.
+ *
+ * <p>NOTE: a fire's point is its origin, not a precise road hazard; a large fire may
+ * affect roads miles away. The pin is an awareness cue, like the LCS closure pins.
+ */
+public class WildfireSource {
+    private static final String TAG = "WildfireSource";
+
+    // WFIGS_Incident_Locations_Current, layer 0. where: California + wildfire type +
+    // active. outSR=4326 so geometry comes back as WGS84 lon/lat.
+    private static final String QUERY_URL =
+            "https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/"
+            + "WFIGS_Incident_Locations_Current/FeatureServer/0/query"
+            + "?where=" + "POOState%3D%27US-CA%27%20AND%20IncidentTypeCategory%3D%27WF%27"
+            + "%20AND%20ActiveFireCandidate%3D1"
+            + "&outFields=IncidentName%2CIncidentSize%2CPercentContained%2C"
+            + "FireDiscoveryDateTime%2CUniqueFireIdentifier"
+            + "&returnGeometry=true&outSR=4326&f=json";
+
+    private static final long CACHE_TTL_MS       = 5 * 60_000L;   // fires update slowly
+    private static final long CACHE_MAX_SERVE_MS = 60 * 60_000L;  // never serve staler than this
+    private static final int  CONNECT_TIMEOUT_MS = 8_000;
+    private static final int  READ_TIMEOUT_MS    = 8_000;
+
+    // ── Parsed fire record (pre-radius) ───────────────────────────────────────
+
+    static final class Fire {
+        final String id, name;
+        final double lat, lon;
+        final double sizeAcres;      // <0 if unknown
+        final double pctContained;   // <0 if unknown
+        final long   reportTs;       // unix seconds
+        Fire(String id, String name, double lat, double lon,
+             double sizeAcres, double pctContained, long reportTs) {
+            this.id = id; this.name = name; this.lat = lat; this.lon = lon;
+            this.sizeAcres = sizeAcres; this.pctContained = pctContained; this.reportTs = reportTs;
+        }
+    }
+
+    private final ExecutorService refreshExec = Executors.newSingleThreadExecutor();
+    private final AtomicBoolean refreshing = new AtomicBoolean(false);
+    private volatile List<Fire> cache = null;
+    private volatile long cacheTimeMs = 0L;
+
+    /** Active wildfires within the radius, served from the cache. Never blocks. */
+    public List<SabreAlert> fetchAlerts(double lat, double lon, double radiusMeters) {
+        triggerRefreshIfStale();
+        List<Fire> snap = cache;
+        if (snap == null || (System.currentTimeMillis() - cacheTimeMs) > CACHE_MAX_SERVE_MS) {
+            return new ArrayList<>();
+        }
+        List<SabreAlert> out = new ArrayList<>();
+        for (Fire f : snap) {
+            if (CHPSource.haversineMeters(lat, lon, f.lat, f.lon) > radiusMeters) continue;
+            out.add(toAlert(f));
+        }
+        return out;
+    }
+
+    /** Warm the cache at service start. */
+    public void prewarm() { triggerRefreshIfStale(); }
+
+    /** Release the background refresh thread when the owning service is destroyed. */
+    public void shutdown() { refreshExec.shutdownNow(); }
+
+    private void triggerRefreshIfStale() {
+        boolean stale = cache == null || (System.currentTimeMillis() - cacheTimeMs) > CACHE_TTL_MS;
+        if (stale && refreshing.compareAndSet(false, true)) {
+            refreshExec.submit(() -> {
+                try {
+                    List<Fire> parsed = fetchAndParse();
+                    cache = parsed;
+                    cacheTimeMs = System.currentTimeMillis();
+                    Log.d(TAG, "Wildfires refreshed: " + parsed.size() + " active in CA");
+                } catch (Exception e) {
+                    // Keep serving the last good parse on a transient failure.
+                    Log.w(TAG, "Wildfire refresh failed (serving cache): "
+                            + e.getClass().getSimpleName() + ": " + e.getMessage());
+                } finally {
+                    refreshing.set(false);
+                }
+            });
+        }
+    }
+
+    private List<Fire> fetchAndParse() throws Exception {
+        URL url = new URL(QUERY_URL);
+        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+        conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        conn.setReadTimeout(READ_TIMEOUT_MS);
+        conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Linux; Android 14)");
+        conn.setRequestProperty("Accept", "application/json");
+        try {
+            StringBuilder sb = new StringBuilder();
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(conn.getInputStream(), "UTF-8"))) {
+                char[] buf = new char[4096];
+                int n;
+                while ((n = reader.read(buf)) != -1) sb.append(buf, 0, n);
+            }
+            return parse(sb.toString());
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    /** Parse the ArcGIS query JSON into fire records (skips features missing geometry). */
+    static List<Fire> parse(String json) throws Exception {
+        List<Fire> out = new ArrayList<>();
+        JSONObject root = new JSONObject(json);
+        JSONArray features = root.optJSONArray("features");
+        if (features == null) return out;
+        long nowSec = System.currentTimeMillis() / 1000L;
+        for (int i = 0; i < features.length(); i++) {
+            JSONObject feat = features.optJSONObject(i);
+            if (feat == null) continue;
+            JSONObject geom = feat.optJSONObject("geometry");
+            JSONObject attr = feat.optJSONObject("attributes");
+            if (geom == null || attr == null) continue;
+            // ArcGIS omits geometry keys when absent; require both.
+            if (!geom.has("x") || !geom.has("y")) continue;
+            double lon = geom.optDouble("x", Double.NaN);
+            double lat = geom.optDouble("y", Double.NaN);
+            if (Double.isNaN(lat) || Double.isNaN(lon)) continue;
+            if (lat == 0.0 && lon == 0.0) continue;
+
+            String id = attr.optString("UniqueFireIdentifier", null);
+            if (id == null || id.isEmpty()) id = "of" + attr.optString("OBJECTID", String.valueOf(i));
+            String name = attr.optString("IncidentName", "").trim();
+
+            double size = attr.isNull("IncidentSize") ? -1 : attr.optDouble("IncidentSize", -1);
+            double pct  = attr.isNull("PercentContained") ? -1 : attr.optDouble("PercentContained", -1);
+            long discMs = attr.isNull("FireDiscoveryDateTime") ? 0L
+                    : attr.optLong("FireDiscoveryDateTime", 0L);
+            long reportTs = discMs > 0 ? discMs / 1000L : nowSec;
+
+            out.add(new Fire(id, name, lat, lon, size, pct, reportTs));
+        }
+        return out;
+    }
+
+    static SabreAlert toAlert(Fire f) {
+        return new SabreAlert(
+                "fire_" + f.id,
+                SabreResponseBuilder.SOURCE_FIRE,
+                "HAZARD_ON_ROAD",              // HR has no fire type; generic on-road hazard
+                f.lat, f.lon,
+                SabreResponseBuilder.HEADING_UNKNOWN,
+                describe(f), f.reportTs);
+    }
+
+    static String describe(Fire f) {
+        StringBuilder sb = new StringBuilder("Wildfire");
+        if (!f.name.isEmpty()) sb.append(": ").append(f.name);
+        if (f.sizeAcres >= 0) sb.append(" · ").append(formatAcres(f.sizeAcres)).append(" ac");
+        if (f.pctContained >= 0) sb.append(" · ").append((int) Math.round(f.pctContained)).append("% contained");
+        return sb.toString();
+    }
+
+    private static String formatAcres(double acres) {
+        if (acres >= 1000) return String.format(Locale.US, "%,d", Math.round(acres));
+        if (acres == Math.floor(acres)) return String.valueOf((long) acres);
+        return String.format(Locale.US, "%.1f", acres);
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
@@ -100,10 +100,12 @@ public class WildfireSource {
                     cache = parsed;
                     cacheTimeMs = System.currentTimeMillis();
                     Log.d(TAG, "Wildfires refreshed: " + parsed.size() + " active in CA");
+                    SourceStatus.success(SabreResponseBuilder.SOURCE_FIRE, parsed.size());
                 } catch (Exception e) {
                     // Keep serving the last good parse on a transient failure.
                     Log.w(TAG, "Wildfire refresh failed (serving cache): "
                             + e.getClass().getSimpleName() + ": " + e.getMessage());
+                    SourceStatus.failure(SabreResponseBuilder.SOURCE_FIRE, e.getClass().getSimpleName());
                 } finally {
                     refreshing.set(false);
                 }

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import app.sabre.wzsabre.SabreAlert;
 import app.sabre.wzsabre.SabreResponseBuilder;
+import app.sabre.wzsabre.SourceStatus;
 
 /**
  * Waze data source backed by the Waze mobile "RT" protocol (replaces the georss
@@ -150,6 +151,7 @@ public final class WazeProtocolSource {
                     cacheLon = lon;
                 } catch (Exception e) {
                     Log.w(TAG, "Waze refresh failed: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+                    SourceStatus.failure(SabreResponseBuilder.SOURCE_WAZE, e.getClass().getSimpleName());
                     // Don't retry a failure at poll cadence. A rejection already set a
                     // longer backoff in handleAccountRejected; only add the short generic
                     // one if we aren't already backing off, so we never shorten it.
@@ -176,6 +178,7 @@ public final class WazeProtocolSource {
         // Reached only on a fully successful refresh — clear any rejection backoff.
         consecutiveRejections = 0;
         backoffUntilMs = 0L;
+        SourceStatus.success(SabreResponseBuilder.SOURCE_WAZE, alertCache.size());
         Log.d(TAG, "Waze cache: " + alertCache.size() + " alerts near "
                 + String.format(Locale.US, "%.4f,%.4f", lat, lon));
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -108,6 +108,56 @@
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
+        <!-- ── Wildfires ──────────────────────────────────────────────────── -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="WILDFIRES"
+            android:textSize="11sp"
+            android:textStyle="bold"
+            android:textColor="#757575"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="20dp"
+            android:paddingBottom="6dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:background="#FFFFFF"
+            android:elevation="1dp"
+            android:padding="16dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Active wildfires"
+                    android:textSize="14sp"
+                    android:textColor="#212121" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Active California wildfires (interagency WFIGS feed), shown as road hazards near the fire's location."
+                    android:textSize="12sp"
+                    android:textColor="#757575"
+                    android:layout_marginTop="2dp" />
+            </LinearLayout>
+
+            <Switch
+                android:id="@+id/fireSwitch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
         <!-- ── Incident Age ───────────────────────────────────────────────── -->
         <TextView
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -36,6 +36,34 @@
                 android:layout_marginTop="4dp" />
         </LinearLayout>
 
+        <!-- ── Update banner (shown only when a newer release exists) ──────── -->
+        <LinearLayout
+            android:id="@+id/updateCard"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:background="#FFF8E1"
+            android:elevation="1dp"
+            android:padding="16dp"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/updateText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Update available"
+                android:textSize="14sp"
+                android:textColor="#5D4037" />
+
+            <Button
+                android:id="@+id/updateButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Download" />
+        </LinearLayout>
+
         <!-- ── CHP Alert Categories ───────────────────────────────────────── -->
         <TextView
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -201,6 +201,28 @@
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
+        <!-- ── Diagnostics ────────────────────────────────────────────────── -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="DIAGNOSTICS"
+            android:textSize="11sp"
+            android:textStyle="bold"
+            android:textColor="#757575"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="20dp"
+            android:paddingBottom="6dp" />
+
+        <LinearLayout
+            android:id="@+id/diagnosticsContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:background="#FFFFFF"
+            android:elevation="1dp"
+            android:padding="16dp" />
+
         <!-- ── About ─────────────────────────────────────────────────────── -->
         <TextView
             android:layout_width="match_parent"

--- a/app/src/test/java/app/sabre/wzsabre/AlertDeduperTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/AlertDeduperTest.java
@@ -1,0 +1,67 @@
+package app.sabre.wzsabre;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/** Tests cross-source pin de-duplication. */
+public class AlertDeduperTest {
+
+    private static SabreAlert a(String id, String source, String type,
+                               double lat, double lon, int confirmCount) {
+        return new SabreAlert(id, source, type, lat, lon,
+                SabreResponseBuilder.HEADING_UNKNOWN, "St", 1_700_000_000L, null, confirmCount);
+    }
+
+    private static final double LAT = 38.4015, LON = -121.8000;
+
+    @Test
+    public void mergesCoLocatedSameFamilyAcrossSources() {
+        // CHP + Waze accident at essentially the same spot → one pin, CHP kept.
+        List<SabreAlert> in = Arrays.asList(
+                a("waze_alert-1/u", SabreResponseBuilder.SOURCE_WAZE, "ACCIDENT", LAT, LON, 5),
+                a("chp_1", SabreResponseBuilder.SOURCE_CHP, "ACCIDENT_MAJOR", LAT + 0.0001, LON, 0));
+        List<SabreAlert> out = AlertDeduper.dedupe(in);
+        assertEquals(1, out.size());
+        assertEquals("CHP kept over Waze", SabreResponseBuilder.SOURCE_CHP, out.get(0).alertSource);
+        assertEquals("Waze crowd-confirmations folded in", 5, out.get(0).confirmCount);
+    }
+
+    @Test
+    public void keepsDistinctFamiliesAtSameSpot() {
+        // A police report and an accident at the same corner are different events.
+        List<SabreAlert> in = Arrays.asList(
+                a("waze_alert-1/u", SabreResponseBuilder.SOURCE_WAZE, "POLICE_VISIBLE", LAT, LON, 0),
+                a("chp_1", SabreResponseBuilder.SOURCE_CHP, "ACCIDENT_MAJOR", LAT, LON, 0));
+        assertEquals(2, AlertDeduper.dedupe(in).size());
+    }
+
+    @Test
+    public void keepsSameFamilyFarApart() {
+        List<SabreAlert> in = Arrays.asList(
+                a("chp_1", SabreResponseBuilder.SOURCE_CHP, "ACCIDENT_MAJOR", LAT, LON, 0),
+                a("chp_2", SabreResponseBuilder.SOURCE_CHP, "ACCIDENT_MAJOR", LAT + 0.02, LON, 0));
+        assertEquals(2, AlertDeduper.dedupe(in).size());
+    }
+
+    @Test
+    public void wildfireNotMergedWithGenericHazard() {
+        // Fire and a debris hazard share the HAZARD_ON_ROAD type string but must not merge.
+        List<SabreAlert> in = Arrays.asList(
+                a("fire_x", SabreResponseBuilder.SOURCE_FIRE, "HAZARD_ON_ROAD", LAT, LON, 0),
+                a("chp_1", SabreResponseBuilder.SOURCE_CHP, "HAZARD_ON_ROAD_DEBRIS", LAT, LON, 0));
+        assertEquals(2, AlertDeduper.dedupe(in).size());
+    }
+
+    @Test
+    public void handlesEmptyAndSingle() {
+        assertEquals(0, AlertDeduper.dedupe(new ArrayList<>()).size());
+        assertEquals(0, AlertDeduper.dedupe(null).size());
+        assertEquals(1, AlertDeduper.dedupe(Arrays.asList(
+                a("chp_1", SabreResponseBuilder.SOURCE_CHP, "ACCIDENT_MAJOR", LAT, LON, 0))).size());
+    }
+}

--- a/app/src/test/java/app/sabre/wzsabre/UpdateCheckerTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/UpdateCheckerTest.java
@@ -1,0 +1,35 @@
+package app.sabre.wzsabre;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/** Tests the version-comparison logic behind the update check. */
+public class UpdateCheckerTest {
+
+    @Test public void stripsLeadingV() {
+        assertEquals("1.6", UpdateChecker.stripV("v1.6"));
+        assertEquals("1.6", UpdateChecker.stripV("1.6"));
+    }
+
+    @Test public void newerMajorMinorPatch() {
+        assertTrue(UpdateChecker.isNewer("1.6", "1.5.1"));
+        assertTrue(UpdateChecker.isNewer("1.5.2", "1.5.1"));
+        assertTrue(UpdateChecker.isNewer("2.0", "1.9.9"));
+        assertTrue(UpdateChecker.isNewer("v1.6", "1.5"));   // handles a raw tag
+    }
+
+    @Test public void notNewerWhenEqualOrOlder() {
+        assertFalse(UpdateChecker.isNewer("1.5.1", "1.5.1"));
+        assertFalse(UpdateChecker.isNewer("1.5", "1.5.1"));
+        assertFalse(UpdateChecker.isNewer("1.4", "1.5"));
+        assertFalse(UpdateChecker.isNewer(null, "1.5"));
+    }
+
+    @Test public void toleratesSuffixes() {
+        assertTrue(UpdateChecker.isNewer("1.6-beta", "1.5"));
+        assertFalse(UpdateChecker.isNewer("1.5-rc1", "1.5"));
+    }
+}

--- a/app/src/test/java/app/sabre/wzsabre/WildfireSourceTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/WildfireSourceTest.java
@@ -1,0 +1,79 @@
+package app.sabre.wzsabre;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.List;
+
+/** Tests parsing of the WFIGS ArcGIS incident-locations response and SABRE mapping. */
+public class WildfireSourceTest {
+
+    // Shape mirrors the real WFIGS_Incident_Locations_Current query (f=json, outSR=4326):
+    // two valid fires plus one feature missing geometry (must be skipped).
+    private static final String JSON =
+        "{\"geometryType\":\"esriGeometryPoint\",\"spatialReference\":{\"wkid\":4326}," +
+        "\"features\":[" +
+        "{\"attributes\":{\"IncidentName\":\"PARK FIRE\",\"IncidentSize\":1200.0," +
+        "\"PercentContained\":40,\"FireDiscoveryDateTime\":1782000000000," +
+        "\"UniqueFireIdentifier\":\"2026-CABTU-001234\"},\"geometry\":{\"x\":-121.5,\"y\":39.8}}," +
+        "{\"attributes\":{\"IncidentName\":\"RIDGE FIRE\",\"IncidentSize\":null," +
+        "\"PercentContained\":null,\"FireDiscoveryDateTime\":null," +
+        "\"UniqueFireIdentifier\":\"2026-CAXXX-000001\"},\"geometry\":{\"x\":-120.0,\"y\":38.0}}," +
+        "{\"attributes\":{\"IncidentName\":\"NO GEOM\",\"UniqueFireIdentifier\":\"2026-CAYYY-000002\"}}" +
+        "]}";
+
+    @Test
+    public void parse_readsFieldsAndSkipsMissingGeometry() throws Exception {
+        List<WildfireSource.Fire> fires = WildfireSource.parse(JSON);
+        assertEquals("feature without geometry is skipped", 2, fires.size());
+
+        WildfireSource.Fire a = fires.get(0);
+        assertEquals("2026-CABTU-001234", a.id);
+        assertEquals("PARK FIRE", a.name);
+        assertEquals(39.8, a.lat, 1e-6);
+        assertEquals(-121.5, a.lon, 1e-6);
+        assertEquals(1200.0, a.sizeAcres, 1e-6);
+        assertEquals(40.0, a.pctContained, 1e-6);
+        assertEquals(1782000000L, a.reportTs);   // ms -> s
+    }
+
+    @Test
+    public void parse_nullFieldsFallBack() throws Exception {
+        WildfireSource.Fire b = WildfireSource.parse(JSON).get(1);
+        assertEquals(-1.0, b.sizeAcres, 0.0);       // unknown size
+        assertEquals(-1.0, b.pctContained, 0.0);    // unknown containment
+        long nowSec = System.currentTimeMillis() / 1000L;
+        assertTrue("missing discovery time falls back to now",
+                b.reportTs > nowSec - 60 && b.reportTs <= nowSec + 1);
+    }
+
+    @Test
+    public void parse_emptyOrMissingFeatures() throws Exception {
+        assertEquals(0, WildfireSource.parse("{\"features\":[]}").size());
+        assertEquals(0, WildfireSource.parse("{}").size());
+    }
+
+    @Test
+    public void toAlert_producesValidSabreAlert() throws Exception {
+        WildfireSource.Fire a = WildfireSource.parse(JSON).get(0);
+        SabreAlert alert = WildfireSource.toAlert(a);
+        assertEquals("fire_2026-CABTU-001234", alert.alertId);
+        assertEquals(SabreResponseBuilder.SOURCE_FIRE, alert.alertSource);
+        assertEquals("HAZARD_ON_ROAD", alert.type);
+        assertTrue("type must be one HR accepts", SabreResponseBuilder.isValidType(alert.type));
+        assertEquals(39.8, alert.lat, 1e-6);
+        assertEquals("fires are directionless → -720 heading sentinel",
+                SabreResponseBuilder.HEADING_UNKNOWN, alert.headingDeg, 0.0);
+    }
+
+    @Test
+    public void describe_formatsSizeAndContainment() throws Exception {
+        List<WildfireSource.Fire> fires = WildfireSource.parse(JSON);
+        assertEquals("Wildfire: PARK FIRE · 1,200 ac · 40% contained",
+                WildfireSource.describe(fires.get(0)));
+        // Unknown size/containment → name only
+        assertEquals("Wildfire: RIDGE FIRE", WildfireSource.describe(fires.get(1)));
+    }
+}


### PR DESCRIPTION
A feature release plus maintainer tooling.

## New
- **Wildfire source** — active California wildfires from the interagency WFIGS "Current Wildland Fire Incident Locations" ArcGIS service (NIFC-hosted), filtered to active CA wildfires, shown as road hazards with name/size/containment. Own settings toggle (default on), async-cached like CHP/LCS. (The CAL FIRE feed is Akamai-blocked to non-browser clients, so WFIGS is used.)
- **Update checking** — settings-screen "update available" banner + one low-importance notification per new version (throttled once/day, deduped by version, only while HR is running). README documents an Obtainium option for true auto-update.
- **Diagnostics panel** — per-source last-update time, item count, and last error on the settings screen.
- **Cross-source dedupe** — a CHP and a Waze accident at the same spot now collapse to one pin (family + ~100m grid; keeps the higher-priority source, folds crowd-confirmations; fires never merge with generic hazards).

## Maintainer / infra
- **Automated releases** — `release.yml`: push a `v*` tag → signed APK built from repo secrets → GitHub release published. Documented in BUILDING.md.
- CI actions bumped to current majors (clears the Node 20 deprecation).

## Notes
- 209 unit tests (new: WildfireSource, AlertDeduper, UpdateChecker), `lintDebug` clean, release APK builds signed.
- New `fire` source declared in the discovery handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)