### PR TITLE
v1.6.1 — post-v1.6 hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,16 @@ jobs:
       - id: check
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
-          if [ -n "$KEYSTORE_BASE64" ]; then
+          if [ -n "$KEYSTORE_BASE64" ] && [ -n "$KEYSTORE_PASSWORD" ] \
+             && [ -n "$KEY_ALIAS" ] && [ -n "$KEY_PASSWORD" ]; then
             echo "signable=true" >> "$GITHUB_OUTPUT"
           else
             echo "signable=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::No KEYSTORE_BASE64 secret set — skipping automated release. Release manually or add signing secrets (see BUILDING.md)."
+            echo "::warning::Signing secrets missing/incomplete — skipping automated release. Release manually or add all four secrets (see BUILDING.md)."
           fi
 
   release:
@@ -80,10 +84,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" \
-            "CHP-Waze-SABRE-${GITHUB_REF_NAME}.apk" \
-            --title "${GITHUB_REF_NAME}" \
-            --generate-notes
+          APK="CHP-Waze-SABRE-${GITHUB_REF_NAME}.apk"
+          # Idempotent: if a release for this tag already exists (re-run or re-pushed
+          # tag), attach/replace the APK instead of failing on "already exists".
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" "$APK" --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" "$APK" \
+              --title "${GITHUB_REF_NAME}" --generate-notes
+          fi
 
       - name: Clean up secrets
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.6.1] — 2026-07-02
+
+Hardening from a post-release review of v1.6.
+
+### Fixed
+- Wildfire outages no longer look like "no active fires" — a broken feed now surfaces as an error in diagnostics, and prescribed burns can't slip in as wildfires.
+- Duplicate-pin merging now only collapses pins from *different* sources, so two genuinely separate incidents at the same spot are never dropped (also restores the debug "one of each type" harness).
+- The update check no longer leaks the settings screen on rotation and no longer calls GitHub on every open.
+- Automated release is now re-runnable, requires all signing secrets before it attempts to sign, and skips cleanly otherwise.
+- Minor: diagnostics status is now a consistent snapshot; the wildfire source isn't fetched when disabled.
+
 ## [1.6] — 2026-07-02
 
 New data source, in-app updates, and quality-of-life.
