### PR TITLE
Fix: match HR 3.2 strict alert model (drop user_id/confirm_count)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.8.4] - 2026-07-09
+
+### Fixed
+- **Highway Radar receives alert data again on the latest HR.** Highway Radar 3.2 tightened its plugin data format and removed two fields our alerts still sent (`user_id` and `confirm_count`). HR reads plugin responses strictly, so those extra fields made it silently reject every response: the plugin looked connected but no alerts appeared. Our alert and discovery payloads now match HR 3.2's format exactly.
+
 ## [1.8.3] - 2026-07-06
 
 ### Fixed
@@ -136,6 +141,7 @@ Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrot
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
+[1.8.4]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.4
 [1.8.3]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.3
 [1.8.2]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.2
 [1.8.1]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.1

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 17
-        versionName = "1.8.3"
+        versionCode = 18
+        versionName = "1.8.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
@@ -99,10 +99,11 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
         response.put("confirm_action",  "app.sabre.wzsabre.CONFIRM_REPORT");
         response.put("discard_action",  "app.sabre.wzsabre.DISCARD_REPORT");
         response.put("shutdown_action", "app.sabre.wzsabre.SHUTDOWN");
-        // Fields added in the wzsabre 2.x discovery format (both nullable).
         // alternative_startup_activity lets HR launch us to the foreground so the
-        // service can start without hitting Android 15/16 BFSL restrictions.
-        response.put("update_url", JSONObject.NULL);
+        // service can start without hitting Android 15/16 BFSL restrictions. This is
+        // the last field of HR 3.2's SabreDiscoveryResponse model. Do NOT re-add the
+        // old wzsabre 2.x "update_url" field: HR 3.2 dropped it and parses the
+        // discovery response strictly, so an extra key breaks discovery.
         response.put("alternative_startup_activity", pkg + ".AltStartupActivity");
         Intent resp = new Intent(responseAction);
         resp.setPackage(SabreResponseBuilder.HR_PACKAGE);   // deliver only to HR

