### PR TITLE
Downloads badge + in-app bug-report link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.7.2] — 2026-07-02
+
+### Added
+- **"Report a bug / send feedback" button** in the settings screen — opens the GitHub issue form in your browser, pre-filled with your plugin and Android version. (No new permissions.)
+
 ## [1.7.1] — 2026-07-02
 
 Fix found from a real test drive.
@@ -106,6 +111,7 @@ Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrot
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
+[1.7.2]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7.2
 [1.7.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7.1
 [1.7]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7
 [1.6.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.6.1

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![CI](https://github.com/nicglazkov/caltrans-sabre/actions/workflows/ci.yml/badge.svg)](https://github.com/nicglazkov/caltrans-sabre/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/v/release/nicglazkov/caltrans-sabre?sort=semver)](https://github.com/nicglazkov/caltrans-sabre/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/nicglazkov/caltrans-sabre/total)](https://github.com/nicglazkov/caltrans-sabre/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Android 7.0+](https://img.shields.io/badge/Android-7.0%2B-3DDC84?logo=android&logoColor=white)](#requirements)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 11
-        versionName = "1.7.1"
+        versionCode = 12
+        versionName = "1.7.2"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -61,7 +61,31 @@ public class MainActivity extends Activity {
         buildUpdateNotifySwitch();
         buildAgeSpinner();
         buildDiagnostics();
+        buildReportButton();
         checkForUpdate();
+    }
+
+    /**
+     * Opens the GitHub bug-report issue form in the browser, pre-filling the plugin
+     * and Android versions. Uses ACTION_VIEW (no permission needed).
+     */
+    private void buildReportButton() {
+        findViewById(R.id.reportButton).setOnClickListener(v -> {
+            String url = "https://github.com/nicglazkov/caltrans-sabre/issues/new"
+                    + "?template=bug_report.yml"
+                    + "&plugin-version=" + Uri.encode(BuildConfig.VERSION_NAME)
+                    + "&android-version=" + Uri.encode(
+                            "Android " + Build.VERSION.RELEASE + " (" + Build.MODEL + ")");
+            try {
+                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+            } catch (Exception e) {
+                // No browser / template unavailable — fall back to the issues list.
+                try {
+                    startActivity(new Intent(Intent.ACTION_VIEW,
+                            Uri.parse("https://github.com/nicglazkov/caltrans-sabre/issues")));
+                } catch (Exception ignored) {}
+            }
+        });
     }
 
     private void buildFireSizeSpinner() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -421,6 +421,13 @@
                 android:textSize="13sp"
                 android:textColor="#424242"
                 android:layout_marginTop="6dp" />
+
+            <Button
+                android:id="@+id/reportButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Report a bug / send feedback"
+                android:layout_marginTop="10dp" />
         </LinearLayout>
 
     </LinearLayout>


### PR DESCRIPTION
Adds a shields.io downloads badge to the README, and a 'Report a bug / send feedback' button in the settings screen that opens the GitHub issue form (pre-filled with plugin + Android version) via the browser — no new permission. v1.7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)