### PR TITLE
Fix false chain-control error (Caltrans now returns 500, not 404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.8.3] - 2026-07-06
+
+### Fixed
+- Chain controls no longer show a false error in regions with no chain-control program (such as the Bay Area). Caltrans changed the "no feed here" response for those districts from 404 to 500; the plugin now treats any non-200 as "no chain controls here" (shown as 0) instead of an error.
+
 ## [1.8.2] - 2026-07-06
 
 ### Changed
@@ -131,6 +136,7 @@ Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrot
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
+[1.8.3]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.3
 [1.8.2]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.2
 [1.8.1]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.1
 [1.8]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 16
-        versionName = "1.8.2"
+        versionCode = 17
+        versionName = "1.8.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/WinterSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/WinterSource.java
@@ -5,7 +5,6 @@ import android.util.Log;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserFactory;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -127,13 +126,18 @@ public class WinterSource {
         conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Linux; Android 14)");
         try {
             int code = conn.getResponseCode();
-            // Flatland districts (e.g. D4 Bay Area, D5 Central Coast) publish no
-            // chain-control feed and return 404 — that's "no chain controls here",
-            // not an error. Return empty so it's cached like a normal result: no red
-            // diagnostics, and no re-request every ~15s (previously we never cached a
-            // failure, so a permanent 404 hammered the feed all drive).
-            if (code == HttpsURLConnection.HTTP_NOT_FOUND) return new ArrayList<>();
-            if (code != HttpsURLConnection.HTTP_OK) throw new IOException("HTTP " + code);
+            // Districts with no chain-control program (D4 Bay Area, D5 Central Coast,
+            // D12 Orange County) return a non-200 for their cc feed. It used to be 404;
+            // as of 2026 Caltrans returns 500. Treat ANY non-200 as "no chain controls
+            // from this district": an empty, cached result, not an error. So it shows 0
+            // instead of a red diagnostics error, and does not re-request every ~15s. A
+            // real chain district with a transient 5xx just shows no controls until it
+            // recovers, same as an empty feed. Genuine connectivity failures still throw
+            // from getResponseCode() above and surface as an error.
+            if (code != HttpsURLConnection.HTTP_OK) {
+                Log.d(TAG, "D" + district + " chain-control feed HTTP " + code + "; treating as no data");
+                return new ArrayList<>();
+            }
             try (InputStream in = conn.getInputStream()) {
                 return parse(in);
             }


### PR DESCRIPTION
Flatland districts (D4/D5/D12) with no chain-control program now return HTTP 500 instead of 404, so the 404-only handling threw IOException and the diagnostics showed 'Chain controls: no data yet, error: D5 IOException'. Now any non-200 is treated as 'no chains here' (empty, shown as 0). Verified live: D4/D5/D12 = 500, the nine mountain/valley districts = 200. v1.8.3.