--- a/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
@@ -5,8 +5,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Builds the SABRE fetch-response JSON that Highway Radar deserializes into
@@ -49,9 +47,6 @@ public class SabreResponseBuilder {
 
     /** Max alerts per response batch — matches the official wzsabre (200). */
     public static final int MAX_ALERTS_PER_BATCH = 200;
-
-    // USER_ID_REGEX matches Waze alert IDs of the form "alert-<digits>/..."
-    private static final Pattern USER_ID_PATTERN = Pattern.compile("alert-(\\d*)/.*");
 
     /**
      * Alert type strings HR's renderer accepts. This is the union of (a) the
@@ -125,19 +120,17 @@ public class SabreResponseBuilder {
      *     "n_batches": Int,           // required
      *     "batch_id":  Int,           // required
      *     "alerts": [                 // required list (may be empty)
-     *       {
+     *       {                            // EXACTLY HR 3.2's SabreFetchResponseAlert (9 fields)
      *         "alert_source":  String,   // required; must be SOURCE_CHP or SOURCE_WAZE
      *         "alert_id":      String,   // required
-     *         "user_id":       String,   // required, non-null (digits or "0")
      *         "type":          String,   // required SABRE type constant
      *         "lat":           Double,   // required
      *         "lon":           Double,   // required
      *         "heading_deg":   Double,   // required
      *         "street_name":   String?,  // nullable String — present (may be null)
      *         "report_ts":     Int,      // required; must fit in Int (not Long)
-     *         "confirm_ts":    null,     // nullable Int — present but null
-     *         "confirm_count": Int       // required; 0
-     *       }
+     *         "confirm_ts":    Int?      // nullable Int — present (may be null)
+     *       }                            // NB: no user_id / confirm_count (HR dropped them; strict parser rejects extras)
      *     ]
      *   }
      * }
@@ -200,10 +193,16 @@ public class SabreResponseBuilder {
             throw new IllegalArgumentException("heading_deg is NaN/Infinite for alert " + a.alertId);
         }
 
+        // These nine fields, in this order, are EXACTLY Highway Radar's current
+        // SabreFetchResponseAlert model (verified by decompiling HR 3.2). HR parses
+        // the response with kotlinx.serialization in strict mode (it never sets
+        // ignoreUnknownKeys), so ANY extra key makes it reject the whole batch and
+        // show no data. The older wzsabre 2.2 model also carried "user_id" and
+        // "confirm_count"; HR dropped both, so we must NOT send them. Do not add
+        // fields here without confirming HR's model still has them.
         JSONObject obj = new JSONObject();
         obj.put("alert_source",  a.alertSource);           // must be SOURCE_CHP or SOURCE_WAZE
         obj.put("alert_id",      a.alertId);
-        obj.put("user_id",       extractUserId(a.alertId)); // required non-null String
         obj.put("type",          a.type);
         obj.put("lat",           a.lat);
         obj.put("lon",           a.lon);
@@ -215,24 +214,7 @@ public class SabreResponseBuilder {
         boolean confirmTsFits = a.confirmTs != null
                 && a.confirmTs >= 0 && a.confirmTs <= Integer.MAX_VALUE;
         obj.put("confirm_ts",    confirmTsFits ? (int) (long) a.confirmTs : JSONObject.NULL);
-        obj.put("confirm_count", Math.max(0, a.confirmCount));
         return obj;
     }
 
-    /**
-     * Extracts a numeric user_id from a Waze alert ID.
-     * Waze IDs look like "alert-1234567890/abcdef" → user_id = "1234567890".
-     * Our alertId prefix is "waze_", stripped before matching.
-     * Returns "0" if no numeric user ID found (CHP alerts, anonymous Waze alerts).
-     */
-    public static String extractUserId(String alertId) {
-        if (alertId == null) return "0";
-        String id = alertId.startsWith("waze_") ? alertId.substring(5) : alertId;
-        Matcher m = USER_ID_PATTERN.matcher(id);
-        if (m.find()) {
-            String uid = m.group(1);
-            return (uid != null && !uid.isEmpty()) ? uid : "0";
-        }
-        return "0";
-    }
 }

