### PR TITLE
Make the wzsabre uninstall note unmissable (README + every release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,17 @@ jobs:
             index($0, hdr) == 1 { flag=1; next }
             flag && index($0, "## [") == 1 { exit }
             flag { print }
-          ' CHANGELOG.md > RELEASE_NOTES.md
-          if [ ! -s RELEASE_NOTES.md ]; then
-            echo "See [CHANGELOG.md](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/CHANGELOG.md)." > RELEASE_NOTES.md
+          ' CHANGELOG.md > BODY.md
+          if [ ! -s BODY.md ]; then
+            echo "See [CHANGELOG.md](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/CHANGELOG.md)." > BODY.md
           fi
+          # Every release leads with a friendly, unmissable note for wzsabre users.
+          printf '%s\n' \
+            "> **👋 Coming from the original wzsabre? Uninstall it first.**" \
+            ">" \
+            "> SABRE Plus replaces wzsabre and shares the plugin ID that Highway Radar looks for, so Android only allows one of them at a time. Uninstall the old **wzsabre** app (long-press its icon, then App info, then Uninstall), then install SABRE Plus below. Your Highway Radar setup stays exactly as it is. Never had wzsabre? Just install, you are all set. 🙂" \
+            "" > RELEASE_NOTES.md
+          cat BODY.md >> RELEASE_NOTES.md
           echo "--- release notes ---"; cat RELEASE_NOTES.md
 
       - name: Publish GitHub release

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ An open-source **Highway Radar SABRE plugin** for California, and a drop-in **wz
 
 > **Package ID: `app.sabre.wzsabre`** (the same as wzsabre), so Highway Radar discovers this plugin automatically without any reconfiguration.
 
+> ### 👋 Switching from wzsabre? One quick step first
+>
+> SABRE Plus is the new home for what wzsabre used to do, and Android only lets **one of them** be installed at a time (they share the plugin ID that Highway Radar looks for). So if the old **wzsabre** app is on your phone:
+>
+> 1. **Uninstall wzsabre** (long-press its icon, then App info, then Uninstall)
+> 2. **Install SABRE Plus** (see [Installation](#installation) below)
+>
+> Your Highway Radar settings stay exactly as they are, and it finds the plugin automatically. Never had wzsabre? You are all set, just install below. 🙂
+
 ---
 
 ## What it does


### PR DESCRIPTION
Adds a friendly top-of-README callout and makes the release workflow prepend a friendly wzsabre banner to every future release. Backfilling existing releases separately.