### PR TITLE
Fix: remap Waze types HR 3.2 silently drops (jams/closures now render)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.8.5] - 2026-07-10
+
+### Fixed
+- **More alerts now show up on the Highway Radar map.** Highway Radar 3.2 only draws crowd alerts categorized as police, hazard, or accident and silently drops the rest, so common Waze traffic jams and road closures were never appearing. They now show as congestion hazards instead of being dropped. (CHP, Caltrans, wildfire, and chain alerts already used categories HR draws.)
+
 ## [1.8.4] - 2026-07-09
 
 ### Fixed
@@ -141,6 +146,7 @@ Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrot
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
+[1.8.5]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.5
 [1.8.4]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.4
 [1.8.3]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.3
 [1.8.2]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.2

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 18
-        versionName = "1.8.4"
+        versionCode = 19
+        versionName = "1.8.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/AlertMapper.java
+++ b/app/src/main/java/app/sabre/wzsabre/AlertMapper.java
@@ -151,4 +151,23 @@ public class AlertMapper {
                 return null; // Waze types we don't care about (e.g., WEATHERHAZARD duplicates)
         }
     }
+
+    /**
+     * The SABRE {@code type} to send for a Waze alert so it actually renders in
+     * Highway Radar. HR 3.2 only draws a crowd alert whose type starts with POLICE,
+     * HAZARD, or ACCIDENT and silently drops the rest, including the very common
+     * JAM_* (traffic) and ROAD_CLOSED. So the raw Waze subtype is passed through when
+     * it already starts with one of those (keeps the most specific HR icon); otherwise
+     * it is remapped via {@link #fromWazeType} so jams/closures become
+     * HAZARD_ON_ROAD_CONGESTION instead of vanishing. Returns null if there is no
+     * usable type.
+     */
+    public static String wazeRenderableType(String type, String subtype) {
+        String raw = (subtype != null && !subtype.isEmpty()) ? subtype : type;
+        if (raw == null || raw.isEmpty()) return null;
+        String u = raw.toUpperCase(Locale.US);
+        if (u.startsWith("POLICE") || u.startsWith("HAZARD") || u.startsWith("ACCIDENT")) return raw;
+        String mapped = fromWazeType(type, subtype);
+        return mapped != null ? mapped : raw;
+    }
 }

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
@@ -14,6 +14,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import app.sabre.wzsabre.SabreAlert;
+import app.sabre.wzsabre.AlertMapper;
 import app.sabre.wzsabre.SabreResponseBuilder;
 import app.sabre.wzsabre.SourceStatus;
 
@@ -281,14 +282,20 @@ public final class WazeProtocolSource {
     }
 
     /**
-     * Map a cached Waze alert to a SABRE alert. Mirrors the official's request():
-     * the SABRE type is the raw Waze subtype name, or the type name when the
-     * subtype is empty — HR natively understands the full Waze vocabulary, so no
-     * remap/whitelist is applied (the old remap silently dropped whole categories
-     * like SOS/stopped-vehicle and flattened "car stopped" into generic debris).
+     * Map a cached Waze alert to a SABRE alert. The SABRE type is the raw Waze
+     * subtype (or type when the subtype is empty), which keeps the most specific
+     * category for HR's icon.
+     *
+     * HR 3.2 only draws a crowd alert whose type starts with POLICE, HAZARD, or
+     * ACCIDENT (verified in HR's decompiled renderer) and silently drops the rest,
+     * including the very common JAM_* (traffic) and ROAD_CLOSED. So when the raw
+     * subtype does not start with one of those, we remap it via
+     * {@link AlertMapper#fromWazeType} (jams/closures become HAZARD_ON_ROAD_CONGESTION)
+     * so the alert renders instead of vanishing. Renderable subtypes are passed
+     * through unchanged so HR still gets the precise icon.
      */
     private SabreAlert toSabreAlert(WazeAlert wa) {
-        String type = (wa.subtype != null && !wa.subtype.isEmpty()) ? wa.subtype : wa.type;
+        String type = AlertMapper.wazeRenderableType(wa.type, wa.subtype);
         if (type == null || type.isEmpty()) return null;
         String id = "alert-" + wa.id + "/" + wa.uuid;   // user_id is parsed from this
         int confirmCount = wa.nThumbsUp != null ? wa.nThumbsUp : 0;

--- a/app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java
@@ -147,4 +147,45 @@ public class AlertMapperTest {
             }
         }
     }