--- a/app/src/test/java/app/sabre/wzsabre/SabreProtocolTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/SabreProtocolTest.java
@@ -11,21 +11,24 @@ import java.util.List;
 import static org.junit.Assert.*;
 
 /**
- * Validates that SabreResponseBuilder produces JSON that exactly matches
- * HR's kotlinx.serialization schema (compatible with the wzsabre SABRE protocol).
+ * Validates that SabreResponseBuilder produces JSON that exactly matches Highway
+ * Radar's kotlinx.serialization schema. HR parses strictly (never sets
+ * ignoreUnknownKeys), so the alert object must contain EXACTLY these nine fields
+ * and no others, or HR rejects the whole batch and shows no data.
  *
- * SabreFetchResponseAlert requires ALL 11 fields (bitmask 2047 = 0b11111111111):
+ * HR 3.2's SabreFetchResponseAlert (verified by decompiling HR):
  *   0  alert_source   String  non-null
  *   1  alert_id       String  non-null
- *   2  user_id        String  non-null   ← was missing before; caused MissingFieldException crash
- *   3  type           String  non-null
- *   4  lat            Double
- *   5  lon            Double
- *   6  heading_deg    Double
- *   7  street_name    String? nullable
- *   8  report_ts      Int     (not Long)
- *   9  confirm_ts     Int?    nullable
- *  10  confirm_count  Int
+ *   2  type           String  non-null
+ *   3  lat            Double
+ *   4  lon            Double
+ *   5  heading_deg    Double
+ *   6  street_name    String? nullable
+ *   7  report_ts      Int     (not Long)
+ *   8  confirm_ts     Int?    nullable
+ *
+ * The old wzsabre 2.2 model also had user_id and confirm_count; HR dropped both,
+ * so sending them now breaks HR (this was the "plugin detected but no data" bug).
  */
 public class SabreProtocolTest {
 
@@ -115,19 +118,27 @@ public class SabreProtocolTest {
         assertEquals(0, arr.length());
     }
 
-    // ── alert: all 11 fields present ─────────────────────────────────────────
+    // ── alert: exactly HR's nine fields, no extras ───────────────────────────
 
     @Test
-    public void alert_hasAll11RequiredFields() throws Exception {
+    public void alert_hasExactly9HrFields() throws Exception {
         JSONObject a = firstAlert(parseResponse(Collections.singletonList(chpAlert())));
         String[] required = {
-            "alert_source", "alert_id", "user_id", "type",
-            "lat", "lon", "heading_deg", "street_name",
-            "report_ts", "confirm_ts", "confirm_count"
+            "alert_source", "alert_id", "type", "lat", "lon",
+            "heading_deg", "street_name", "report_ts", "confirm_ts"
         };
         for (String field : required) {
             assertTrue("Missing required field: " + field, a.has(field));
         }
+        // HR parses the response strictly (never sets ignoreUnknownKeys), so ANY
+        // extra key makes it reject the whole batch and show no data. HR 3.2's
+        // SabreFetchResponseAlert model is exactly these nine fields: user_id and
+        // confirm_count (present in the old wzsabre 2.2 model) were dropped. Lock
+        // the field set to exactly nine so a regression can't silently break HR.
+        assertEquals("alert must have exactly HR's 9 fields (no user_id/confirm_count)",
+                9, a.length());
+        assertFalse("user_id must NOT be sent (HR rejects unknown keys)", a.has("user_id"));
+        assertFalse("confirm_count must NOT be sent (HR rejects unknown keys)", a.has("confirm_count"));
     }
 
     // ── alert_source must match handshake source IDs ──────────────────────────
@@ -154,43 +165,6 @@ public class SabreProtocolTest {
                 a.getString("alert_source"));
         assertNotEquals("'Waze' would not match declared source id 'waze'", "Waze",
                 a.getString("alert_source"));
-    }
-
-    // ── user_id: required non-null String ────────────────────────────────────
-
-    @Test
-    public void alert_userIdPresentAndNonNull() throws Exception {
-        for (SabreAlert alert : Arrays.asList(chpAlert(), wazeAlert(), wazeAlertNullStreet())) {
-            JSONObject a = firstAlert(parseResponse(Collections.singletonList(alert)));
-            assertTrue("user_id must be present", a.has("user_id"));
-            assertFalse("user_id must not be JSON null", a.isNull("user_id"));
-            assertNotNull("user_id must not be null", a.getString("user_id"));
-        }
-    }
-
-    @Test
-    public void alert_userIdExtractedFromWazeId() throws Exception {
-        JSONObject a = firstAlert(parseResponse(Collections.singletonList(wazeAlert())));
-        assertEquals("user_id should be extracted from 'alert-9876543210/abcdef123'",
-                "9876543210", a.getString("user_id"));
-    }
-
-    @Test
-    public void alert_userIdFallsBackToZeroForChp() throws Exception {
-        JSONObject a = firstAlert(parseResponse(Collections.singletonList(chpAlert())));
-        assertEquals("CHP alerts have no user_id, should be '0'",
-                "0", a.getString("user_id"));
-    }
-
-    @Test
-    public void alert_userIdFallsBackToZeroForAnonymousWaze() throws Exception {
-        // Waze UUID format (no "alert-<digits>/" prefix)
-        SabreAlert anon = new SabreAlert(
-                "waze_some-uuid-without-digits",
-                SabreResponseBuilder.SOURCE_WAZE,
-                "HAZARD_ON_ROAD_CONGESTION", 34.0, -118.0, 0.0, null, NOW_SECONDS);
-        JSONObject a = firstAlert(parseResponse(Collections.singletonList(anon)));
-        assertEquals("0", a.getString("user_id"));
     }
 
     // ── report_ts must fit in Int ─────────────────────────────────────────────
@@ -293,7 +267,6 @@ public class SabreProtocolTest {
                 "POLICE_VISIBLE", 38.0, -122.0, 0.0, "US-101", NOW_SECONDS,
                 NOW_SECONDS, 4);
         JSONObject a = firstAlert(parseResponse(Collections.singletonList(confirmed)));
-        assertEquals(4, a.getInt("confirm_count"));
         assertFalse("confirm_ts must be present and non-null when set", a.isNull("confirm_ts"));
         assertEquals((int) NOW_SECONDS, a.getInt("confirm_ts"));
     }
