### PR TITLE
Remove em dashes from user-facing text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,64 +2,69 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
-## [1.7.2] — 2026-07-02
+## [1.7.3] - 2026-07-06
+
+### Changed
+- Tidied wording across the app, README, and release notes.
+
+## [1.7.2] - 2026-07-02
 
 ### Added
-- **"Report a bug / send feedback" button** in the settings screen — opens the GitHub issue form in your browser, pre-filled with your plugin and Android version. (No new permissions.)
+- **"Report a bug / send feedback" button** in the settings screen, opens the GitHub issue form in your browser, pre-filled with your plugin and Android version. (No new permissions.)
 
-## [1.7.1] — 2026-07-02
+## [1.7.1] - 2026-07-02
 
 Fix found from a real test drive.
 
 ### Fixed
 - **Chain controls stop hammering feeds that don't exist.** In regions with no mountain routes (e.g. the Bay Area), Caltrans returns "not found" for the chain-control feed. The plugin was re-requesting those every few seconds all drive and showing a false error in Diagnostics; it now treats "not found" as "no chain controls here" and caches it like any other result.
 
-## [1.7] — 2026-07-02
+## [1.7] - 2026-07-02
 
 New source and quality-of-life controls.
 
 ### Added
-- **Chain controls** — Caltrans winter chain requirements (R-1/R-2/R-3) on mountain routes, shown as slippery-road hazards. Settings toggle (on by default); off-season it shows nothing.
-- **Waze filters** — coarse per-category toggles (police & cameras / accidents / hazards / traffic jams / road closures) to cut noise.
-- **Wildfire size threshold** — optionally hide small fires (All / 10+ / 100+ / 1000+ acres).
-- **Update-notification toggle** — silence the update notification while keeping the in-app banner.
-- **Diagnostics: Refresh button + last-crash line** — poke a refresh and see the most recent crash (on-device only), which makes bug reports far more useful.
+- **Chain controls**: Caltrans winter chain requirements (R-1/R-2/R-3) on mountain routes, shown as slippery-road hazards. Settings toggle (on by default); off-season it shows nothing.
+- **Waze filters**: coarse per-category toggles (police & cameras / accidents / hazards / traffic jams / road closures) to cut noise.
+- **Wildfire size threshold**: optionally hide small fires (All / 10+ / 100+ / 1000+ acres).
+- **Update-notification toggle**: silence the update notification while keeping the in-app banner.
+- **Diagnostics: Refresh button + last-crash line**: poke a refresh and see the most recent crash (on-device only), which makes bug reports far more useful.
 
-## [1.6.1] — 2026-07-02
+## [1.6.1] - 2026-07-02
 
 Hardening from a post-release review of v1.6.
 
 ### Fixed
-- Wildfire outages no longer look like "no active fires" — a broken feed now surfaces as an error in diagnostics, and prescribed burns can't slip in as wildfires.
+- Wildfire outages no longer look like "no active fires", a broken feed now surfaces as an error in diagnostics, and prescribed burns can't slip in as wildfires.
 - Duplicate-pin merging now only collapses pins from *different* sources, so two genuinely separate incidents at the same spot are never dropped (also restores the debug "one of each type" harness).
 - The update check no longer leaks the settings screen on rotation and no longer calls GitHub on every open.
 - Automated release is now re-runnable, requires all signing secrets before it attempts to sign, and skips cleanly otherwise.
 - Minor: diagnostics status is now a consistent snapshot; the wildfire source isn't fetched when disabled.
 
-## [1.6] — 2026-07-02
+## [1.6] - 2026-07-02
 
 New data source, in-app updates, and quality-of-life.
 
 ### Added
-- **Wildfires** — active California wildfires (name, size, containment) from the interagency WFIGS feed, shown as road hazards near the fire. New settings toggle (on by default).
-- **Update checking** — the settings screen shows an "update available" banner, and you get a single notification per new version (no spam). README documents an Obtainium option for hands-off auto-update.
-- **Diagnostics panel** — the settings screen shows each source's last update time, item count, and last error.
-- **Automated releases** — pushing a version tag builds a signed APK and publishes the GitHub release via CI.
+- **Wildfires**: active California wildfires (name, size, containment) from the interagency WFIGS feed, shown as road hazards near the fire. New settings toggle (on by default).
+- **Update checking**: the settings screen shows an "update available" banner, and you get a single notification per new version (no spam). README documents an Obtainium option for hands-off auto-update.
+- **Diagnostics panel**: the settings screen shows each source's last update time, item count, and last error.
+- **Automated releases**: pushing a version tag builds a signed APK and publishes the GitHub release via CI.
 
 ### Changed
 - Duplicate pins reported by more than one source (e.g. a CHP and a Waze accident at the same spot) are now merged into one.
 - CI actions updated; the debug/release build is unchanged.
 
