### PR TITLE
v1.7 — chain controls + QoL controls

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -64,13 +64,14 @@ Current test suites:
 
 | Suite | Tests | What it covers |
 |-------|-------|----------------|
-| `AlertMapperTest` | 47 | Every CHP log type and Waze type maps to the correct SABRE type (incl. injury-collision codes, locale independence) |
+| `AlertMapperTest` | 55 | CHP/Waze type → SABRE type (injury codes, locale independence, Waze coarse categories) |
 | `ChpConfigTest` | 42 | Category toggles, type overrides, age filter, LogTime parsing (both CHP feed formats) |
 | `SabreProtocolTest` | 38 | HR JSON schema — all 11 required alert fields, type whitelist, nullability, drop-bad-alert semantics |
 | `LcsSourceTest` | 27 | Caltrans LCS parsing, 1097/1098/1022 state filtering, shoulder/aux skip, span pins, district selection |
 | `CHPSourceTest` | 18 | XML parsing (incl. entity refs + real feed shape), radius filter, coordinate parsing, haversine |
-| `WildfireSourceTest` | 5 | WFIGS ArcGIS JSON parse + SABRE mapping |
-| `AlertDeduperTest` | 5 | Cross-source pin de-duplication (family + proximity, confirm-fold) |
+| `WildfireSourceTest` | 7 | WFIGS ArcGIS JSON parse (incl. error body + RX filter), SABRE mapping |
+| `WinterSourceTest` | 7 | Chain-control parse, R-0…R-3 active filtering, SABRE mapping |
+| `AlertDeduperTest` | 7 | Cross-source-only pin de-duplication (family + proximity, confirm-fold) |
 | `UpdateCheckerTest` | 4 | Version-comparison logic for the update check |
 | Waze suites | 23 | RT cache delta-merge/soft-delete, in-band error classification, shrinking-box geometry, confirm-ts, RmAlert parsing |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.7] — 2026-07-02
+
+New source and quality-of-life controls.
+
+### Added
+- **Chain controls** — Caltrans winter chain requirements (R-1/R-2/R-3) on mountain routes, shown as slippery-road hazards. Settings toggle (on by default); off-season it shows nothing.
+- **Waze filters** — coarse per-category toggles (police & cameras / accidents / hazards / traffic jams / road closures) to cut noise.
+- **Wildfire size threshold** — optionally hide small fires (All / 10+ / 100+ / 1000+ acres).
+- **Update-notification toggle** — silence the update notification while keeping the in-app banner.
+- **Diagnostics: Refresh button + last-crash line** — poke a refresh and see the most recent crash (on-device only), which makes bug reports far more useful.
+
 ## [1.6.1] — 2026-07-02
 
 Hardening from a post-release review of v1.6.