@@ -306,7 +279,6 @@ public class SabreProtocolTest {
                 ((long) Integer.MAX_VALUE) + 100L, 2);
         JSONObject obj = firstAlert(parseResponse(Collections.singletonList(a)));
         assertTrue("oversized confirm_ts must be null", obj.isNull("confirm_ts"));
-        assertEquals(2, obj.getInt("confirm_count"));
     }
 
     // ── batching ──────────────────────────────────────────────────────────────
@@ -369,14 +341,6 @@ public class SabreProtocolTest {
         SabreResponseBuilder.buildAlert(bad);
     }
 
-    // ── confirm_count is 0 ────────────────────────────────────────────────────
-
-    @Test
-    public void alert_confirmCountIsZero() throws Exception {
-        JSONObject a = firstAlert(parseResponse(Collections.singletonList(chpAlert())));
-        assertEquals(0, a.getInt("confirm_count"));
-    }
-
     // ── multiple alerts ───────────────────────────────────────────────────────
 
     @Test
@@ -387,11 +351,10 @@ public class SabreProtocolTest {
     }
 
     @Test
-    public void multipleAlerts_eachHasAll11Fields() throws Exception {
+    public void multipleAlerts_eachHasExactly9Fields() throws Exception {
         String[] fields = {
-            "alert_source", "alert_id", "user_id", "type",
-            "lat", "lon", "heading_deg", "street_name",
-            "report_ts", "confirm_ts", "confirm_count"
+            "alert_source", "alert_id", "type", "lat", "lon",
+            "heading_deg", "street_name", "report_ts", "confirm_ts"
         };
         JSONArray arr = parseResponse(Arrays.asList(chpAlert(), wazeAlert()))
                 .getJSONObject("response").getJSONArray("alerts");
@@ -400,33 +363,7 @@ public class SabreProtocolTest {
             for (String f : fields) {
                 assertTrue("Alert[" + i + "] missing field: " + f, a.has(f));
             }
+            assertEquals("Alert[" + i + "] must have exactly 9 fields", 9, a.length());
         }
-    }
-
-    // ── user_id extraction edge cases ─────────────────────────────────────────
-
-    @Test
-    public void extractUserId_fromWazeNativeId() {
-        assertEquals("1234567890",
-                SabreResponseBuilder.extractUserId("alert-1234567890/somehash"));
-    }
-
-    @Test
-    public void extractUserId_fromWazePrefixedId() {
-        assertEquals("9876543210",
-                SabreResponseBuilder.extractUserId("waze_alert-9876543210/abc"));
-    }
-
-    @Test
-    public void extractUserId_emptyDigitsReturnsZero() {
-        assertEquals("0",
-                SabreResponseBuilder.extractUserId("alert-/nohash"));
-    }
-
-    @Test
-    public void extractUserId_noMatchReturnsZero() {
-        assertEquals("0", SabreResponseBuilder.extractUserId("chp_12345"));
-        assertEquals("0", SabreResponseBuilder.extractUserId(null));
-        assertEquals("0", SabreResponseBuilder.extractUserId(""));
     }
 }


### PR DESCRIPTION
Root cause of 'plugin detected but no data' (found by decompiling HR 3.2): HR parses plugin responses strictly (no ignoreUnknownKeys), and HR 3.2 dropped user_id and confirm_count from its alert model (and update_url from discovery). Our alerts still sent them, so HR rejected every response. Now we emit exactly HR 3.2's 9 alert fields; a unit test locks it. v1.8.4.