-## [1.5.1] — 2026-07-01
+## [1.5.1] - 2026-07-01
 
 Follow-up hardening from an independent post-release review of 1.5, plus repo hygiene.
 
 ### Fixed
-- **Waze in-band errors** — a benign informational error attached to a normal response no longer fails every refresh; only real server errors (HTTP 500-class) or session/credential errors trigger recovery.
-- **Waze rejection backoff** — the backoff timer is now visible across threads (it wasn't, so the throttle could be skipped); non-rejection failures back off briefly instead of retrying at poll cadence; a bad account recovers after the 24-hour registration window rolls over.
-- **Waze ghost prevention** — the cache is only reset once a new session's first query succeeds, so a re-login followed by a dropped query no longer blanks Waze.
-- **CHP conditional fetch** — cache validators are committed only after a successful download+parse, so a mid-download failure can't leave the cache empty.
-- **Service lifecycle** — a stopping service can't be resurrected by a late shutdown; the full alert payload is no longer logged in release builds; the exported startup activity only accepts callbacks to Highway Radar; two rapid requests can't clobber each other's start alarm.
+- **Waze in-band errors**: a benign informational error attached to a normal response no longer fails every refresh; only real server errors (HTTP 500-class) or session/credential errors trigger recovery.
+- **Waze rejection backoff**: the backoff timer is now visible across threads (it wasn't, so the throttle could be skipped); non-rejection failures back off briefly instead of retrying at poll cadence; a bad account recovers after the 24-hour registration window rolls over.
+- **Waze ghost prevention**: the cache is only reset once a new session's first query succeeds, so a re-login followed by a dropped query no longer blanks Waze.
+- **CHP conditional fetch**: cache validators are committed only after a successful download+parse, so a mid-download failure can't leave the cache empty.
+- **Service lifecycle**: a stopping service can't be resurrected by a late shutdown; the full alert payload is no longer logged in release builds; the exported startup activity only accepts callbacks to Highway Radar; two rapid requests can't clobber each other's start alarm.
 
 ### Added
 - GitHub Actions CI (unit tests + lint + debug APK on every push/PR).
@@ -68,49 +73,50 @@ Follow-up hardening from an independent post-release review of 1.5, plus repo hy
 ### Changed
 - Pinned the Gradle wrapper distribution checksum; `assembleRelease` without a keystore now produces an unsigned APK with a clear warning instead of a cryptic failure.
 
-## [1.5] — 2026-07-01
+## [1.5] - 2026-07-01
 
 Data-reliability release: keeps Waze and CHP alerts accurate and always flowing.
 
 ### Fixed
-- **Waze can no longer lock itself out** — a run of connection rejections used to mint a new anonymous account every couple of seconds; now bounded by exponential backoff and a per-day cap.
+- **Waze can no longer lock itself out**: a run of connection rejections used to mint a new anonymous account every couple of seconds; now bounded by exponential backoff and a per-day cap.
 - **Waze recovers instead of going silent** when the server invalidates a session mid-drive (in-band error detection).
 - **No more stale "ghost" alerts** lingering after they clear (cache cleared on session change).
-- **CHP alerts stop flapping** — served from a background last-good cache with conditional GETs; a slow CHP feed can no longer delay Waze/closure alerts.
+- **CHP alerts stop flapping**: served from a background last-good cache with conditional GETs; a slow CHP feed can no longer delay Waze/closure alerts.
 - A bad heading can't blank a whole update; correct behavior on non-English device locales; Caltrans auxiliary-lane closures are now shown; LCS closures never emit a 1970 timestamp.
 
-## [1.4] — 2026-07-01
+## [1.4] - 2026-07-01
 
 Lifecycle, crashes, and privacy.
 
 ### Fixed
-- **No more daily crash on Android 15/16** — the background service ran into Android 15's ~6-hour data-sync limit; it now runs as a `specialUse` service with no such cap.
+- **No more daily crash on Android 15/16**: the background service ran into Android 15's ~6-hour data-sync limit; it now runs as a `specialUse` service with no such cap.
 - **Fixed a crash on Android 10 and 11** that stopped the plugin from working at all on those versions.
-- **Closed a privacy leak** — alert replies are delivered only to Highway Radar (previously any app on the device could listen in).
+- **Closed a privacy leak**: alert replies are delivered only to Highway Radar (previously any app on the device could listen in).
 - Waze credentials are no longer included in device backups.
 
 ### Added
-- **Stops when Highway Radar closes** — the plugin now runs only while Highway Radar is open and shuts down cleanly afterward.
+- **Stops when Highway Radar closes**: the plugin now runs only while Highway Radar is open and shuts down cleanly afterward.
 
 ### Changed
 - Minimum Android version is now 7.0.
 
-## [1.3] — 2026-06-10
+## [1.3] - 2026-06-10
 
 Waze RT faithful-port: delta-merge cache, shrinking-box queries, session pre-warm, `-720` directionless heading, raw subtype passthrough, crowd-confirmation fields, and 200-alert response batching.
 
-## [1.2] — 2026-06-09
+## [1.2] - 2026-06-09
 
 Added Caltrans lane/road closures (LCS) as a data source, plus reliability fixes.
 
-## [1.1] — 2026-06-09
+## [1.1] - 2026-06-09
 
 Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrote the Waze integration onto the mobile RT protocol after the georss API was blocked.
 
-## [1.0] — 2026-03-26
+## [1.0] - 2026-03-26
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
+[1.7.3]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7.3
 [1.7.2]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7.2
 [1.7.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7.1
 [1.7]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 An open-source **Highway Radar SABRE plugin** for California, and a drop-in **wzsabre** replacement: it brings live CHP incidents, Waze crowdsourced alerts, Caltrans lane closures, active wildfires, and winter chain controls to [Highway Radar](https://www.highwayradar.com/) via the SABRE plugin protocol.
 
-> **Package ID: `app.sabre.wzsabre`** — same as wzsabre, so Highway Radar discovers this plugin automatically without any reconfiguration.
+> **Package ID: `app.sabre.wzsabre`** (the same as wzsabre), so Highway Radar discovers this plugin automatically without any reconfiguration.
 
 ---
 
@@ -18,13 +18,13 @@ An open-source **Highway Radar SABRE plugin** for California, and a drop-in **wz
 
 | Source | Data | Update cadence |
 |--------|------|----------------|
-| **CHP Live Feed** | Accidents, road closures, debris, officer on road, weather hazards — directly from the California Highway Patrol statewide XML feed | Every HR map refresh |
+| **CHP Live Feed** | Accidents, road closures, debris, officer on road, weather hazards, directly from the California Highway Patrol statewide XML feed | Every HR map refresh |
 | **Waze** | Crowdsourced police, accidents, hazards, road closures | Every HR map refresh |
 | **Caltrans Closures (LCS)** | Lane and road closures that are physically in place right now (CHP code 1097), from the per-district Caltrans Lane Closure System feeds | Cached, refreshed every 5 min |
 | **Wildfires** | Active California wildfires (name, size, containment) from the interagency WFIGS feed, shown as road hazards near the fire | Cached, refreshed every 5 min |
 | **Chain Controls** | Caltrans winter chain requirements (R-1/R-2/R-3) on mountain routes, shown as slippery-road hazards | Cached, refreshed every 5 min |
 
-All sources run in parallel and feed into the standard HR crowdsourced-alerts layer — the same map overlay that wzsabre used to power.
+All sources run in parallel and feed into the standard HR crowdsourced-alerts layer, the same map overlay that wzsabre used to power.
 
 ---
 
@@ -47,23 +47,23 @@ All sources run in parallel and feed into the standard HR crowdsourced-alerts la
 
 ## Installation
 
-### Option A — Download the APK (recommended for most users)
+### Option A: Download the APK (recommended for most users)
 
 1. Go to the [Releases](../../releases) page and download the latest APK.
 2. On your Android device, open **Settings → Security** (or *Install unknown apps*) and allow installs from your browser or file manager. If Google Play Protect warns that the app is unrecognized, tap **More details → Install anyway**.
 3. Open the downloaded APK and tap **Install**.
-4. Open the **CHP + Waze SABRE** app once. On first launch, **allow notifications** and **allow the battery-optimization exemption** when prompted — without these the background service can be frozen and alerts stop.
+4. Open the **CHP + Waze SABRE** app once. On first launch, **allow notifications** and **allow the battery-optimization exemption** when prompted, without these the background service can be frozen and alerts stop.
 5. Open **Highway Radar → Settings → SABRE** and select **CHP + Waze SABRE**.
 
 > **Why the persistent notification?** Android requires a foreground-service notification while the plugin is feeding alerts. The plugin only runs while Highway Radar is open and stops itself shortly after you close HR, so it isn't running (or notifying) in the background the rest of the time.
 
-> **After a phone reboot:** Just open Highway Radar — the plugin starts automatically when HR sends its first request.
+> **After a phone reboot:** Just open Highway Radar, the plugin starts automatically when HR sends its first request.
 
-### Option B — Auto-update with Obtainium
+### Option B: Auto-update with Obtainium
 
 For hands-off updates, install via [Obtainium](https://github.com/ImranR98/Obtainium): add this repo's URL (`https://github.com/nicglazkov/caltrans-sabre`) as an app source and Obtainium will check GitHub Releases and install new versions for you. (The app also shows an in-app banner and a one-time notification when an update is available.)
 
-### Option C — Build from source
+### Option C: Build from source
 
 See [BUILDING.md](BUILDING.md).
 
@@ -71,14 +71,14 @@ See [BUILDING.md](BUILDING.md).
 
 ## Configuration
 
-Open the **CHP + Waze SABRE** app to access settings. All changes take effect immediately on the next HR map refresh — no restart needed.
+Open the **CHP + Waze SABRE** app to access settings. All changes take effect immediately on the next HR map refresh, no restart needed.
 
 ### Alert Categories
 
 Each CHP category has two controls:
 
-- **Toggle (on/off)** — disabled categories are never sent to HR.
-- **"Shows as" picker** — controls which Highway Radar icon is used for that category.
+- **Toggle (on/off)**: disabled categories are never sent to HR.
+- **"Shows as" picker**: controls which Highway Radar icon is used for that category.
 
 | Category | Default HR icon | What it covers |
 |----------|----------------|----------------|
@@ -104,10 +104,10 @@ Options: **No limit / 30 min / 1 hr / 2 hr / 4 hr / 8 hr** (default: 1 hour)
 If you already have wzsabre installed:
 
 1. **Uninstall wzsabre** (Settings → Apps → wzsabre → Uninstall).
-2. Install this APK — it uses the same package ID (`app.sabre.wzsabre`) so HR picks it up without any changes to HR's settings.
+2. Install this APK, it uses the same package ID (`app.sabre.wzsabre`) so HR picks it up without any changes to HR's settings.
 3. Open the new app once to start the service.
 
-> The package ID being identical to wzsabre is intentional — HR's plugin discovery whitelists `app.sabre.wzsabre`, and we reuse it so no HR-side changes are needed.
+> The package ID being identical to wzsabre is intentional: HR's plugin discovery whitelists `app.sabre.wzsabre`, and we reuse it so no HR-side changes are needed.
 
 ---
 
@@ -115,11 +115,11 @@ If you already have wzsabre installed:
 
 **"Crowd-Sourced Alert Problems" banner in HR**
 - Open the CHP + Waze SABRE app and check that the service status shows *"Plugin active"*.
-- Tap the green start button in HR — this sends a fresh handshake.
+- Tap the green start button in HR, this sends a fresh handshake.
 - On Android 15: open this app first, then HR. The background service must be running before HR requests data.
 
 **CHP alerts visible but no Waze alerts**
-- Waze requires a real internet connection. On the very first use the plugin registers an anonymous Waze session in the background — Waze alerts can take ~10–20 seconds to appear that first time. After that the session and a live alert cache are kept warm and pre-loaded at start, so alerts appear within a second or two on subsequent sessions.
+- Waze requires a real internet connection. On the very first use the plugin registers an anonymous Waze session in the background; Waze alerts can take ~10–20 seconds to appear that first time. After that the session and a live alert cache are kept warm and pre-loaded at start, so alerts appear within a second or two on subsequent sessions.
 - Check that the app has network permission (it should request none explicitly; all network access is in the background service).
 
 **No alerts at all**
@@ -150,7 +150,7 @@ Highway Radar  ──broadcast──▶  MainBroadcastReceiver
 ```
 
 - **CHP**: fetches `https://media.chp.ca.gov/sa_xml/sa.xml`, filters by radius and incident age, applies your category settings.
-- **Waze**: emulates the Waze mobile app's binary "RT" protocol — it registers an anonymous Waze session, logs in, and queries crowd-sourced alerts over Waze's protobuf API (the older live-map/georss API is now blocked). The RT feed is session-stateful (each alert is sent once, then removed when it clears), so query results are merged into a persistent alert cache rather than replacing it — this keeps alerts from disappearing as you drive. A series of progressively smaller map viewports is queried so the server doesn't thin out minor alerts near you, the session is pre-warmed at start to cut first-load latency, and Waze alert subtypes (e.g. *car stopped on shoulder*, *heavy traffic*) are passed through to Highway Radar verbatim rather than flattened.
+- **Waze**: emulates the Waze mobile app's binary "RT" protocol. It registers an anonymous Waze session, logs in, and queries crowd-sourced alerts over Waze's protobuf API (the older live-map/georss API is now blocked). The RT feed is session-stateful (each alert is sent once, then removed when it clears), so query results are merged into a persistent alert cache rather than replacing it, this keeps alerts from disappearing as you drive. A series of progressively smaller map viewports is queried so the server doesn't thin out minor alerts near you, the session is pre-warmed at start to cut first-load latency, and Waze alert subtypes (e.g. *car stopped on shoulder*, *heavy traffic*) are passed through to Highway Radar verbatim rather than flattened.
 - **Caltrans LCS**: fetches the per-district lane-closure feeds (`https://cwwp2.dot.ca.gov/data/d<N>/lcs/lcsStatusD<NN>.xml`) for whichever districts cover your location. Only closures that are physically established (CHP code 1097 set, not picked up or canceled) are shown; shoulder-only closures are skipped. Closures longer than 2 km get a pin at each end. The ~4 MB feeds are parsed in the background and cached for 5 minutes, so they never delay a Highway Radar request.
 - **Wildfires**: active California wildfires from the interagency WFIGS "Current Wildland Fire Incident Locations" feed (NIFC-hosted ArcGIS), filtered to active wildfires in California. Each is shown as a road hazard at the fire's location with its name, size, and containment. Background-cached like the other sources. Optional minimum-size filter in settings.
 - **Chain controls**: Caltrans winter chain-control status from the per-district CWWP feeds (`https://cwwp2.dot.ca.gov/data/d<N>/cc/ccStatusD<NN>.xml`). Records at level R-1/R-2/R-3 (in service) are shown as slippery-road hazards; off-season the feed is all R-0 so nothing shows.
@@ -176,7 +176,7 @@ This is an independent, unofficial project. It is **not affiliated with, endorse
 
 - The **Waze** integration works by emulating Waze's private, undocumented mobile protocol using an anonymous session. This may break at any time if Waze changes their protocol, and it may be contrary to Waze's Terms of Service. Use it at your own risk.
 - The **CHP** and **Caltrans** data comes from public government feeds and is provided without any guarantee of accuracy, completeness, or timeliness.
-- This app is provided for personal and educational use, **as-is and without warranty of any kind**. Do not rely on it for safety-critical decisions — always follow real-world road conditions, signage, and the law.
+- This app is provided for personal and educational use, **as-is and without warranty of any kind**. Do not rely on it for safety-critical decisions; always follow real-world road conditions, signage, and the law.
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 12
-        versionName = "1.7.2"
+        versionCode = 13
+        versionName = "1.7.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -224,7 +224,7 @@ public class MainActivity extends Activity {
             cr.setTextColor(0xFFD32F2F);
             long whenMs = 0L;
             try { whenMs = Long.parseLong(crash[0]); } catch (NumberFormatException ignored) {}
-            cr.setText("Last crash: " + (whenMs > 0 ? ago(whenMs) : "?") + " — " + crash[1] + "  (tap to clear)");
+            cr.setText("Last crash: " + (whenMs > 0 ? ago(whenMs) : "?") + ", " + crash[1] + "  (tap to clear)");
             cr.setOnClickListener(v -> { CrashLog.clear(this); buildDiagnostics(); });
             container.addView(cr);
         }

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -162,7 +162,7 @@ public class SabreService extends Service {
                 : new Notification.Builder(this);
         b.setSmallIcon(android.R.drawable.stat_sys_download_done)
          .setContentTitle("CHP + Waze SABRE update available")
-         .setContentText("Version " + r.latestVersion + " — tap to download")
+         .setContentText("Version " + r.latestVersion + " available. Tap to download.")
          .setAutoCancel(true)
          .setContentIntent(pi);
         nm.notify(UPDATE_NOTIFICATION_ID, b.build());


### PR DESCRIPTION
Strips em dashes from on-screen strings, README, CHANGELOG, and the repo description (rephrased so nothing reads as a run-on). Code comments and dev logs left as-is. v1.7.3.