### PR TITLE
Docs: uninstall official wzsabre before installing SABRE Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ All sources run in parallel and feed into the standard HR crowdsourced-alerts la
 
 ## Installation
 
+> **Already have the official wzsabre (from wzsabre.rocks) installed? Uninstall it first.** SABRE Plus is a replacement for wzsabre, and Highway Radar only recognizes one specific plugin ID, so both apps must share it and cannot be installed at the same time. If you try to install SABRE Plus while wzsabre is still on the device, Android blocks it with "App not installed" because the two are signed by different developers. Uninstall the official wzsabre first (long-press its icon, then App info, then Uninstall), then install SABRE Plus. Your Highway Radar setup is unaffected and it will rediscover the plugin automatically.
+
 ### Option A: Download the APK (recommended for most users)
 
 1. Go to the [Releases](../../releases) page and download the latest APK.
@@ -112,6 +114,9 @@ If you already have wzsabre installed:
 ---
 
 ## Troubleshooting
+
+**"App not installed", "package conflicts with an existing package", or "signatures do not match"**
+- You have the official wzsabre (from wzsabre.rocks) installed. SABRE Plus replaces wzsabre and must use the same plugin ID that Highway Radar looks for, so the two cannot be installed at once, and they are signed by different developers. Uninstall the official wzsabre (long-press its icon, then App info, then Uninstall), then install SABRE Plus. Highway Radar rediscovers the plugin automatically, and your settings are unaffected.
 
 **"Crowd-Sourced Alert Problems" banner in HR**
 - Open the SABRE Plus app and check that the service status shows *"Plugin active"*.


### PR DESCRIPTION
A user on Android 11 reported the APK 'does not want to run.' Reproduced on an API 30 AVD: it installs and launches fine on a clean device, but fails with INSTALL_FAILED_UPDATE_INCOMPATIBLE when the official wzsabre is already installed (same package id, different signing key). We must keep the app.sabre.wzsabre id (HR's queries whitelist + Android 11+ visibility), so the fix is guidance: uninstall wzsabre first. Adds an install callout and a troubleshooting entry.