@@ -77,6 +88,7 @@ Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrot
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
+[1.6.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.6.1
 [1.6]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.6
 [1.5.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.5.1
 [1.5]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.5

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 8
-        versionName = "1.6"
+        versionCode = 9
+        versionName = "1.6.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/AlertDeduper.java
+++ b/app/src/main/java/app/sabre/wzsabre/AlertDeduper.java
@@ -1,50 +1,52 @@
 package app.sabre.wzsabre;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
- * Collapses duplicate pins that different sources report for the same real-world
+ * Collapses duplicate pins that DIFFERENT sources report for the same real-world
  * event — e.g. a CHP accident and a Waze accident at the same intersection, or a
  * CHP closure and a Caltrans LCS closure on the same segment.
  *
- * <p>Two alerts are treated as duplicates when they share an alert "family"
- * (accident / police / closure-congestion / weather / hazard / fire) AND fall in
- * the same ~100&nbsp;m grid cell. The higher-priority source's alert is kept (CHP >
- * LCS > Fire > Waze), and the dropped alert's crowd-confirmation count is folded in
- * so that signal isn't lost.
+ * <p>Two alerts are duplicates when they come from different sources, share an alert
+ * "family" (accident / police / camera / sos / closure-congestion / construction /
+ * weather / hazard / fire), and are within {@value #DEDUPE_METERS} m of each other.
+ * The higher-priority source's alert is kept (CHP &gt; LCS &gt; Fire &gt; Waze) and the
+ * dropped alert's crowd-confirmation count is folded in.
  *
- * <p>Deliberately conservative: grid bucketing under-merges across cell boundaries
- * (it never merges two events that are actually distinct), and fires get their own
- * family so a real wildfire is never hidden by a co-located generic hazard.
+ * <p>Only cross-source pairs are ever merged: two alerts from the SAME source are
+ * always kept, because in a safety app two co-located same-family reports may be two
+ * genuinely distinct incidents and must not be silently dropped. Distance is a real
+ * great-circle check (not a grid), so there's no cell-boundary blind spot.
  */
 final class AlertDeduper {
     private AlertDeduper() {}
 
-    /** ~0.001° ≈ 111 m of latitude (a bit less in longitude at CA latitudes). */
-    private static final double CELL_DEG = 0.001;
+    private static final double DEDUPE_METERS = 120.0;
 
     static List<SabreAlert> dedupe(List<SabreAlert> alerts) {
         if (alerts == null || alerts.size() < 2) {
             return alerts == null ? new ArrayList<>() : new ArrayList<>(alerts);
         }
-        Map<String, SabreAlert> kept = new LinkedHashMap<>();
+        List<SabreAlert> survivors = new ArrayList<>();
         for (SabreAlert a : alerts) {
             if (a == null) continue;
-            String key = family(a) + "@" + Math.round(a.lat / CELL_DEG)
-                    + "," + Math.round(a.lon / CELL_DEG);
-            SabreAlert prev = kept.get(key);
-            if (prev == null) {
-                kept.put(key, a);
-            } else {
-                SabreAlert winner = priority(a) >= priority(prev) ? a : prev;
-                SabreAlert loser  = winner == a ? prev : a;
-                kept.put(key, foldConfirmations(winner, loser));
+            boolean merged = false;
+            for (int i = 0; i < survivors.size(); i++) {
+                SabreAlert s = survivors.get(i);
+                // Cross-source only: never merge two alerts from the same source.
+                if (a.alertSource == null || a.alertSource.equals(s.alertSource)) continue;
+                if (!family(a).equals(family(s))) continue;
+                if (CHPSource.haversineMeters(a.lat, a.lon, s.lat, s.lon) > DEDUPE_METERS) continue;
+                SabreAlert winner = priority(a) >= priority(s) ? a : s;
+                SabreAlert loser  = winner == a ? s : a;
+                survivors.set(i, foldConfirmations(winner, loser));
+                merged = true;
+                break;
             }
+            if (!merged) survivors.add(a);
         }
-        return new ArrayList<>(kept.values());
+        return survivors;
     }
 
     private static String family(SabreAlert a) {
@@ -52,10 +54,14 @@ final class AlertDeduper {
         // generic HAZARD_ON_ROAD (which is the same type string).
         if (SabreResponseBuilder.SOURCE_FIRE.equals(a.alertSource)) return "fire";
         String t = a.type == null ? "?" : a.type;
-        if (t.startsWith("POLICE"))   return "police";
-        if (t.startsWith("ACCIDENT")) return "accident";
-        if (t.contains("CONGESTION") || t.startsWith("JAM") || t.contains("CLOS")
-                || t.contains("LANE_CLOSURE")) return "closure";
+        if (t.startsWith("POLICE"))     return "police";
+        if (t.contains("CAMERA"))       return "camera";
+        if (t.startsWith("SOS"))        return "sos";
+        if (t.startsWith("ACCIDENT"))   return "accident";
+        // "CLOS" catches ROAD_CLOSED / TURN_CLOSED / LANE_CLOSURE; checked before
+        // construction so ROAD_CLOSED_CONSTRUCTION groups as a closure.
+        if (t.contains("CLOS") || t.contains("CONGESTION") || t.startsWith("JAM")) return "closure";
+        if (t.contains("CONSTRUCTION")) return "construction";
         if (t.startsWith("HAZARD_WEATHER") || t.contains("BAD_WEATHER")) return "weather";
         return "hazard";
     }

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -58,12 +58,30 @@ public class MainActivity extends Activity {
 
     // ── Update banner ─────────────────────────────────────────────────────────
 
+    // Throttle GitHub checks and cache the decision across Activity re-creations
+    // (rotation, quick reopen) so we don't hit the API on every onCreate.
+    private static final long UPDATE_CHECK_THROTTLE_MS = 30 * 60_000L;
+    private static volatile long lastUpdateCheckMs = 0L;
+    private static volatile UpdateChecker.Result pendingUpdate; // non-null → show the card
+
     private void checkForUpdate() {
+        long now = android.os.SystemClock.elapsedRealtime();
+        if (lastUpdateCheckMs != 0 && now - lastUpdateCheckMs < UPDATE_CHECK_THROTTLE_MS) {
+            showUpdateCard(pendingUpdate);   // reuse the last decision (may be null)
+            return;
+        }
+        lastUpdateCheckMs = now;
         new Thread(() -> {
             UpdateChecker.Result r = UpdateChecker.fetchLatest();
-            boolean newer = r != null
-                    && UpdateChecker.isNewer(r.latestVersion, BuildConfig.VERSION_NAME);
-            runOnUiThread(() -> showUpdateCard(newer ? r : null));
+            UpdateChecker.Result showable = (r != null
+                    && UpdateChecker.isNewer(r.latestVersion, BuildConfig.VERSION_NAME)) ? r : null;
+            pendingUpdate = showable;
+            runOnUiThread(() -> {
+                // The thread outlives a destroyed Activity (up to ~12s); don't touch
+                // its views if it's gone.
+                if (isFinishing() || isDestroyed()) return;
+                showUpdateCard(showable);
+            });
         }).start();
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -84,7 +84,9 @@ public class SabreService extends Service {
         createNotificationChannel();
         startForeground(NOTIFICATION_ID, buildForegroundNotification());
         chpSource.prewarm();          // statewide feed — no location needed
-        fireSource.prewarm();         // statewide feed — no location needed
+        // Only warm wildfires if the source is enabled — otherwise it's a wasted
+        // network fetch on every service start for a disabled source.
+        if (ChpConfig.load(this).fireEnabled) fireSource.prewarm();
         prewarmFromLastLocation();    // Waze — needs last known location
         maybeCheckForUpdate();        // throttled; notifies once per new version
         armIdleStop();                // stop if no HR activity arrives

--- a/app/src/main/java/app/sabre/wzsabre/SourceStatus.java
+++ b/app/src/main/java/app/sabre/wzsabre/SourceStatus.java
@@ -6,42 +6,45 @@ import java.util.concurrent.ConcurrentHashMap;
  * Process-wide, in-memory health record for each data source, so the settings
  * screen can show a diagnostics panel (last update, item count, last error) even
  * though the sources live inside {@link SabreService}. Both run in the same
- * process, so plain statics are sufficient; state is lost on process death, which
+ * process, so a static map is sufficient; state is lost on process death, which
  * is fine — it reflects the current session.
+ *
+ * <p>Each {@link Entry} is immutable and swapped in atomically, so a reader always
+ * sees a self-consistent snapshot (never, say, a fresh count next to a stale error).
  */
 public final class SourceStatus {
     private SourceStatus() {}
 
     public static final class Entry {
-        public volatile boolean ran;          // attempted at least one refresh
-        public volatile long    lastUpdateMs; // wall-clock of last SUCCESSFUL refresh
-        public volatile int     count;        // items the source currently holds
-        public volatile String  lastError;    // non-null if the most recent refresh failed
+        public final boolean ran;          // attempted at least one refresh
+        public final long    lastUpdateMs; // wall-clock of last SUCCESSFUL refresh (0 if none)
+        public final int     count;        // items held as of the last success
+        public final String  lastError;    // non-null if the most recent refresh failed
+
+        Entry(boolean ran, long lastUpdateMs, int count, String lastError) {
+            this.ran = ran;
+            this.lastUpdateMs = lastUpdateMs;
+            this.count = count;
+            this.lastError = lastError;
+        }
     }
 
     private static final ConcurrentHashMap<String, Entry> MAP = new ConcurrentHashMap<>();
 
-    private static Entry entry(String source) {
-        return MAP.computeIfAbsent(source, k -> new Entry());
-    }
-
     /** Record a successful refresh holding {@code count} items. */
     public static void success(String source, int count) {
-        Entry e = entry(source);
-        e.ran = true;
-        e.count = count;
-        e.lastUpdateMs = System.currentTimeMillis();
-        e.lastError = null;
+        MAP.put(source, new Entry(true, System.currentTimeMillis(), count, null));
     }
 
     /** Record a failed refresh (keeps the previous count / lastUpdateMs). */
     public static void failure(String source, String error) {
-        Entry e = entry(source);
-        e.ran = true;
-        e.lastError = error;
+        Entry prev = MAP.get(source);
+        long lastUpdate = prev != null ? prev.lastUpdateMs : 0L;
+        int count = prev != null ? prev.count : 0;
+        MAP.put(source, new Entry(true, lastUpdate, count, error));
     }
 
-    /** @return the entry for a source, or null if it has never run. */
+    /** @return the current snapshot for a source, or null if it has never run. */
     public static Entry get(String source) {
         return MAP.get(source);
     }

--- a/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
@@ -42,7 +42,7 @@ public class WildfireSource {
             + "?where=" + "POOState%3D%27US-CA%27%20AND%20IncidentTypeCategory%3D%27WF%27"
             + "%20AND%20ActiveFireCandidate%3D1"
             + "&outFields=IncidentName%2CIncidentSize%2CPercentContained%2C"
-            + "FireDiscoveryDateTime%2CUniqueFireIdentifier"
+            + "FireDiscoveryDateTime%2CUniqueFireIdentifier%2CIncidentTypeCategory"
             + "&returnGeometry=true&outSR=4326&f=json";
 
     private static final long CACHE_TTL_MS       = 5 * 60_000L;   // fires update slowly
@@ -65,20 +65,27 @@ public class WildfireSource {
         }
     }
 
+    /** Immutable {list, timestamp} pair so a reader never sees a fresh list with a
+     *  stale time (which would wrongly treat a just-refreshed cache as expired). */
+    private static final class Snapshot {
+        final List<Fire> fires;
+        final long timeMs;
+        Snapshot(List<Fire> fires, long timeMs) { this.fires = fires; this.timeMs = timeMs; }
+    }
+
     private final ExecutorService refreshExec = Executors.newSingleThreadExecutor();
     private final AtomicBoolean refreshing = new AtomicBoolean(false);
-    private volatile List<Fire> cache = null;
-    private volatile long cacheTimeMs = 0L;
+    private volatile Snapshot cache = null;
 
     /** Active wildfires within the radius, served from the cache. Never blocks. */
     public List<SabreAlert> fetchAlerts(double lat, double lon, double radiusMeters) {
         triggerRefreshIfStale();
-        List<Fire> snap = cache;
-        if (snap == null || (System.currentTimeMillis() - cacheTimeMs) > CACHE_MAX_SERVE_MS) {
+        Snapshot snap = cache;
+        if (snap == null || (System.currentTimeMillis() - snap.timeMs) > CACHE_MAX_SERVE_MS) {
             return new ArrayList<>();
         }
         List<SabreAlert> out = new ArrayList<>();
-        for (Fire f : snap) {
+        for (Fire f : snap.fires) {
             if (CHPSource.haversineMeters(lat, lon, f.lat, f.lon) > radiusMeters) continue;
             out.add(toAlert(f));
         }
@@ -92,13 +99,13 @@ public class WildfireSource {
     public void shutdown() { refreshExec.shutdownNow(); }
 
     private void triggerRefreshIfStale() {
-        boolean stale = cache == null || (System.currentTimeMillis() - cacheTimeMs) > CACHE_TTL_MS;
+        Snapshot snap = cache;
+        boolean stale = snap == null || (System.currentTimeMillis() - snap.timeMs) > CACHE_TTL_MS;
         if (stale && refreshing.compareAndSet(false, true)) {
             refreshExec.submit(() -> {
                 try {
                     List<Fire> parsed = fetchAndParse();
-                    cache = parsed;
-                    cacheTimeMs = System.currentTimeMillis();
+                    cache = new Snapshot(parsed, System.currentTimeMillis());
                     Log.d(TAG, "Wildfires refreshed: " + parsed.size() + " active in CA");
                     SourceStatus.success(SabreResponseBuilder.SOURCE_FIRE, parsed.size());
                 } catch (Exception e) {
@@ -138,6 +145,17 @@ public class WildfireSource {
     static List<Fire> parse(String json) throws Exception {
         List<Fire> out = new ArrayList<>();
         JSONObject root = new JSONObject(json);
+        // ArcGIS reports query failures as HTTP 200 with an {"error":...} body (e.g.
+        // a renamed field). Treat that as a failure so it surfaces in diagnostics
+        // instead of looking like "0 active fires".
+        if (root.has("error")) {
+            throw new Exception("WFIGS query error: " + root.optJSONObject("error"));
+        }
+        if (root.optBoolean("exceededTransferLimit", false)) {
+            // Server capped the result set — we'd be silently dropping fires. Very
+            // unlikely for active CA wildfires, but log it rather than hide it.
+            Log.w(TAG, "WFIGS response hit the record cap — some fires may be omitted");
+        }
         JSONArray features = root.optJSONArray("features");
         if (features == null) return out;
         long nowSec = System.currentTimeMillis() / 1000L;
@@ -147,6 +165,9 @@ public class WildfireSource {
             JSONObject geom = feat.optJSONObject("geometry");
             JSONObject attr = feat.optJSONObject("attributes");
             if (geom == null || attr == null) continue;
+            // Defense-in-depth: only real wildfires (WF), never prescribed burns (RX),
+            // even if the server-side type filter ever stops applying.
+            if (!"WF".equals(attr.optString("IncidentTypeCategory", "WF"))) continue;
             // ArcGIS omits geometry keys when absent; require both.
             if (!geom.has("x") || !geom.has("y")) continue;
             double lon = geom.optDouble("x", Double.NaN);

--- a/app/src/test/java/app/sabre/wzsabre/AlertDeduperTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/AlertDeduperTest.java
@@ -49,6 +49,26 @@ public class AlertDeduperTest {
     }
 
     @Test
+    public void sameSourceCoLocatedNotMerged() {
+        // Two distinct CHP accidents ~30m apart at an interchange must BOTH survive —
+        // only cross-source duplicates are collapsed.
+        List<SabreAlert> in = Arrays.asList(
+                a("chp_1", SabreResponseBuilder.SOURCE_CHP, "ACCIDENT_MAJOR", LAT, LON, 0),
+                a("chp_2", SabreResponseBuilder.SOURCE_CHP, "ACCIDENT_MAJOR", LAT + 0.0003, LON, 0));
+        assertEquals(2, AlertDeduper.dedupe(in).size());
+    }
+
+    @Test
+    public void sosNotMergedWithGenericHazard() {
+        // An SOS (stranded/emergency) and a debris hazard at the same spot are
+        // different events even across sources.
+        List<SabreAlert> in = Arrays.asList(
+                a("waze_alert-1/u", SabreResponseBuilder.SOURCE_WAZE, "SOS_MEDICAL_HELP", LAT, LON, 0),
+                a("chp_1", SabreResponseBuilder.SOURCE_CHP, "HAZARD_ON_ROAD_DEBRIS", LAT, LON, 0));
+        assertEquals(2, AlertDeduper.dedupe(in).size());
+    }
+
+    @Test
     public void wildfireNotMergedWithGenericHazard() {
         // Fire and a debris hazard share the HAZARD_ON_ROAD type string but must not merge.
         List<SabreAlert> in = Arrays.asList(

--- a/app/src/test/java/app/sabre/wzsabre/WildfireSourceTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/WildfireSourceTest.java
@@ -55,6 +55,26 @@ public class WildfireSourceTest {
         assertEquals(0, WildfireSource.parse("{}").size());
     }
 
+    @Test(expected = Exception.class)
+    public void parse_arcgisErrorBody_throws() throws Exception {
+        // ArcGIS returns HTTP 200 with an error body on a bad query — must NOT be
+        // treated as "0 fires" (which would hide the outage in diagnostics).
+        WildfireSource.parse("{\"error\":{\"code\":400,\"message\":\"Invalid field\"}}");
+    }
+
+    @Test
+    public void parse_skipsNonWildfireType() throws Exception {
+        String json = "{\"features\":[" +
+            "{\"attributes\":{\"IncidentName\":\"PRESCRIBED\",\"IncidentTypeCategory\":\"RX\"," +
+            "\"UniqueFireIdentifier\":\"2026-CA-RX1\"},\"geometry\":{\"x\":-121.0,\"y\":38.0}}," +
+            "{\"attributes\":{\"IncidentName\":\"REAL FIRE\",\"IncidentTypeCategory\":\"WF\"," +
+            "\"UniqueFireIdentifier\":\"2026-CA-WF1\"},\"geometry\":{\"x\":-121.0,\"y\":38.0}}" +
+            "]}";
+        List<WildfireSource.Fire> fires = WildfireSource.parse(json);
+        assertEquals("prescribed burn (RX) dropped client-side", 1, fires.size());
+        assertEquals("REAL FIRE", fires.get(0).name);
+    }
+
     @Test
     public void toAlert_producesValidSabreAlert() throws Exception {
         WildfireSource.Fire a = WildfireSource.parse(JSON).get(0);


### PR DESCRIPTION
Fixes from a fresh-eyes audit of the v1.6 code (two agents; one "pipeline-breaking" finding was a false positive — the bumped CI actions exist and CI is green).

## Fixed
- **Wildfire silent failure** — a broken WFIGS query (HTTP 200 + `{error}` body) was read as "0 fires" and recorded as success. Now it surfaces as an error in diagnostics; also a client-side `WF` filter so prescribed burns can't leak in, and a torn-read fix on the cache.
- **Deduper dropped distinct same-source incidents** — now merges *only across* sources (pairwise, 120 m great-circle), so two separate CHP accidents at one interchange both survive. Also restores the debug "one of each type" harness, and gives SOS/camera/construction their own families.
- **Update-check Activity leak + API spam** — guarded against touching a destroyed Activity on rotation, and throttled to once/30 min.
- **Release workflow** — requires all four signing secrets before signing, and the publish step is idempotent (re-runnable / re-pushed tag).
- **Lows** — atomic diagnostics snapshot; wildfire not fetched when disabled.

213 unit tests (4 new), `lintDebug` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)