### PR TITLE
Fix chain-control 404 hammering (from real-drive logs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.7.1] — 2026-07-02
+
+Fix found from a real test drive.
+
+### Fixed
+- **Chain controls stop hammering feeds that don't exist.** In regions with no mountain routes (e.g. the Bay Area), Caltrans returns "not found" for the chain-control feed. The plugin was re-requesting those every few seconds all drive and showing a false error in Diagnostics; it now treats "not found" as "no chain controls here" and caches it like any other result.
+
 ## [1.7] — 2026-07-02
 
 New source and quality-of-life controls.
@@ -99,6 +106,7 @@ Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrot
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
+[1.7.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7.1
 [1.7]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7
 [1.6.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.6.1
 [1.6]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.6

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 10
-        versionName = "1.7"
+        versionCode = 11
+        versionName = "1.7.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/WinterSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/WinterSource.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserFactory;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -124,8 +125,18 @@ public class WinterSource {
         conn.setConnectTimeout(TIMEOUT_MS);
         conn.setReadTimeout(TIMEOUT_MS);
         conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Linux; Android 14)");
-        try (InputStream in = conn.getInputStream()) {
-            return parse(in);
+        try {
+            int code = conn.getResponseCode();
+            // Flatland districts (e.g. D4 Bay Area, D5 Central Coast) publish no
+            // chain-control feed and return 404 — that's "no chain controls here",
+            // not an error. Return empty so it's cached like a normal result: no red
+            // diagnostics, and no re-request every ~15s (previously we never cached a
+            // failure, so a permanent 404 hammered the feed all drive).
+            if (code == HttpsURLConnection.HTTP_NOT_FOUND) return new ArrayList<>();
+            if (code != HttpsURLConnection.HTTP_OK) throw new IOException("HTTP " + code);
+            try (InputStream in = conn.getInputStream()) {
+                return parse(in);
+            }
         } finally {
             conn.disconnect();
         }


### PR DESCRIPTION
Real test-drive logs showed the chain-control source re-requesting the D4/D5 feeds every ~15s (they 404 — no mountain routes there), never caching the failure. Now a 404 is treated as 'no chain controls here' (empty, cached on the normal cadence) instead of an error. v1.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)