+
+    // ── wazeRenderableType: HR 3.2 only draws POLICE*/HAZARD*/ACCIDENT* ───────────
+
+    @Test
+    public void waze_renderableSubtypesPassThrough() {
+        // Already-renderable subtypes keep their specific value (best HR icon).
+        assertEquals("HAZARD_ON_ROAD_OBJECT", AlertMapper.wazeRenderableType("HAZARD", "HAZARD_ON_ROAD_OBJECT"));
+        assertEquals("ACCIDENT_MAJOR",        AlertMapper.wazeRenderableType("ACCIDENT", "ACCIDENT_MAJOR"));
+        assertEquals("POLICE_VISIBLE",        AlertMapper.wazeRenderableType("POLICE", "POLICE_VISIBLE"));
+    }
+
+    @Test
+    public void waze_droppableSubtypesAreRemappedSoTheyRender() {
+        // JAM_* and ROAD_CLOSED would be silently dropped by HR (don't start with
+        // POLICE/HAZARD/ACCIDENT); they must be remapped to a rendered hazard.
+        assertEquals("HAZARD_ON_ROAD_CONGESTION", AlertMapper.wazeRenderableType("JAM", "JAM_HEAVY_TRAFFIC"));
+        assertEquals("HAZARD_ON_ROAD_CONGESTION", AlertMapper.wazeRenderableType("ROAD_CLOSED", ""));
+        assertEquals("HAZARD_ON_ROAD_CONGESTION", AlertMapper.wazeRenderableType("JAM", null));
+    }
+
+    @Test
+    public void waze_everyMappableCategoryRendersInHr() {
+        // The invariant HR requires: the emitted type starts with POLICE/HAZARD/ACCIDENT.
+        String[][] cases = {
+            {"POLICE", "POLICE_HIDING"}, {"CAMERA", ""}, {"ACCIDENT", "ACCIDENT_MINOR"},
+            {"HAZARD", "HAZARD_ON_SHOULDER_CAR_STOPPED"}, {"JAM", "JAM_STAND_STILL_TRAFFIC"},
+            {"ROAD_CLOSED", "ROAD_CLOSED"}, {"HAZARD", ""}
+        };
+        for (String[] c : cases) {
+            String out = AlertMapper.wazeRenderableType(c[0], c[1]);
+            assertNotNull("null for " + c[0] + "/" + c[1], out);
+            assertTrue("HR would DROP '" + out + "' (from " + c[0] + "/" + c[1] + ")",
+                    out.startsWith("POLICE") || out.startsWith("HAZARD") || out.startsWith("ACCIDENT"));
+        }
+    }
+
+    @Test
+    public void waze_emptyTypeReturnsNull() {
+        assertNull(AlertMapper.wazeRenderableType(null, null));
+        assertNull(AlertMapper.wazeRenderableType("", ""));
+    }
 }


### PR DESCRIPTION
Root cause of 'plugin detected + up to date, nothing on map' (found by decompiling HR 3.2's crowd renderer): HR only draws alerts whose type starts with POLICE/HAZARD/ACCIDENT and drops the rest. Our raw Waze passthrough meant JAM_* and ROAD_CLOSED were dropped. Now remapped to HAZARD_ON_ROAD_CONGESTION via AlertMapper.wazeRenderableType; renderable subtypes still pass through for the right icon. Unit tests added. v1.8.5.