### PR TITLE
Add privacy-safe in-app Share diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.9] - 2026-07-10
+
+### Added
+- **Share diagnostics** button in the settings screen. If something is not working, tap it to send a plain-text troubleshooting report (app and Highway Radar versions, alert counts and category names, recent plugin activity) without a computer or ADB. A popup lets you choose which of four categories to include, and the report never contains your location, street names, alert details, or any personal data.
+
 ## [1.8.5] - 2026-07-10
 
 ### Fixed
@@ -146,6 +151,7 @@ Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrot
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
+[1.9]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.9
 [1.8.5]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.5
 [1.8.4]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.4
 [1.8.3]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.3

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 19
-        versionName = "1.8.5"
+        versionCode = 20
+        versionName = "1.9"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/DebugLog.java
+++ b/app/src/main/java/app/sabre/wzsabre/DebugLog.java
@@ -1,0 +1,107 @@
+package app.sabre.wzsabre;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * A small, privacy-safe, in-memory ring buffer of curated diagnostic events, plus
+ * the last fetch's per-source and per-type counts. It powers the user-facing
+ * "Share diagnostics" report so a user can troubleshoot without ADB.
+ *
+ * <p><b>This is deliberately separate from {@code android.util.Log} (logcat).</b>
+ * Logcat lines carry GPS coordinates and alert street names, which must never be
+ * shared. Nothing recorded here may contain location, street names, alert IDs, or
+ * any personal data: only counts, source ids, alert-type category names, versions,
+ * and error strings. {@link #recordFetch} reads only {@code alertSource} and
+ * {@code type} off each alert, so it cannot leak where the user is.
+ */
+public final class DebugLog {
+    private DebugLog() {}
+
+    private static final int MAX_EVENTS = 60;
+
+    private static final class Ev {
+        final long ts; final String msg;
+        Ev(long ts, String msg) { this.ts = ts; this.msg = msg; }
+    }
+
+    private static final Deque<Ev> EVENTS = new ArrayDeque<>();
+    private static volatile long lastFetchReceivedMs = 0;
+    private static volatile String lastFetchSummary = null;
+    private static final Map<String, Integer> lastFetchTypes = new LinkedHashMap<>();
+
+    /** Record a curated event. Callers MUST NOT pass coordinates, street names, or PII. */
+    public static synchronized void event(String msg) {
+        EVENTS.addLast(new Ev(System.currentTimeMillis(), msg));
+        while (EVENTS.size() > MAX_EVENTS) EVENTS.removeFirst();
+    }
+
+    /** Note that Highway Radar asked us for data (drives "HR last requested Ns ago"). */
+    public static synchronized void fetchReceived() {
+        lastFetchReceivedMs = System.currentTimeMillis();
+    }
+
+    /**
+     * Record a fetch response as per-source and per-type counts. Reads only
+     * {@code alertSource} and {@code type}, never lat/lon/street, so it is incapable
+     * of leaking location or personal data.
+     */
+    public static synchronized void recordFetch(List<SabreAlert> sent, int rawCount) {
+        Map<String, Integer> perSource = new LinkedHashMap<>();
+        Map<String, Integer> perType = new LinkedHashMap<>();
+        for (SabreAlert a : sent) {
+            bump(perSource, a.alertSource);
+            bump(perType, a.type);
+        }
+        StringBuilder src = new StringBuilder();
+        for (Map.Entry<String, Integer> e : perSource.entrySet()) {
+            if (src.length() > 0) src.append(' ');
+            src.append(e.getKey()).append(e.getValue());
+        }
+        lastFetchSummary = "sent " + sent.size() + " of " + rawCount
+                + (src.length() > 0 ? " (" + src + ")" : "");
+        lastFetchTypes.clear();
+        lastFetchTypes.putAll(perType);
+        event("fetch: " + lastFetchSummary);
+    }
+
+    private static void bump(Map<String, Integer> m, String key) {
+        String k = (key != null) ? key : "?";
+        Integer n = m.get(k);
+        m.put(k, (n == null) ? 1 : n + 1);
+    }
+
+    public static synchronized long lastFetchAgeMs() {
+        return (lastFetchReceivedMs == 0) ? -1 : System.currentTimeMillis() - lastFetchReceivedMs;
+    }
+
+    public static synchronized String lastFetchSummary() { return lastFetchSummary; }
+
+    public static synchronized Map<String, Integer> lastFetchTypes() {
+        return new LinkedHashMap<>(lastFetchTypes);
+    }
+
+    /** Recent events as display lines, e.g. "  12s ago  fetch: sent 59 (chp8 waze46 ...)". */
+    public static synchronized List<String> recentEvents() {
+        long now = System.currentTimeMillis();
+        List<String> out = new ArrayList<>();
+        for (Ev e : EVENTS) {
+            long ageS = Math.max(0, (now - e.ts) / 1000);
+            out.add(String.format(Locale.US, "%5ds ago  %s", ageS, e.msg));
+        }
+        return out;
+    }
+
+    /** Test/reset hook. */
+    static synchronized void clear() {
+        EVENTS.clear();
+        lastFetchReceivedMs = 0;
+        lastFetchSummary = null;
+        lastFetchTypes.clear();
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/DiagnosticsReport.java
+++ b/app/src/main/java/app/sabre/wzsabre/DiagnosticsReport.java
@@ -1,0 +1,113 @@
+package app.sabre.wzsabre;
+
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds the user-facing, privacy-safe "Share diagnostics" text report. The report
+ * is assembled from four independently toggleable sections (see {@link #SECTION_LABELS})
+ * so the user decides exactly what leaves their device. Every section contains only
+ * versions, counts, category names, and error strings: no location, street names,
+ * alert IDs, or personal data is ever included.
+ */
+public final class DiagnosticsReport {
+    private DiagnosticsReport() {}
+
+    /**
+     * The four categories the user can individually include or exclude. Index order
+     * matches the booleans passed to {@link #build}.
+     */
+    public static final String[] SECTION_LABELS = {
+        "App and device (SABRE Plus version, Android version, phone model)",
+        "Highway Radar (its version, and whether it is requesting data)",
+        "Alert counts and types (numbers and category names only)",
+        "Activity and crashes (recent plugin events, never any location)"
+    };
+
+    private static final String[] SOURCES = {
+        SabreResponseBuilder.SOURCE_CHP, SabreResponseBuilder.SOURCE_WAZE,
+        SabreResponseBuilder.SOURCE_LCS, SabreResponseBuilder.SOURCE_FIRE,
+        SabreResponseBuilder.SOURCE_CHAINS
+    };
+
+    public static String build(Context ctx, boolean appDevice, boolean hr,
+                               boolean sources, boolean activity) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("SABRE Plus diagnostics\n");
+        sb.append("Contains no location, street names, or personal data.\n");
+
+        if (appDevice) {
+            sb.append("\n[App and device]\n");
+            sb.append("SABRE Plus ").append(BuildConfig.VERSION_NAME)
+              .append(" (build ").append(BuildConfig.VERSION_CODE).append(")\n");
+            sb.append("Android ").append(Build.VERSION.RELEASE)
+              .append(" (API ").append(Build.VERSION.SDK_INT).append("), ")
+              .append(Build.MANUFACTURER).append(' ').append(Build.MODEL).append('\n');
+        }
+
+        if (hr) {
+            sb.append("\n[Highway Radar]\n");
+            sb.append("Installed: ").append(hrVersion(ctx)).append('\n');
+            sb.append("Plugin service running: ").append(SabreService.RUNNING ? "yes" : "no").append('\n');
+            long age = DebugLog.lastFetchAgeMs();
+            sb.append("Last request from Highway Radar: ")
+              .append(age < 0 ? "none this session" : (age / 1000) + "s ago").append('\n');
+        }
+
+        if (sources) {
+            sb.append("\n[Alert sources]\n");
+            for (String s : SOURCES) {
+                SourceStatus.Entry e = SourceStatus.get(s);
+                sb.append("  ").append(s).append(": ");
+                if (e == null) {
+                    sb.append("no data yet\n");
+                } else if (e.lastError != null) {
+                    sb.append(e.count).append(" items, error: ").append(e.lastError).append('\n');
+                } else {
+                    sb.append(e.count).append(" items");
+                    if (e.lastUpdateMs > 0) {
+                        sb.append(", ok ").append((System.currentTimeMillis() - e.lastUpdateMs) / 1000).append("s ago");
+                    }
+                    sb.append('\n');
+                }
+            }
+            String summary = DebugLog.lastFetchSummary();
+            if (summary != null) sb.append("  last ").append(summary).append('\n');
+            Map<String, Integer> types = DebugLog.lastFetchTypes();
+            if (!types.isEmpty()) {
+                sb.append("Alert types sent to Highway Radar (category names only):\n");
+                for (Map.Entry<String, Integer> t : types.entrySet()) {
+                    sb.append("  ").append(t.getKey()).append(" x").append(t.getValue()).append('\n');
+                }
+            }
+        }
+
+        if (activity) {
+            sb.append("\n[Recent activity]\n");
+            List<String> events = DebugLog.recentEvents();
+            if (events.isEmpty()) {
+                sb.append("  (none yet)\n");
+            } else {
+                for (String line : events) sb.append(line).append('\n');
+            }
+            String[] crash = CrashLog.readSummary(ctx);
+            sb.append("Last crash: ").append(crash == null ? "none" : crash[1]).append('\n');
+        }
+
+        return sb.toString();
+    }
+
+    private static String hrVersion(Context ctx) {
+        try {
+            PackageInfo pi = ctx.getPackageManager().getPackageInfo("com.highwayradar.app", 0);
+            return "yes, v" + pi.versionName;
+        } catch (PackageManager.NameNotFoundException e) {
+            return "not installed";
+        }
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -2,6 +2,7 @@ package app.sabre.wzsabre;
 
 import android.Manifest;
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -62,6 +63,7 @@ public class MainActivity extends Activity {
         buildAgeSpinner();
         buildDiagnostics();
         buildReportButton();
+        buildShareDiagnostics();
         checkForUpdate();
     }
 
@@ -85,6 +87,36 @@ public class MainActivity extends Activity {
                             Uri.parse("https://github.com/nicglazkov/highway-radar-sabre-plus/issues")));
                 } catch (Exception ignored) {}
             }
+        });
+    }
+
+    /**
+     * "Share diagnostics" opens a popup where the user chooses which of the four
+     * categories to include, then shares a plain-text report via the Android share
+     * sheet. Every category is already free of location and personal data (see
+     * {@link DiagnosticsReport}); the checkboxes just give the user final say over
+     * what leaves the device. Uses ACTION_SEND, so no new permission is needed.
+     */
+    private void buildShareDiagnostics() {
+        findViewById(R.id.shareDiagnosticsButton).setOnClickListener(v -> {
+            final boolean[] include = {true, true, true, true};
+            new AlertDialog.Builder(this)
+                .setTitle("Share diagnostics")
+                .setMultiChoiceItems(DiagnosticsReport.SECTION_LABELS, include,
+                        (d, which, checked) -> include[which] = checked)
+                .setPositiveButton("Share", (d, w) -> {
+                    String report = DiagnosticsReport.build(
+                            this, include[0], include[1], include[2], include[3]);
+                    Intent send = new Intent(Intent.ACTION_SEND);
+                    send.setType("text/plain");
+                    send.putExtra(Intent.EXTRA_SUBJECT, "SABRE Plus diagnostics");
+                    send.putExtra(Intent.EXTRA_TEXT, report);
+                    try {
+                        startActivity(Intent.createChooser(send, "Share diagnostics"));
+                    } catch (Exception ignored) {}
+                })
+                .setNeutralButton("Cancel", null)
+                .show();
         });
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -76,6 +76,7 @@ public class SabreService extends Service {
     public void onCreate() {
         super.onCreate();
         RUNNING = true;
+        DebugLog.event("service started");
         requestExecutor = Executors.newSingleThreadExecutor();
         fetchExecutor   = Executors.newFixedThreadPool(5);
         chpSource  = new CHPSource();
@@ -214,6 +215,7 @@ public class SabreService extends Service {
     @Override
     public void onDestroy() {
         RUNNING = false;
+        DebugLog.event("service stopped");
         lifecycleHandler.removeCallbacks(stopRunnable);
         if (requestExecutor != null) requestExecutor.shutdownNow();
         if (fetchExecutor   != null) fetchExecutor.shutdownNow();
@@ -230,6 +232,7 @@ public class SabreService extends Service {
     private static final long RESPONSE_BUDGET_MS = 8_000;
 
     private void handleFetchRequest(String data) {
+        DebugLog.fetchReceived();
         requestExecutor.submit(() -> {
             // Parsed up front so the catch block can still answer HR with an error
             // response — an unanswered request makes HR show "plugin not responding".
@@ -344,6 +347,7 @@ public class SabreService extends Service {
                 // the same spot) before sending.
                 int rawCount = allAlerts.size();
                 List<SabreAlert> finalAlerts = AlertDeduper.dedupe(allAlerts);
+                DebugLog.recordFetch(finalAlerts, rawCount);
                 Log.d(TAG, "Sending " + finalAlerts.size() + " alerts (" + rawCount + " before dedupe)");
                 sendFetchResponse(responseAction, requestId, finalAlerts);
             } catch (Exception e) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -386,6 +386,14 @@
             android:elevation="1dp"
             android:padding="16dp" />
 
+        <Button
+            android:id="@+id/shareDiagnosticsButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Share diagnostics"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="4dp" />
+
         <!-- ── About ─────────────────────────────────────────────────────── -->
         <TextView
             android:layout_width="match_parent"

--- a/app/src/test/java/app/sabre/wzsabre/DebugLogTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/DebugLogTest.java
@@ -1,0 +1,75 @@
+package app.sabre.wzsabre;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Locks the privacy guarantee of the diagnostics buffer: it records only source ids,
+ * alert-type category names, and counts, and can NEVER contain street names or
+ * coordinates even when the alerts it summarizes carry them.
+ */
+public class DebugLogTest {
+
+    @Before public void reset() { DebugLog.clear(); }
+
+    private SabreAlert alert(String source, String type, String street) {
+        // distinctive street + coordinates that must not appear in any shared output
+        return new SabreAlert("id-" + type, source, type,
+                37.775012345, -122.418698765, 90.0, street, 1_700_000_000L);
+    }
+
+    @Test
+    public void recordFetch_countsBySourceAndType() {
+        DebugLog.recordFetch(Arrays.asList(
+                alert("chp", "ACCIDENT_MINOR", "SECRET STREET NAME"),
+                alert("chp", "ACCIDENT_MINOR", "123 Private Ave"),
+                alert("waze", "HAZARD_ON_ROAD_CONGESTION", "Confidential Blvd")
+        ), 5);
+
+        String summary = DebugLog.lastFetchSummary();
+        assertTrue("total", summary.contains("sent 3 of 5"));
+        assertTrue("per-source counts", summary.contains("chp2") && summary.contains("waze1"));
+
+        Map<String, Integer> types = DebugLog.lastFetchTypes();
+        assertEquals(Integer.valueOf(2), types.get("ACCIDENT_MINOR"));
+        assertEquals(Integer.valueOf(1), types.get("HAZARD_ON_ROAD_CONGESTION"));
+    }
+
+    @Test
+    public void recordFetch_neverLeaksStreetsOrCoordinates() {
+        DebugLog.recordFetch(Arrays.asList(
+                alert("chp", "ACCIDENT_MINOR", "SECRET STREET NAME"),
+                alert("waze", "POLICE_VISIBLE", "Confidential Blvd 123 Private Ave")
+        ), 2);
+
+        String all = DebugLog.lastFetchSummary() + DebugLog.lastFetchTypes() + DebugLog.recentEvents();
+        assertFalse("street name leaked", all.contains("SECRET STREET NAME"));
+        assertFalse("street name leaked", all.contains("Confidential") || all.contains("Blvd") || all.contains("Ave"));
+        assertFalse("latitude leaked",  all.contains("37.775"));
+        assertFalse("longitude leaked", all.contains("122.418"));
+    }
+
+    @Test
+    public void event_ringBufferCapsAndKeepsMostRecent() {
+        for (int i = 0; i < 100; i++) DebugLog.event("evt" + i);
+        List<String> ev = DebugLog.recentEvents();
+        assertTrue("capped at 60", ev.size() <= 60);
+        assertTrue("keeps most recent", ev.get(ev.size() - 1).contains("evt99"));
+        assertFalse("drops oldest", ev.get(0).contains("evt0 "));
+    }
+
+    @Test
+    public void fetchReceived_setsAge() {
+        assertEquals(-1, DebugLog.lastFetchAgeMs());
+        DebugLog.fetchReceived();
+        assertTrue(DebugLog.lastFetchAgeMs() >= 0);
+    }
+}


### PR DESCRIPTION
A 'Share diagnostics' button lets users troubleshoot without ADB. Tapping it opens a popup to choose which of four categories to include, then shares a plain-text report via the share sheet. Content is curated (versions, counts, alert type category names, recent events) and never includes location, street names, alert details, or personal data. New DebugLog buffer reads only source/type off alerts; unit tests lock the no-PII guarantee. v1.9.