### PR TITLE
Rename the app to SABRE Plus

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
   - type: input
     id: plugin-version
     attributes:
-      label: Plugin (CHP + Waze SABRE) version
+      label: Plugin (SABRE Plus) version
       description: Shown on the app's settings screen and the release you installed.
       placeholder: e.g. 1.5.1
     validations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.8.1] - 2026-07-06
+
+### Changed
+- Renamed the app to **SABRE Plus** (shown on the launcher, in the settings screen, in notifications, and in Highway Radar's plugin list, where it appears as "SABRE Plus (CHP, Waze, Caltrans)"). No functional change; the package ID is unchanged, so an existing Highway Radar selection keeps working.
+
 ## [1.8] - 2026-07-06
 
 ### Changed
@@ -121,6 +126,7 @@ Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrot
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
+[1.8.1]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.1
 [1.8]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8
 [1.7.3]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.7.3
 [1.7.2]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.7.2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CHP + Waze SABRE for Highway Radar
+# SABRE Plus for Highway Radar
 
 <img align="right" width="104" src="docs/screenshots/app-icon.png" alt="App icon">
 
@@ -52,8 +52,8 @@ All sources run in parallel and feed into the standard HR crowdsourced-alerts la
 1. Go to the [Releases](../../releases) page and download the latest APK.
 2. On your Android device, open **Settings → Security** (or *Install unknown apps*) and allow installs from your browser or file manager. If Google Play Protect warns that the app is unrecognized, tap **More details → Install anyway**.
 3. Open the downloaded APK and tap **Install**.
-4. Open the **CHP + Waze SABRE** app once. On first launch, **allow notifications** and **allow the battery-optimization exemption** when prompted, without these the background service can be frozen and alerts stop.
-5. Open **Highway Radar → Settings → SABRE** and select **CHP + Waze SABRE**.
+4. Open the **SABRE Plus** app once. On first launch, **allow notifications** and **allow the battery-optimization exemption** when prompted, without these the background service can be frozen and alerts stop.
+5. Open **Highway Radar → Settings → SABRE** and select **SABRE Plus**.
 
 > **Why the persistent notification?** Android requires a foreground-service notification while the plugin is feeding alerts. The plugin only runs while Highway Radar is open and stops itself shortly after you close HR, so it isn't running (or notifying) in the background the rest of the time.
 
@@ -71,7 +71,7 @@ See [BUILDING.md](BUILDING.md).
 
 ## Configuration
 
-Open the **CHP + Waze SABRE** app to access settings. All changes take effect immediately on the next HR map refresh, no restart needed.
+Open the **SABRE Plus** app to access settings. All changes take effect immediately on the next HR map refresh, no restart needed.
 
 ### Alert Categories
 
@@ -114,7 +114,7 @@ If you already have wzsabre installed:
 ## Troubleshooting
 
 **"Crowd-Sourced Alert Problems" banner in HR**
-- Open the CHP + Waze SABRE app and check that the service status shows *"Plugin active"*.
+- Open the SABRE Plus app and check that the service status shows *"Plugin active"*.
 - Tap the green start button in HR, this sends a fresh handshake.
 - On Android 15: open this app first, then HR. The background service must be running before HR requests data.
 
@@ -123,7 +123,7 @@ If you already have wzsabre installed:
 - Check that the app has network permission (it should request none explicitly; all network access is in the background service).
 
 **No alerts at all**
-- Confirm HR is using the correct plugin: HR → Settings → SABRE → should show "CHP + Waze SABRE".
+- Confirm HR is using the correct plugin: HR → Settings → SABRE → should show "SABRE Plus".
 - Check that no alert categories are all turned off in the app settings.
 
 ---

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 14
-        versionName = "1.8"
+        versionCode = 15
+        versionName = "1.8.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:label="CHP + Waze SABRE"
+        android:label="SABRE Plus"
         android:theme="@android:style/Theme.Material.Light">
 
         <activity

--- a/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
@@ -84,7 +84,7 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
         String pkg = context.getPackageName();
         JSONObject response = new JSONObject();
         response.put("id",           pkg);
-        response.put("name",         "CHP + Waze SABRE");
+        response.put("name",         "SABRE Plus (CHP, Waze, Caltrans)");
         response.put("package_name", pkg);
         response.put("version",      BuildConfig.VERSION_NAME);
         JSONArray sources = new JSONArray();

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -161,7 +161,7 @@ public class SabreService extends Service {
                 ? new Notification.Builder(this, UPDATE_CHANNEL_ID)
                 : new Notification.Builder(this);
         b.setSmallIcon(android.R.drawable.stat_sys_download_done)
-         .setContentTitle("CHP + Waze SABRE update available")
+         .setContentTitle("SABRE Plus update available")
          .setContentText("Version " + r.latestVersion + " available. Tap to download.")
          .setAutoCancel(true)
          .setContentIntent(pi);
@@ -435,7 +435,7 @@ public class SabreService extends Service {
     private void createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel ch = new NotificationChannel(
-                    CHANNEL_ID, "CHP + Waze SABRE", NotificationManager.IMPORTANCE_LOW);
+                    CHANNEL_ID, "SABRE Plus", NotificationManager.IMPORTANCE_LOW);
             ch.enableVibration(false);
             ch.setSound(null, null);
             NotificationManager nm = getSystemService(NotificationManager.class);
@@ -449,8 +449,8 @@ public class SabreService extends Service {
                 : new Notification.Builder(this);
         b.setOngoing(true)
          .setSmallIcon(android.R.drawable.ic_menu_compass)
-         .setContentTitle("CHP + Waze SABRE")
-         .setContentText("Providing CHP and Waze alerts to Highway Radar")
+         .setContentTitle("SABRE Plus")
+         .setContentText("Providing CHP, Waze, and Caltrans road alerts to Highway Radar")
          .setVisibility(Notification.VISIBILITY_PUBLIC);
         // setForegroundServiceBehavior is API 31 (S), not Q — guarding at Q threw
         // NoSuchMethodError on Android 10/11, killing the service on those devices.

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,7 +21,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="CHP + Waze SABRE"
+                android:text="SABRE Plus"
                 android:textSize="20sp"
                 android:textStyle="bold"
                 android:textColor="#FFFFFF" />


### PR DESCRIPTION
Renames the on-device display name from 'CHP + Waze SABRE' (only named 2 of 5 sources) to 'SABRE Plus', shown as 'SABRE Plus (CHP, Waze, Caltrans)' in Highway Radar's plugin list. Package ID unchanged, so existing selections keep working. v1.8.1.