@@ -88,6 +99,7 @@ Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrot
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
+[1.7]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7
 [1.6.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.6.1
 [1.6]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.6
 [1.5.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.5.1

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A drop-in replacement for **wzsabre** that brings CHP live incident alerts and W
 | **Waze** | Crowdsourced police, accidents, hazards, road closures | Every HR map refresh |
 | **Caltrans Closures (LCS)** | Lane and road closures that are physically in place right now (CHP code 1097), from the per-district Caltrans Lane Closure System feeds | Cached, refreshed every 5 min |
 | **Wildfires** | Active California wildfires (name, size, containment) from the interagency WFIGS feed, shown as road hazards near the fire | Cached, refreshed every 5 min |
+| **Chain Controls** | Caltrans winter chain requirements (R-1/R-2/R-3) on mountain routes, shown as slippery-road hazards | Cached, refreshed every 5 min |
 
 All sources run in parallel and feed into the standard HR crowdsourced-alerts layer — the same map overlay that wzsabre used to power.
 
@@ -150,7 +151,8 @@ Highway Radar  ──broadcast──▶  MainBroadcastReceiver
 - **CHP**: fetches `https://media.chp.ca.gov/sa_xml/sa.xml`, filters by radius and incident age, applies your category settings.
 - **Waze**: emulates the Waze mobile app's binary "RT" protocol — it registers an anonymous Waze session, logs in, and queries crowd-sourced alerts over Waze's protobuf API (the older live-map/georss API is now blocked). The RT feed is session-stateful (each alert is sent once, then removed when it clears), so query results are merged into a persistent alert cache rather than replacing it — this keeps alerts from disappearing as you drive. A series of progressively smaller map viewports is queried so the server doesn't thin out minor alerts near you, the session is pre-warmed at start to cut first-load latency, and Waze alert subtypes (e.g. *car stopped on shoulder*, *heavy traffic*) are passed through to Highway Radar verbatim rather than flattened.
 - **Caltrans LCS**: fetches the per-district lane-closure feeds (`https://cwwp2.dot.ca.gov/data/d<N>/lcs/lcsStatusD<NN>.xml`) for whichever districts cover your location. Only closures that are physically established (CHP code 1097 set, not picked up or canceled) are shown; shoulder-only closures are skipped. Closures longer than 2 km get a pin at each end. The ~4 MB feeds are parsed in the background and cached for 5 minutes, so they never delay a Highway Radar request.
-- **Wildfires**: active California wildfires from the interagency WFIGS "Current Wildland Fire Incident Locations" feed (NIFC-hosted ArcGIS), filtered to active wildfires in California. Each is shown as a road hazard at the fire's location with its name, size, and containment. Background-cached like the other sources.
+- **Wildfires**: active California wildfires from the interagency WFIGS "Current Wildland Fire Incident Locations" feed (NIFC-hosted ArcGIS), filtered to active wildfires in California. Each is shown as a road hazard at the fire's location with its name, size, and containment. Background-cached like the other sources. Optional minimum-size filter in settings.
+- **Chain controls**: Caltrans winter chain-control status from the per-district CWWP feeds (`https://cwwp2.dot.ca.gov/data/d<N>/cc/ccStatusD<NN>.xml`). Records at level R-1/R-2/R-3 (in service) are shown as slippery-road hazards; off-season the feed is all R-0 so nothing shows.
 - **SABRE protocol**: a broadcast-intent IPC protocol defined by Highway Radar. Our plugin responds to `FETCH_REQUEST` broadcasts with a JSON payload containing `SabreFetchResponseAlert` objects.
 
 ---
@@ -163,7 +165,7 @@ Pull requests welcome. Run the test suite before submitting:
 ./gradlew test
 ```
 
-209 unit tests cover the SABRE response format, alert type mapping, the Waze alert cache (delta merge + soft-delete), in-band Waze error classification, shrinking-box geometry, crowd-confirmation tracking, CHP XML parsing, Caltrans LCS parsing and filtering, wildfire (WFIGS) parsing, cross-source de-duplication, the update-check version compare, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup, and [CHANGELOG.md](CHANGELOG.md) for release history.
+228 unit tests cover the SABRE response format, alert type mapping (incl. Waze category filters), the Waze alert cache (delta merge + soft-delete), in-band Waze error classification, shrinking-box geometry, crowd-confirmation tracking, CHP XML parsing, Caltrans LCS and chain-control parsing and filtering, wildfire (WFIGS) parsing, cross-source de-duplication, the update-check version compare, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup, and [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 9
-        versionName = "1.6.1"
+        versionCode = 10
+        versionName = "1.7"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
     </queries>
 
     <application
+        android:name=".App"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/app/sabre/wzsabre/AlertMapper.java
+++ b/app/src/main/java/app/sabre/wzsabre/AlertMapper.java
@@ -92,6 +92,21 @@ public class AlertMapper {
         return "HAZARD_ON_ROAD_DEBRIS";
     }
 
+    /**
+     * Coarse category for a Waze passthrough type (the raw Waze type/subtype name),
+     * used by the settings Waze filters: police / accidents / jams / closures /
+     * hazards (the catch-all, incl. SOS, weather, construction, etc.).
+     */
+    public static String wazeCategory(String type) {
+        if (type == null) return "hazards";
+        String t = type.toUpperCase(Locale.US);
+        if (t.startsWith("POLICE") || t.contains("CAMERA")) return "police";
+        if (t.startsWith("ACCIDENT"))                       return "accidents";
+        if (t.startsWith("JAM") || t.contains("CONGESTION")) return "jams";
+        if (t.contains("CLOS") || t.contains("LANE_CLOSURE")) return "closures";
+        return "hazards";
+    }
+
     // ── Waze ─────────────────────────────────────────────────────────────────
 
     public static String fromWazeType(String type, String subtype) {

--- a/app/src/main/java/app/sabre/wzsabre/App.java
+++ b/app/src/main/java/app/sabre/wzsabre/App.java
@@ -1,0 +1,20 @@
+package app.sabre.wzsabre;
+
+import android.app.Application;
+
+/**
+ * Records the last uncaught exception (see {@link CrashLog}) before delegating to
+ * the platform's default handler, so the settings diagnostics panel can show it.
+ */
+public class App extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        final Thread.UncaughtExceptionHandler previous =
+                Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
+            CrashLog.record(this, throwable);
+            if (previous != null) previous.uncaughtException(thread, throwable);
+        });
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/ChpConfig.java
+++ b/app/src/main/java/app/sabre/wzsabre/ChpConfig.java
@@ -46,6 +46,38 @@ public class ChpConfig {
     public boolean chainsEnabled;
     private static final String KEY_CHAINS_ENABLED = "chains_enabled";
 
+    // ── Update notification ────────────────────────────────────────────────────
+    /** When false, the once-per-version update notification is suppressed (the
+     *  in-app banner still shows). */
+    public boolean updateNotifyEnabled;
+    private static final String KEY_UPDATE_NOTIFY = "update_notify_enabled";
+
+    // ── Wildfire noise control ─────────────────────────────────────────────────
+    /** Hide wildfires smaller than this many acres (0 = show all). */
+    public int fireMinAcres;
+    private static final String KEY_FIRE_MIN_ACRES = "fire_min_acres";
+
+    // ── Waze category filters (coarse) ─────────────────────────────────────────
+    // Each toggles a whole class of Waze alerts. Default all on.
+    public boolean wazePolice, wazeAccidents, wazeHazards, wazeJams, wazeClosures;
+    private static final String KEY_WAZE_POLICE    = "waze_police";
+    private static final String KEY_WAZE_ACCIDENTS = "waze_accidents";
+    private static final String KEY_WAZE_HAZARDS   = "waze_hazards";
+    private static final String KEY_WAZE_JAMS      = "waze_jams";
+    private static final String KEY_WAZE_CLOSURES  = "waze_closures";
+
+    /** @return whether a Waze coarse category ("police"/"accidents"/... from
+     *  {@link AlertMapper#wazeCategory}) is currently enabled. */
+    public boolean isWazeCategoryEnabled(String category) {
+        switch (category) {
+            case "police":    return wazePolice;
+            case "accidents": return wazeAccidents;
+            case "jams":      return wazeJams;
+            case "closures":  return wazeClosures;
+            default:          return wazeHazards;   // hazards + anything else
+        }
+    }
+
     // ── Constructor (defaults) ───────────────────────────────────────────────
     private ChpConfig() {
         for (ChpCategory cat : ChpCategory.values()) {
@@ -56,6 +88,9 @@ public class ChpConfig {
         lcsEnabled = true;
         fireEnabled = true;
         chainsEnabled = true;
+        updateNotifyEnabled = true;
+        fireMinAcres = 0;
+        wazePolice = wazeAccidents = wazeHazards = wazeJams = wazeClosures = true;
     }
 
     // ── Accessors ─────────────────────────────────────────────────────────────
@@ -112,6 +147,13 @@ public class ChpConfig {
         cfg.lcsEnabled    = prefs.getBoolean(KEY_LCS_ENABLED, true);
         cfg.fireEnabled   = prefs.getBoolean(KEY_FIRE_ENABLED, true);
         cfg.chainsEnabled = prefs.getBoolean(KEY_CHAINS_ENABLED, true);
+        cfg.updateNotifyEnabled = prefs.getBoolean(KEY_UPDATE_NOTIFY, true);
+        cfg.fireMinAcres  = Math.max(0, prefs.getInt(KEY_FIRE_MIN_ACRES, 0));
+        cfg.wazePolice    = prefs.getBoolean(KEY_WAZE_POLICE, true);
+        cfg.wazeAccidents = prefs.getBoolean(KEY_WAZE_ACCIDENTS, true);
+        cfg.wazeHazards   = prefs.getBoolean(KEY_WAZE_HAZARDS, true);
+        cfg.wazeJams      = prefs.getBoolean(KEY_WAZE_JAMS, true);
+        cfg.wazeClosures  = prefs.getBoolean(KEY_WAZE_CLOSURES, true);
         return cfg;
     }
 
@@ -130,6 +172,13 @@ public class ChpConfig {
         ed.putBoolean(KEY_LCS_ENABLED, lcsEnabled);
         ed.putBoolean(KEY_FIRE_ENABLED, fireEnabled);
         ed.putBoolean(KEY_CHAINS_ENABLED, chainsEnabled);
+        ed.putBoolean(KEY_UPDATE_NOTIFY, updateNotifyEnabled);
+        ed.putInt(KEY_FIRE_MIN_ACRES, fireMinAcres);
+        ed.putBoolean(KEY_WAZE_POLICE, wazePolice);
+        ed.putBoolean(KEY_WAZE_ACCIDENTS, wazeAccidents);
+        ed.putBoolean(KEY_WAZE_HAZARDS, wazeHazards);
+        ed.putBoolean(KEY_WAZE_JAMS, wazeJams);
+        ed.putBoolean(KEY_WAZE_CLOSURES, wazeClosures);
         ed.apply();
     }
 
@@ -187,5 +236,19 @@ public class ChpConfig {
             if (AGE_VALUES_MINUTES[i] == minutes) return i;
         }
         return 2; // default to 1 hour
+    }
+
+    // ── Wildfire min-size option helpers ────────────────────────────────────────
+
+    public static final int[]    FIRE_SIZE_VALUES = { 0, 10, 100, 1000 };
+    public static final String[] FIRE_SIZE_LABELS = {
+        "All sizes", "10+ acres", "100+ acres", "1000+ acres"
+    };
+
+    public static int fireSizeToSpinnerIndex(int acres) {
+        for (int i = 0; i < FIRE_SIZE_VALUES.length; i++) {
+            if (FIRE_SIZE_VALUES[i] == acres) return i;
+        }
+        return 0; // default to all sizes
     }
 }

--- a/app/src/main/java/app/sabre/wzsabre/ChpConfig.java
+++ b/app/src/main/java/app/sabre/wzsabre/ChpConfig.java
@@ -42,6 +42,10 @@ public class ChpConfig {
     public boolean fireEnabled;
     private static final String KEY_FIRE_ENABLED = "fire_enabled";
 
+    // ── Chain controls (Caltrans CC) ──────────────────────────────────────────
+    public boolean chainsEnabled;
+    private static final String KEY_CHAINS_ENABLED = "chains_enabled";
+
     // ── Constructor (defaults) ───────────────────────────────────────────────
     private ChpConfig() {
         for (ChpCategory cat : ChpCategory.values()) {
@@ -51,6 +55,7 @@ public class ChpConfig {
         maxAgeMinutes = 60;  // 1 hour default
         lcsEnabled = true;
         fireEnabled = true;
+        chainsEnabled = true;
     }
 
     // ── Accessors ─────────────────────────────────────────────────────────────
@@ -106,6 +111,7 @@ public class ChpConfig {
         cfg.maxAgeMinutes = prefs.getInt(KEY_MAX_AGE, 60);
         cfg.lcsEnabled    = prefs.getBoolean(KEY_LCS_ENABLED, true);
         cfg.fireEnabled   = prefs.getBoolean(KEY_FIRE_ENABLED, true);
+        cfg.chainsEnabled = prefs.getBoolean(KEY_CHAINS_ENABLED, true);
         return cfg;
     }
 
@@ -123,6 +129,7 @@ public class ChpConfig {
         ed.putInt(KEY_MAX_AGE, maxAgeMinutes);
         ed.putBoolean(KEY_LCS_ENABLED, lcsEnabled);
         ed.putBoolean(KEY_FIRE_ENABLED, fireEnabled);
+        ed.putBoolean(KEY_CHAINS_ENABLED, chainsEnabled);
         ed.apply();
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/CrashLog.java
+++ b/app/src/main/java/app/sabre/wzsabre/CrashLog.java
@@ -1,0 +1,57 @@
+package app.sabre.wzsabre;
+
+import android.content.Context;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Records the most recent uncaught exception to a private file so the settings
+ * diagnostics panel can surface "last crash" — turns a vague "it crashed" report
+ * into something actionable. Stays entirely on-device; never transmitted.
+ */
+public final class CrashLog {
+    private CrashLog() {}
+
+    private static final String FILE = "last_crash.txt";
+
+    /** Persist a crash: line 1 = epoch millis, line 2 = summary, then the stack trace. */
+    static void record(Context ctx, Throwable t) {
+        try {
+            StringWriter sw = new StringWriter();
+            t.printStackTrace(new PrintWriter(sw));
+            String content = System.currentTimeMillis() + "\n"
+                    + t.toString() + "\n" + sw;
+            try (FileOutputStream fos = ctx.openFileOutput(FILE, Context.MODE_PRIVATE)) {
+                fos.write(content.getBytes(StandardCharsets.UTF_8));
+            }
+        } catch (Exception ignored) {
+            // Never let crash logging itself throw.
+        }
+    }
+
+    /** @return {epochMillisString, summaryLine} of the last crash, or null if none. */
+    static String[] readSummary(Context ctx) {
+        File f = new File(ctx.getFilesDir(), FILE);
+        if (!f.exists()) return null;
+        try (BufferedReader r = new BufferedReader(
+                new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8))) {
+            String ts = r.readLine();
+            String summary = r.readLine();
+            if (ts == null || summary == null) return null;
+            return new String[]{ts, summary};
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    static void clear(Context ctx) {
+        ctx.deleteFile(FILE);
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -9,15 +9,19 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.provider.Settings;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
 import android.widget.CompoundButton;
 import android.widget.LinearLayout;
 import android.widget.Spinner;
 import android.widget.Switch;
 import android.widget.TextView;
+
+import java.util.function.Consumer;
 
 /**
  * Settings screen for the CHP alert feed.
@@ -51,10 +55,67 @@ public class MainActivity extends Activity {
         buildCategoryRows();
         buildLcsSwitch();
         buildFireSwitch();
+        buildFireSizeSpinner();
         buildChainsSwitch();
+        buildWazeFilters();
+        buildUpdateNotifySwitch();
         buildAgeSpinner();
         buildDiagnostics();
         checkForUpdate();
+    }
+
+    private void buildFireSizeSpinner() {
+        Spinner sp = findViewById(R.id.fireSizeSpinner);
+        ArrayAdapter<String> ad = new ArrayAdapter<>(
+                this, android.R.layout.simple_spinner_item, ChpConfig.FIRE_SIZE_LABELS);
+        ad.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        sp.setAdapter(ad);
+        sp.setSelection(ChpConfig.fireSizeToSpinnerIndex(config.fireMinAcres));
+        sp.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override public void onItemSelected(AdapterView<?> p, View v, int pos, long id) {
+                config.fireMinAcres = ChpConfig.FIRE_SIZE_VALUES[pos];
+                config.save(MainActivity.this);
+            }
+            @Override public void onNothingSelected(AdapterView<?> p) {}
+        });
+    }
+
+    private void buildUpdateNotifySwitch() {
+        Switch sw = findViewById(R.id.updateNotifySwitch);
+        sw.setChecked(config.updateNotifyEnabled);
+        sw.setOnCheckedChangeListener((CompoundButton b, boolean isChecked) -> {
+            config.updateNotifyEnabled = isChecked;
+            config.save(this);
+        });
+    }
+
+    // ── Waze category filters ───────────────────────────────────────────────────
+
+    private void buildWazeFilters() {
+        LinearLayout c = findViewById(R.id.wazeFilterContainer);
+        addWazeToggle(c, "Police & cameras", config.wazePolice, v -> config.wazePolice = v);
+        addWazeToggle(c, "Accidents",        config.wazeAccidents, v -> config.wazeAccidents = v);
+        addWazeToggle(c, "Hazards",          config.wazeHazards, v -> config.wazeHazards = v);
+        addWazeToggle(c, "Traffic jams",     config.wazeJams, v -> config.wazeJams = v);
+        addWazeToggle(c, "Road closures",    config.wazeClosures, v -> config.wazeClosures = v);
+    }
+
+    private void addWazeToggle(LinearLayout container, String label, boolean checked,
+                               Consumer<Boolean> setter) {
+        LinearLayout row = new LinearLayout(this);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+        row.setPadding(0, 12, 0, 12);
+        TextView tv = new TextView(this);
+        tv.setText(label);
+        tv.setTextSize(14f);
+        tv.setTextColor(0xFF212121);
+        row.addView(tv, new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f));
+        Switch sw = new Switch(this);
+        sw.setChecked(checked);
+        sw.setOnCheckedChangeListener((b, isChecked) -> { setter.accept(isChecked); config.save(this); });
+        row.addView(sw);
+        container.addView(row);
     }
 
     // ── Update banner ─────────────────────────────────────────────────────────
@@ -129,6 +190,29 @@ public class MainActivity extends Activity {
             row.setTextColor(e != null && e.lastError != null ? 0xFFD32F2F : 0xFF424242);
             container.addView(row);
         }
+
+        // Last crash (if any) — tap to clear.
+        String[] crash = CrashLog.readSummary(this);
+        if (crash != null) {
+            TextView cr = new TextView(this);
+            cr.setTextSize(13f);
+            cr.setPadding(0, 6, 0, 6);
+            cr.setTextColor(0xFFD32F2F);
+            long whenMs = 0L;
+            try { whenMs = Long.parseLong(crash[0]); } catch (NumberFormatException ignored) {}
+            cr.setText("Last crash: " + (whenMs > 0 ? ago(whenMs) : "?") + " — " + crash[1] + "  (tap to clear)");
+            cr.setOnClickListener(v -> { CrashLog.clear(this); buildDiagnostics(); });
+            container.addView(cr);
+        }
+
+        // Refresh: poke the service (prewarms/refreshes stale sources) and re-render.
+        Button refresh = new Button(this);
+        refresh.setText("Refresh");
+        refresh.setOnClickListener(v -> {
+            ForegroundServiceStarter.start(this, null, null);
+            v.postDelayed(this::buildDiagnostics, 1500);
+        });
+        container.addView(refresh);
     }
 
     private static String formatStatus(String label, SourceStatus.Entry e) {

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -51,6 +51,7 @@ public class MainActivity extends Activity {
         buildCategoryRows();
         buildLcsSwitch();
         buildFireSwitch();
+        buildChainsSwitch();
         buildAgeSpinner();
         buildDiagnostics();
         checkForUpdate();
@@ -117,6 +118,7 @@ public class MainActivity extends Activity {
                 {SabreResponseBuilder.SOURCE_WAZE, "Waze alerts"},
                 {SabreResponseBuilder.SOURCE_LCS,  "Caltrans closures"},
                 {SabreResponseBuilder.SOURCE_FIRE, "Wildfires"},
+                {SabreResponseBuilder.SOURCE_CHAINS, "Chain controls"},
         };
         for (String[] s : sources) {
             SourceStatus.Entry e = SourceStatus.get(s[0]);
@@ -161,6 +163,15 @@ public class MainActivity extends Activity {
         sw.setChecked(config.fireEnabled);
         sw.setOnCheckedChangeListener((CompoundButton btn, boolean isChecked) -> {
             config.fireEnabled = isChecked;
+            config.save(this);
+        });
+    }
+
+    private void buildChainsSwitch() {
+        Switch sw = findViewById(R.id.chainsSwitch);
+        sw.setChecked(config.chainsEnabled);
+        sw.setOnCheckedChangeListener((CompoundButton btn, boolean isChecked) -> {
+            config.chainsEnabled = isChecked;
             config.save(this);
         });
     }

--- a/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
@@ -92,6 +92,7 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
         JSONObject s2 = new JSONObject(); s2.put("id", "waze"); s2.put("name", "Waze");               sources.put(s2);
         JSONObject s3 = new JSONObject(); s3.put("id", "lcs");  s3.put("name", "Caltrans Closures");  sources.put(s3);
         JSONObject s4 = new JSONObject(); s4.put("id", "fire"); s4.put("name", "Wildfires");          sources.put(s4);
+        JSONObject s5 = new JSONObject(); s5.put("id", "chains"); s5.put("name", "Chain Controls");   sources.put(s5);
         response.put("supported_sources", sources);
         response.put("request_action",  "app.sabre.wzsabre.FETCH_REQUEST");
         response.put("report_action",   "app.sabre.wzsabre.SUBMIT_REPORT");

--- a/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
@@ -23,10 +23,11 @@ public class SabreResponseBuilder {
      * HR may use these IDs to look up source metadata (icon, color, etc.)
      * and crash with NPE/IOOB if the value is unknown.
      */
-    public static final String SOURCE_CHP  = "chp";
-    public static final String SOURCE_WAZE = "waze";
-    public static final String SOURCE_LCS  = "lcs";
-    public static final String SOURCE_FIRE = "fire";
+    public static final String SOURCE_CHP    = "chp";
+    public static final String SOURCE_WAZE   = "waze";
+    public static final String SOURCE_LCS    = "lcs";
+    public static final String SOURCE_FIRE   = "fire";
+    public static final String SOURCE_CHAINS = "chains";
 
     /**
      * Highway Radar's package. Every reply broadcast is explicitly targeted at it

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -62,6 +62,7 @@ public class SabreService extends Service {
     private CHPSource chpSource;
     private LcsSource lcsSource;
     private WildfireSource fireSource;
+    private WinterSource chainsSource;
     private app.sabre.wzsabre.waze.WazeProtocolSource wazeSource;
 
     // Last fetch location, persisted so the Waze session can be pre-warmed at the
@@ -76,10 +77,11 @@ public class SabreService extends Service {
         super.onCreate();
         RUNNING = true;
         requestExecutor = Executors.newSingleThreadExecutor();
-        fetchExecutor   = Executors.newFixedThreadPool(4);
+        fetchExecutor   = Executors.newFixedThreadPool(5);
         chpSource  = new CHPSource();
         lcsSource  = new LcsSource();
         fireSource = new WildfireSource();
+        chainsSource = new WinterSource();
         wazeSource = new app.sabre.wzsabre.waze.WazeProtocolSource(this);
         createNotificationChannel();
         startForeground(NOTIFICATION_ID, buildForegroundNotification());
@@ -110,8 +112,10 @@ public class SabreService extends Service {
         double lon = Double.longBitsToDouble(p.getLong("last_lon", 0));
         double radius = Double.longBitsToDouble(p.getLong("last_radius", 0));
         if (radius <= 0) radius = 80_000;
-        Log.d(TAG, String.format("Pre-warming Waze for last location %.4f,%.4f", lat, lon));
+        Log.d(TAG, String.format("Pre-warming for last location %.4f,%.4f", lat, lon));
         wazeSource.prewarm(lat, lon, radius);
+        // Chain controls are per-district (need a location); warm only if enabled.
+        if (ChpConfig.load(this).chainsEnabled) chainsSource.prewarm(lat, lon, radius);
     }
 
     private void saveLastLocation(double lat, double lon, double radius) {
@@ -216,6 +220,7 @@ public class SabreService extends Service {
         if (lcsSource  != null) lcsSource.shutdown();
         if (chpSource  != null) chpSource.shutdown();
         if (fireSource != null) fireSource.shutdown();
+        if (chainsSource != null) chainsSource.shutdown();
         super.onDestroy();
     }
 
@@ -253,6 +258,9 @@ public class SabreService extends Service {
                         : null;
                 Future<List<SabreAlert>> fireFuture = chpConfig.fireEnabled
                         ? fetchExecutor.submit(() -> fireSource.fetchAlerts(lat, lon, radius))
+                        : null;
+                Future<List<SabreAlert>> chainsFuture = chpConfig.chainsEnabled
+                        ? fetchExecutor.submit(() -> chainsSource.fetchAlerts(lat, lon, radius))
                         : null;
 
                 List<SabreAlert> allAlerts = new ArrayList<>();
@@ -306,6 +314,18 @@ public class SabreService extends Service {
                     } catch (Exception e) {
                         Log.w(TAG, "Wildfire unavailable this cycle: " + e.getClass().getSimpleName());
                         fireFuture.cancel(true);
+                    }
+                }
+
+                // Chain controls serve from cache and never block; 1s is generous
+                if (chainsFuture != null) {
+                    try {
+                        List<SabreAlert> chainAlerts = chainsFuture.get(1, TimeUnit.SECONDS);
+                        allAlerts.addAll(chainAlerts);
+                        Log.d(TAG, "Chains: " + chainAlerts.size() + " alerts");
+                    } catch (Exception e) {
+                        Log.w(TAG, "Chain controls unavailable this cycle: " + e.getClass().getSimpleName());
+                        chainsFuture.cancel(true);
                     }
                 }
 

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -137,6 +137,7 @@ public class SabreService extends Service {
             pp.edit().putLong("update_check_ms", System.currentTimeMillis()).apply();
             if (r == null) return;
             if (!UpdateChecker.isNewer(r.latestVersion, BuildConfig.VERSION_NAME)) return;
+            if (!ChpConfig.load(this).updateNotifyEnabled) return;   // user silenced update notifications
             if (r.latestVersion.equals(pp.getString("update_notified_version", null))) return;
             postUpdateNotification(r);
             pp.edit().putString("update_notified_version", r.latestVersion).apply();
@@ -257,7 +258,7 @@ public class SabreService extends Service {
                         ? fetchExecutor.submit(() -> lcsSource.fetchAlerts(lat, lon, radius))
                         : null;
                 Future<List<SabreAlert>> fireFuture = chpConfig.fireEnabled
-                        ? fetchExecutor.submit(() -> fireSource.fetchAlerts(lat, lon, radius))
+                        ? fetchExecutor.submit(() -> fireSource.fetchAlerts(lat, lon, radius, chpConfig.fireMinAcres))
                         : null;
                 Future<List<SabreAlert>> chainsFuture = chpConfig.chainsEnabled
                         ? fetchExecutor.submit(() -> chainsSource.fetchAlerts(lat, lon, radius))
@@ -282,8 +283,14 @@ public class SabreService extends Service {
                 if (wazeMs > 500) {
                     try {
                         List<SabreAlert> wazeAlerts = wazeFuture.get(wazeMs, TimeUnit.MILLISECONDS);
-                        allAlerts.addAll(wazeAlerts);
-                        Log.d(TAG, "Waze: " + wazeAlerts.size() + " alerts");
+                        int kept = 0;
+                        for (SabreAlert wa : wazeAlerts) {
+                            if (chpConfig.isWazeCategoryEnabled(AlertMapper.wazeCategory(wa.type))) {
+                                allAlerts.add(wa);
+                                kept++;
+                            }
+                        }
+                        Log.d(TAG, "Waze: " + kept + "/" + wazeAlerts.size() + " alerts (after category filter)");
                     } catch (Exception e) {
                         Log.w(TAG, "Waze unavailable this cycle: " + e.getClass().getSimpleName());
                         wazeFuture.cancel(true);

--- a/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
@@ -77,8 +77,12 @@ public class WildfireSource {
     private final AtomicBoolean refreshing = new AtomicBoolean(false);
     private volatile Snapshot cache = null;
 
-    /** Active wildfires within the radius, served from the cache. Never blocks. */
-    public List<SabreAlert> fetchAlerts(double lat, double lon, double radiusMeters) {
+    /**
+     * Active wildfires within the radius, served from the cache. Never blocks.
+     * Fires with a known size below {@code minAcres} are hidden (0 = show all;
+     * unknown-size fires are always shown).
+     */
+    public List<SabreAlert> fetchAlerts(double lat, double lon, double radiusMeters, int minAcres) {
         triggerRefreshIfStale();
         Snapshot snap = cache;
         if (snap == null || (System.currentTimeMillis() - snap.timeMs) > CACHE_MAX_SERVE_MS) {
@@ -86,6 +90,7 @@ public class WildfireSource {
         }
         List<SabreAlert> out = new ArrayList<>();
         for (Fire f : snap.fires) {
+            if (minAcres > 0 && f.sizeAcres >= 0 && f.sizeAcres < minAcres) continue;
             if (CHPSource.haversineMeters(lat, lon, f.lat, f.lon) > radiusMeters) continue;
             out.add(toAlert(f));
         }

--- a/app/src/main/java/app/sabre/wzsabre/WinterSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/WinterSource.java
@@ -1,0 +1,236 @@
+package app.sabre.wzsabre;
+
+import android.util.Log;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserFactory;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.net.ssl.HttpsURLConnection;
+
+/**
+ * Caltrans chain-control (winter) requirements, from the per-district feeds at
+ * {@code https://cwwp2.dot.ca.gov/data/d<N>/cc/ccStatusD<NN>.xml} — the same CWWP
+ * portal and per-district shape as {@link LcsSource}, so district selection and the
+ * async-cache pattern are shared.
+ *
+ * <p>Each record is a single point on a mountain route with a status: {@code R-0}
+ * (none), {@code R-1} (chains or snow tires), {@code R-2} (chains except 4WD w/ snow
+ * tires), {@code R-3} (chains all vehicles). Records with an active level (not R-0)
+ * are shown as a slippery-road hazard. Off-season the feed is all R-0, so nothing
+ * shows.
+ */
+public class WinterSource {
+    private static final String TAG = "WinterSource";
+
+    private static final long CACHE_TTL_MS       = 5 * 60_000L;
+    private static final long CACHE_MAX_SERVE_MS = 30 * 60_000L;
+    private static final int  TIMEOUT_MS         = 25_000;
+
+    private static final TimeZone TZ_PACIFIC = TimeZone.getTimeZone("America/Los_Angeles");
+
+    static String feedUrl(int district) {
+        return String.format(Locale.US,
+                "https://cwwp2.dot.ca.gov/data/d%d/cc/ccStatusD%02d.xml", district, district);
+    }
+
+    // ── Parsed record ─────────────────────────────────────────────────────────
+
+    static final class ChainControl {
+        String index;
+        double lat, lon;
+        String route = "", locationName = "", nearbyPlace = "";
+        String status = "", statusDescription = "";
+        String statusDate = "", statusTime = "";
+        boolean inService;
+    }
+
+    private static final class CacheEntry {
+        final List<ChainControl> records;
+        final long timeMs;
+        CacheEntry(List<ChainControl> records, long timeMs) {
+            this.records = records;
+            this.timeMs = timeMs;
+        }
+    }
+
+    private final Map<Integer, CacheEntry> cache = new ConcurrentHashMap<>();
+    private final Map<Integer, AtomicBoolean> refreshing = new ConcurrentHashMap<>();
+    private final ExecutorService refreshExec = Executors.newSingleThreadExecutor();
+
+    /** Active chain controls within the radius, served from the district caches. */
+    public List<SabreAlert> fetchAlerts(double lat, double lon, double radiusMeters) {
+        long now = System.currentTimeMillis();
+        List<SabreAlert> out = new ArrayList<>();
+        for (int district : LcsSource.districtsFor(lat, lon, radiusMeters)) {
+            CacheEntry entry = cache.get(district);
+            if (entry == null || (now - entry.timeMs) > CACHE_TTL_MS) scheduleRefresh(district);
+            if (entry == null || (now - entry.timeMs) > CACHE_MAX_SERVE_MS) continue;
+            for (ChainControl c : entry.records) {
+                if (!isActive(c)) continue;
+                if (CHPSource.haversineMeters(lat, lon, c.lat, c.lon) > radiusMeters) continue;
+                out.add(toAlert(c));
+            }
+        }
+        return out;
+    }
+
+    /** Warm the caches for a location at service start. */
+    public void prewarm(double lat, double lon, double radiusMeters) {
+        for (int district : LcsSource.districtsFor(lat, lon, radiusMeters)) scheduleRefresh(district);
+    }
+
+    public void shutdown() { refreshExec.shutdownNow(); }
+
+    private void scheduleRefresh(final int district) {
+        AtomicBoolean flag = refreshing.computeIfAbsent(district, d -> new AtomicBoolean(false));
+        if (!flag.compareAndSet(false, true)) return;
+        refreshExec.submit(() -> {
+            try {
+                List<ChainControl> parsed = fetchDistrict(district);
+                cache.put(district, new CacheEntry(parsed, System.currentTimeMillis()));
+                int total = 0;
+                for (CacheEntry ce : cache.values()) total += ce.records.size();
+                SourceStatus.success(SabreResponseBuilder.SOURCE_CHAINS, total);
+                Log.d(TAG, "D" + district + " chain controls: " + parsed.size() + " records");
+            } catch (Exception e) {
+                SourceStatus.failure(SabreResponseBuilder.SOURCE_CHAINS,
+                        "D" + district + " " + e.getClass().getSimpleName());
+                Log.w(TAG, "D" + district + " chain-control refresh failed: "
+                        + e.getClass().getSimpleName() + ": " + e.getMessage());
+            } finally {
+                flag.set(false);
+            }
+        });
+    }
+
+    private List<ChainControl> fetchDistrict(int district) throws Exception {
+        URL url = new URL(feedUrl(district));
+        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+        conn.setConnectTimeout(TIMEOUT_MS);
+        conn.setReadTimeout(TIMEOUT_MS);
+        conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Linux; Android 14)");
+        try (InputStream in = conn.getInputStream()) {
+            return parse(in);
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    // ── Streaming XML parse ──────────────────────────────────────────────────
+
+    static List<ChainControl> parse(InputStream in) throws Exception {
+        List<ChainControl> out = new ArrayList<>();
+        XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
+        XmlPullParser parser = factory.newPullParser();
+        parser.setInput(new InputStreamReader(in, "ISO-8859-1"));
+
+        ChainControl c = null;
+        StringBuilder text = new StringBuilder();
+        String currentTag = null;
+
+        int eventType = parser.getEventType();
+        while (eventType != XmlPullParser.END_DOCUMENT) {
+            switch (eventType) {
+                case XmlPullParser.START_TAG:
+                    currentTag = parser.getName();
+                    text.setLength(0);
+                    if ("cc".equals(currentTag)) c = new ChainControl();
+                    break;
+
+                case XmlPullParser.TEXT:
+                    text.append(parser.getText());
+                    break;
+
+                case XmlPullParser.END_TAG:
+                    String tag = parser.getName();
+                    String v = text.toString().trim();
+                    text.setLength(0);
+                    if (c != null && !v.isEmpty() && tag.equals(currentTag)) {
+                        switch (tag) {
+                            case "index":             c.index = v; break;
+                            case "latitude":          c.lat = parseDouble(v); break;
+                            case "longitude":         c.lon = parseDouble(v); break;
+                            case "route":             c.route = v; break;
+                            case "locationName":      c.locationName = v; break;
+                            case "nearbyPlace":       c.nearbyPlace = v; break;
+                            case "inService":         c.inService = "true".equalsIgnoreCase(v); break;
+                            case "status":            c.status = v; break;
+                            case "statusDescription": c.statusDescription = v; break;
+                            case "statusDate":        c.statusDate = v; break;
+                            case "statusTime":        c.statusTime = v; break;
+                        }
+                    }
+                    if ("cc".equals(tag)) {
+                        if (c != null && c.index != null) out.add(c);
+                        c = null;
+                    }
+                    break;
+            }
+            try {
+                eventType = parser.next();
+            } catch (Exception e) {
+                Log.w(TAG, "chain-control feed parse error — salvaged " + out.size() + " records");
+                break;
+            }
+        }
+        return out;
+    }
+
+    private static double parseDouble(String v) {
+        try { return Double.parseDouble(v); } catch (Exception e) { return 0.0; }
+    }
+
+    // ── Filtering + mapping ───────────────────────────────────────────────────
+
+    /** Active = in service, has coordinates, and a chain-control level above R-0. */
+    static boolean isActive(ChainControl c) {
+        if (!c.inService) return false;
+        if (c.lat == 0.0 && c.lon == 0.0) return false;
+        if (c.status == null || c.status.isEmpty()) return false;
+        return !c.status.equalsIgnoreCase("R-0");
+    }
+
+    static SabreAlert toAlert(ChainControl c) {
+        long reportTs = parseStatusTs(c.statusDate, c.statusTime);
+        if (reportTs <= 0) reportTs = System.currentTimeMillis() / 1000L;
+        return new SabreAlert("cc_" + c.index, SabreResponseBuilder.SOURCE_CHAINS,
+                "HAZARD_ON_ROAD_SLIPPERY", c.lat, c.lon,
+                SabreResponseBuilder.HEADING_UNKNOWN, describe(c), reportTs);
+    }
+
+    static String describe(ChainControl c) {
+        StringBuilder sb = new StringBuilder("Chains ").append(c.status);
+        if (!c.route.isEmpty()) sb.append(" · ").append(c.route);
+        if (!c.locationName.isEmpty()) sb.append(" @ ").append(c.locationName);
+        if (!c.nearbyPlace.isEmpty()) sb.append(" (").append(c.nearbyPlace).append(')');
+        return sb.toString();
+    }
+
+    private static long parseStatusTs(String date, String time) {
+        if (date == null || date.isEmpty() || time == null || time.isEmpty()) return 0;
+        try {
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
+            sdf.setTimeZone(TZ_PACIFIC);
+            sdf.setLenient(false);
+            Date d = sdf.parse(date + " " + time);
+            return d != null ? d.getTime() / 1000L : 0;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -186,6 +186,30 @@
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:background="#FFFFFF"
+            android:elevation="1dp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="16dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Only show fires at least"
+                android:textSize="13sp"
+                android:textColor="#757575"
+                android:layout_marginBottom="4dp" />
+
+            <Spinner
+                android:id="@+id/fireSizeSpinner"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
         <!-- ── Chain controls ─────────────────────────────────────────────── -->
         <TextView
             android:layout_width="match_parent"
@@ -275,6 +299,67 @@
 
             <Spinner
                 android:id="@+id/ageSpinner"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <!-- ── Waze filters ───────────────────────────────────────────────── -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="WAZE FILTERS"
+            android:textSize="11sp"
+            android:textStyle="bold"
+            android:textColor="#757575"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="20dp"
+            android:paddingBottom="6dp" />
+
+        <LinearLayout
+            android:id="@+id/wazeFilterContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:background="#FFFFFF"
+            android:elevation="1dp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp" />
+
+        <!-- ── Notifications ──────────────────────────────────────────────── -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="NOTIFICATIONS"
+            android:textSize="11sp"
+            android:textStyle="bold"
+            android:textColor="#757575"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="20dp"
+            android:paddingBottom="6dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:background="#FFFFFF"
+            android:elevation="1dp"
+            android:padding="16dp">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Notify me when a plugin update is available"
+                android:textSize="14sp"
+                android:textColor="#212121" />
+
+            <Switch
+                android:id="@+id/updateNotifySwitch"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content" />
         </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -186,6 +186,56 @@
                 android:layout_height="wrap_content" />
         </LinearLayout>
 
+        <!-- ── Chain controls ─────────────────────────────────────────────── -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="CHAIN CONTROLS"
+            android:textSize="11sp"
+            android:textStyle="bold"
+            android:textColor="#757575"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="20dp"
+            android:paddingBottom="6dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:background="#FFFFFF"
+            android:elevation="1dp"
+            android:padding="16dp">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Winter chain controls"
+                    android:textSize="14sp"
+                    android:textColor="#212121" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Caltrans chain requirements (R-1/R-2/R-3) on mountain routes. Off-season this shows nothing."
+                    android:textSize="12sp"
+                    android:textColor="#757575"
+                    android:layout_marginTop="2dp" />
+            </LinearLayout>
+
+            <Switch
+                android:id="@+id/chainsSwitch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
         <!-- ── Incident Age ───────────────────────────────────────────────── -->
         <TextView
             android:layout_width="match_parent"

--- a/app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java
@@ -49,6 +49,17 @@ public class AlertMapperTest {
     @Test public void waze_unknown_returnsNull() { assertNull(AlertMapper.fromWazeType("WEATHERHAZARD", "")); }
     @Test public void waze_null_returnsNull()    { assertNull(AlertMapper.fromWazeType(null, "")); }
 
+    // ── Waze coarse category (settings filters) ─────────────────────────────────
+
+    @Test public void wazeCategory_police()    { assertEquals("police",    AlertMapper.wazeCategory("POLICE_HIDING")); }
+    @Test public void wazeCategory_camera()    { assertEquals("police",    AlertMapper.wazeCategory("DEFAULT_CAMERA")); }
+    @Test public void wazeCategory_accident()  { assertEquals("accidents", AlertMapper.wazeCategory("ACCIDENT_MAJOR")); }
+    @Test public void wazeCategory_jam()       { assertEquals("jams",      AlertMapper.wazeCategory("JAM_HEAVY_TRAFFIC")); }
+    @Test public void wazeCategory_closure()   { assertEquals("closures",  AlertMapper.wazeCategory("ROAD_CLOSED")); }
+    @Test public void wazeCategory_hazardDefault() { assertEquals("hazards", AlertMapper.wazeCategory("HAZARD_ON_ROAD_CAR_STOPPED")); }
+    @Test public void wazeCategory_sosIsHazard()   { assertEquals("hazards", AlertMapper.wazeCategory("SOS_MEDICAL_HELP")); }
+    @Test public void wazeCategory_null()      { assertEquals("hazards",   AlertMapper.wazeCategory(null)); }
+
     // ── locale independence ───────────────────────────────────────────────────
 
     @Test

--- a/app/src/test/java/app/sabre/wzsabre/WinterSourceTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/WinterSourceTest.java
@@ -1,0 +1,111 @@
+package app.sabre.wzsabre;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/** Tests Caltrans chain-control (cc) feed parsing, active filtering, and SABRE mapping. */
+public class WinterSourceTest {
+
+    private static String record(String index, double lat, double lon, String route,
+                                 String locName, String nearby, boolean inService, String status) {
+        return "<cc><index>" + index + "</index>" +
+            "<recordTimestamp><recordDate>2026-01-05</recordDate><recordTime>08:00:00</recordTime></recordTimestamp>" +
+            "<location>" +
+            "<district>10</district>" +
+            "<locationName>" + locName + "</locationName>" +
+            "<nearbyPlace>" + nearby + "</nearbyPlace>" +
+            "<longitude>" + lon + "</longitude>" +
+            "<latitude>" + lat + "</latitude>" +
+            "<elevation>7000</elevation>" +
+            "<direction>West</direction>" +
+            "<county>Alpine</county>" +
+            "<route>" + route + "</route>" +
+            "</location>" +
+            "<inService>" + inService + "</inService>" +
+            "<statusData>" +
+            "<statusTimestamp><statusDate>2026-01-05</statusDate><statusTime>07:30:00</statusTime></statusTimestamp>" +
+            "<status>" + status + "</status>" +
+            "<statusDescription>Chain control desc.</statusDescription>" +
+            "</statusData></cc>";
+    }
+
+    private static String feed(String... records) {
+        StringBuilder sb = new StringBuilder("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><data>");
+        for (String r : records) sb.append(r);
+        return sb.append("</data>").toString();
+    }
+
+    private static List<WinterSource.ChainControl> parse(String xml) throws Exception {
+        return WinterSource.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.ISO_8859_1)));
+    }
+
+    @Test
+    public void parse_readsFields() throws Exception {
+        WinterSource.ChainControl c = parse(feed(
+                record("10-ALP-4-0.65-W", 38.4605, -120.0448, "SR-4", "BEAR VALLEY", "Arnold", true, "R-2")))
+                .get(0);
+        assertEquals("10-ALP-4-0.65-W", c.index);
+        assertEquals(38.4605, c.lat, 1e-6);
+        assertEquals(-120.0448, c.lon, 1e-6);
+        assertEquals("SR-4", c.route);
+        assertEquals("BEAR VALLEY", c.locationName);
+        assertEquals("Arnold", c.nearbyPlace);
+        assertTrue(c.inService);
+        assertEquals("R-2", c.status);
+    }
+
+    @Test
+    public void isActive_levelAboveR0_whenInService() throws Exception {
+        WinterSource.ChainControl c = parse(feed(
+                record("i", 38.46, -120.04, "SR-4", "X", "Y", true, "R-2"))).get(0);
+        assertTrue(WinterSource.isActive(c));
+    }
+
+    @Test
+    public void isActive_r0_isInactive() throws Exception {
+        WinterSource.ChainControl c = parse(feed(
+                record("i", 38.46, -120.04, "SR-4", "X", "Y", true, "R-0"))).get(0);
+        assertFalse("R-0 = no chain control, must not alert", WinterSource.isActive(c));
+    }
+
+    @Test
+    public void isActive_notInService_isInactive() throws Exception {
+        WinterSource.ChainControl c = parse(feed(
+                record("i", 38.46, -120.04, "SR-4", "X", "Y", false, "R-2"))).get(0);
+        assertFalse(WinterSource.isActive(c));
+    }
+
+    @Test
+    public void isActive_missingCoords_isInactive() throws Exception {
+        WinterSource.ChainControl c = parse(feed(
+                record("i", 0.0, 0.0, "SR-4", "X", "Y", true, "R-2"))).get(0);
+        assertFalse(WinterSource.isActive(c));
+    }
+
+    @Test
+    public void toAlert_validSabreFields() throws Exception {
+        WinterSource.ChainControl c = parse(feed(
+                record("10-ALP-4-0.65-W", 38.4605, -120.0448, "SR-4", "BEAR VALLEY", "Arnold", true, "R-2")))
+                .get(0);
+        SabreAlert a = WinterSource.toAlert(c);
+        assertEquals("cc_10-ALP-4-0.65-W", a.alertId);
+        assertEquals(SabreResponseBuilder.SOURCE_CHAINS, a.alertSource);
+        assertEquals("HAZARD_ON_ROAD_SLIPPERY", a.type);
+        assertTrue(SabreResponseBuilder.isValidType(a.type));
+        assertEquals(SabreResponseBuilder.HEADING_UNKNOWN, a.headingDeg, 0.0);
+        assertTrue("report_ts parsed from statusTimestamp", a.reportTs > 0);
+        assertTrue(a.reportTs <= Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void describe_format() throws Exception {
+        WinterSource.ChainControl c = parse(feed(
+                record("i", 38.46, -120.04, "SR-4", "BEAR VALLEY", "Arnold", true, "R-2"))).get(0);
+        assertEquals("Chains R-2 · SR-4 @ BEAR VALLEY (Arnold)", WinterSource.describe(c));
+    }
+}


### PR DESCRIPTION
A new source and a set of noise/UX controls.

## New source
- **Chain controls (winter)** — Caltrans chain requirements (R-1/R-2/R-3) on mountain routes, from the per-district CWWP `cc` feeds (same portal/shape as LCS, so it reuses district selection + the async-cache pattern). Shown as slippery-road hazards; off-season the feed is all R-0 so nothing shows. New `chains` source, settings toggle, diagnostics row.

## Quality-of-life
- **Waze category filters** — coarse per-class toggles (police & cameras / accidents / hazards / traffic jams / road closures).
- **Wildfire size threshold** — hide small fires (All / 10+ / 100+ / 1000+ acres).
- **Update-notification toggle** — silence the update notification, keep the in-app banner.
- **Diagnostics: Refresh button + last-crash line** — on-device crash capture (new `App` uncaught-exception handler) surfaced in the panel; tap to clear.

228 unit tests (new: WinterSource, Waze-category classifier, wildfire error/RX filter, cross-source dedupe), `lintDebug` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)