### PR TITLE
Rename to highway-radar-sabre-plus

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
             flag { print }
           ' CHANGELOG.md > RELEASE_NOTES.md
           if [ ! -s RELEASE_NOTES.md ]; then
-            echo "See [CHANGELOG.md](https://github.com/nicglazkov/caltrans-sabre/blob/main/CHANGELOG.md)." > RELEASE_NOTES.md
+            echo "See [CHANGELOG.md](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/CHANGELOG.md)." > RELEASE_NOTES.md
           fi
           echo "--- release notes ---"; cat RELEASE_NOTES.md
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -13,8 +13,8 @@ No NDK or additional toolchains needed. The Waze protobuf classes are generated 
 ## Clone and build
 
 ```bash
-git clone https://github.com/nicglazkov/caltrans-sabre.git
-cd caltrans-sabre
+git clone https://github.com/nicglazkov/highway-radar-sabre-plus.git
+cd highway-radar-sabre-plus
 ```
 
 **Debug APK** (for sideloading during development):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.8] - 2026-07-06
+
+### Changed
+- Renamed the project to **highway-radar-sabre-plus**. The app, package ID, and settings are unchanged; the in-app update check and "report a bug" links now point at the new repository.
+
 ## [1.7.3] - 2026-07-06
 
 ### Changed
@@ -116,16 +121,17 @@ Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrot
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
-[1.7.3]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7.3
-[1.7.2]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7.2
-[1.7.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7.1
-[1.7]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.7
-[1.6.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.6.1
-[1.6]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.6
-[1.5.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.5.1
-[1.5]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.5
-[1.4]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.4
-[1.3]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.3
-[1.2]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.2
-[1.1]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.1
-[1.0]: https://github.com/nicglazkov/caltrans-sabre/releases/tag/v1.0
+[1.8]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8
+[1.7.3]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.7.3
+[1.7.2]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.7.2
+[1.7.1]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.7.1
+[1.7]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.7
+[1.6.1]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.6.1
+[1.6]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.6
+[1.5.1]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.5.1
+[1.5]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.5
+[1.4]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.4
+[1.3]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.3
+[1.2]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.2
+[1.1]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.1
+[1.0]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 caltrans-sabre contributors
+Copyright (c) 2026 highway-radar-sabre-plus contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <img align="right" width="104" src="docs/screenshots/app-icon.png" alt="App icon">
 
-[![CI](https://github.com/nicglazkov/caltrans-sabre/actions/workflows/ci.yml/badge.svg)](https://github.com/nicglazkov/caltrans-sabre/actions/workflows/ci.yml)
-[![Latest release](https://img.shields.io/github/v/release/nicglazkov/caltrans-sabre?sort=semver)](https://github.com/nicglazkov/caltrans-sabre/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/nicglazkov/caltrans-sabre/total)](https://github.com/nicglazkov/caltrans-sabre/releases)
+[![CI](https://github.com/nicglazkov/highway-radar-sabre-plus/actions/workflows/ci.yml/badge.svg)](https://github.com/nicglazkov/highway-radar-sabre-plus/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/nicglazkov/highway-radar-sabre-plus?sort=semver)](https://github.com/nicglazkov/highway-radar-sabre-plus/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/nicglazkov/highway-radar-sabre-plus/total)](https://github.com/nicglazkov/highway-radar-sabre-plus/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Android 7.0+](https://img.shields.io/badge/Android-7.0%2B-3DDC84?logo=android&logoColor=white)](#requirements)
 
@@ -61,7 +61,7 @@ All sources run in parallel and feed into the standard HR crowdsourced-alerts la
 
 ### Option B: Auto-update with Obtainium
 
-For hands-off updates, install via [Obtainium](https://github.com/ImranR98/Obtainium): add this repo's URL (`https://github.com/nicglazkov/caltrans-sabre`) as an app source and Obtainium will check GitHub Releases and install new versions for you. (The app also shows an in-app banner and a one-time notification when an update is available.)
+For hands-off updates, install via [Obtainium](https://github.com/ImranR98/Obtainium): add this repo's URL (`https://github.com/nicglazkov/highway-radar-sabre-plus`) as an app source and Obtainium will check GitHub Releases and install new versions for you. (The app also shows an in-app banner and a one-time notification when an update is available.)
 
 ### Option C: Build from source
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 13
-        versionName = "1.7.3"
+        versionCode = 14
+        versionName = "1.8"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -71,7 +71,7 @@ public class MainActivity extends Activity {
      */
     private void buildReportButton() {
         findViewById(R.id.reportButton).setOnClickListener(v -> {
-            String url = "https://github.com/nicglazkov/caltrans-sabre/issues/new"
+            String url = "https://github.com/nicglazkov/highway-radar-sabre-plus/issues/new"
                     + "?template=bug_report.yml"
                     + "&plugin-version=" + Uri.encode(BuildConfig.VERSION_NAME)
                     + "&android-version=" + Uri.encode(
@@ -82,7 +82,7 @@ public class MainActivity extends Activity {
                 // No browser / template unavailable — fall back to the issues list.
                 try {
                     startActivity(new Intent(Intent.ACTION_VIEW,
-                            Uri.parse("https://github.com/nicglazkov/caltrans-sabre/issues")));
+                            Uri.parse("https://github.com/nicglazkov/highway-radar-sabre-plus/issues")));
                 } catch (Exception ignored) {}
             }
         });

--- a/app/src/main/java/app/sabre/wzsabre/UpdateChecker.java
+++ b/app/src/main/java/app/sabre/wzsabre/UpdateChecker.java
@@ -18,9 +18,9 @@ public final class UpdateChecker {
     private UpdateChecker() {}
 
     static final String RELEASES_API =
-            "https://api.github.com/repos/nicglazkov/caltrans-sabre/releases/latest";
+            "https://api.github.com/repos/nicglazkov/highway-radar-sabre-plus/releases/latest";
     public static final String RELEASES_PAGE =
-            "https://github.com/nicglazkov/caltrans-sabre/releases/latest";
+            "https://github.com/nicglazkov/highway-radar-sabre-plus/releases/latest";
 
     public static final class Result {
         public final String latestVersion;   // normalized, e.g. "1.6"
@@ -39,7 +39,7 @@ public final class UpdateChecker {
             conn.setConnectTimeout(6000);
             conn.setReadTimeout(6000);
             conn.setRequestProperty("Accept", "application/vnd.github+json");
-            conn.setRequestProperty("User-Agent", "caltrans-sabre-app");
+            conn.setRequestProperty("User-Agent", "highway-radar-sabre-plus-app");
             if (conn.getResponseCode() != 200) return null;
             StringBuilder sb = new StringBuilder();
             try (BufferedReader r = new BufferedReader(


### PR DESCRIPTION
Renames the project and updates all repo URL references (in-app update check + report link, release workflow, README badges/links, BUILDING, CHANGELOG, LICENSE). App/package/settings unchanged. v1.8.