### PR TITLE
Ultra-detailed Share diagnostics (no PII)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.9.1] - 2026-07-10
+
+### Changed
+- The Share diagnostics report is now much more detailed. It adds device ABIs, all of your settings and category toggles, the Highway Radar version and how often it is requesting data, the exact alert types being sent (category names only), per-source health, and a longer activity timeline including source refreshes, Waze session events, and service lifecycle. It still contains no location, street names, alert details, or personal data.
+
 ## [1.9] - 2026-07-10
 
 ### Added
@@ -151,6 +156,7 @@ Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrot
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
+[1.9.1]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.9.1
 [1.9]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.9
 [1.8.5]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.5
 [1.8.4]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 20
-        versionName = "1.9"
+        versionCode = 21
+        versionName = "1.9.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/App.java
+++ b/app/src/main/java/app/sabre/wzsabre/App.java
@@ -7,9 +7,15 @@ import android.app.Application;
  * the platform's default handler, so the settings diagnostics panel can show it.
  */
 public class App extends Application {
+
+    /** Wall-clock time this process started, for the diagnostics "app uptime" line. */
+    public static volatile long PROCESS_START_MS = 0L;
+
     @Override
     public void onCreate() {
         super.onCreate();
+        PROCESS_START_MS = System.currentTimeMillis();
+        DebugLog.event("app process started");
         final Thread.UncaughtExceptionHandler previous =
                 Thread.getDefaultUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {

--- a/app/src/main/java/app/sabre/wzsabre/CHPSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/CHPSource.java
@@ -106,6 +106,7 @@ public class CHPSource {
                         cache = parsed;
                         cacheTimeMs = System.currentTimeMillis();
                         Log.d(TAG, "CHP refreshed: " + parsed.size() + " statewide incidents");
+                        DebugLog.event("chp: refreshed " + parsed.size() + " statewide");
                     } else {
                         cacheTimeMs = System.currentTimeMillis();   // fresh enough, unchanged
                     }
@@ -116,6 +117,7 @@ public class CHPSource {
                     // blank CHP for the whole cycle.
                     Log.w(TAG, "CHP refresh failed (serving cache): "
                             + e.getClass().getSimpleName() + ": " + e.getMessage());
+                    DebugLog.event("chp: refresh failed " + e.getClass().getSimpleName());
                     SourceStatus.failure(SabreResponseBuilder.SOURCE_CHP,
                             e.getClass().getSimpleName());
                 } finally {

--- a/app/src/main/java/app/sabre/wzsabre/DebugLog.java
+++ b/app/src/main/java/app/sabre/wzsabre/DebugLog.java
@@ -23,7 +23,7 @@ import java.util.Map;
 public final class DebugLog {
     private DebugLog() {}
 
-    private static final int MAX_EVENTS = 60;
+    private static final int MAX_EVENTS = 150;
 
     private static final class Ev {
         final long ts; final String msg;
@@ -32,6 +32,8 @@ public final class DebugLog {
 
     private static final Deque<Ev> EVENTS = new ArrayDeque<>();
     private static volatile long lastFetchReceivedMs = 0;
+    private static volatile long lastFetchIntervalMs = 0;
+    private static volatile int  fetchCount = 0;
     private static volatile String lastFetchSummary = null;
     private static final Map<String, Integer> lastFetchTypes = new LinkedHashMap<>();
 
@@ -43,7 +45,10 @@ public final class DebugLog {
 
     /** Note that Highway Radar asked us for data (drives "HR last requested Ns ago"). */
     public static synchronized void fetchReceived() {
-        lastFetchReceivedMs = System.currentTimeMillis();
+        long now = System.currentTimeMillis();
+        if (lastFetchReceivedMs > 0) lastFetchIntervalMs = now - lastFetchReceivedMs;
+        lastFetchReceivedMs = now;
+        fetchCount++;
     }
 
     /**
@@ -80,6 +85,9 @@ public final class DebugLog {
         return (lastFetchReceivedMs == 0) ? -1 : System.currentTimeMillis() - lastFetchReceivedMs;
     }
 
+    public static synchronized int  sessionFetchCount()   { return fetchCount; }
+    public static synchronized long lastFetchIntervalMs() { return lastFetchIntervalMs; }
+
     public static synchronized String lastFetchSummary() { return lastFetchSummary; }
 
     public static synchronized Map<String, Integer> lastFetchTypes() {
@@ -101,6 +109,8 @@ public final class DebugLog {
     static synchronized void clear() {
         EVENTS.clear();
         lastFetchReceivedMs = 0;
+        lastFetchIntervalMs = 0;
+        fetchCount = 0;
         lastFetchSummary = null;
         lastFetchTypes.clear();
     }

--- a/app/src/main/java/app/sabre/wzsabre/DiagnosticsReport.java
+++ b/app/src/main/java/app/sabre/wzsabre/DiagnosticsReport.java
@@ -1,19 +1,23 @@
 package app.sabre.wzsabre;
 
+import android.app.NotificationManager;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.os.PowerManager;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 /**
  * Builds the user-facing, privacy-safe "Share diagnostics" text report. The report
  * is assembled from four independently toggleable sections (see {@link #SECTION_LABELS})
  * so the user decides exactly what leaves their device. Every section contains only
- * versions, counts, category names, and error strings: no location, street names,
- * alert IDs, or personal data is ever included.
+ * versions, settings, counts, category names, and error strings: no location, street
+ * names, alert IDs, or personal data is ever included.
  */
 public final class DiagnosticsReport {
     private DiagnosticsReport() {}
@@ -23,12 +27,13 @@ public final class DiagnosticsReport {
      * matches the booleans passed to {@link #build}.
      */
     public static final String[] SECTION_LABELS = {
-        "App and device (SABRE Plus version, Android version, phone model)",
+        "App, device and settings (versions, toggles, no personal data)",
         "Highway Radar (its version, and whether it is requesting data)",
         "Alert counts and types (numbers and category names only)",
         "Activity and crashes (recent plugin events, never any location)"
     };
 
+    private static final String HR_PKG = "com.highwayradar.app";
     private static final String[] SOURCES = {
         SabreResponseBuilder.SOURCE_CHP, SabreResponseBuilder.SOURCE_WAZE,
         SabreResponseBuilder.SOURCE_LCS, SabreResponseBuilder.SOURCE_FIRE,
@@ -41,73 +46,174 @@ public final class DiagnosticsReport {
         sb.append("SABRE Plus diagnostics\n");
         sb.append("Contains no location, street names, or personal data.\n");
 
-        if (appDevice) {
-            sb.append("\n[App and device]\n");
-            sb.append("SABRE Plus ").append(BuildConfig.VERSION_NAME)
-              .append(" (build ").append(BuildConfig.VERSION_CODE).append(")\n");
-            sb.append("Android ").append(Build.VERSION.RELEASE)
-              .append(" (API ").append(Build.VERSION.SDK_INT).append("), ")
-              .append(Build.MANUFACTURER).append(' ').append(Build.MODEL).append('\n');
-        }
-
-        if (hr) {
-            sb.append("\n[Highway Radar]\n");
-            sb.append("Installed: ").append(hrVersion(ctx)).append('\n');
-            sb.append("Plugin service running: ").append(SabreService.RUNNING ? "yes" : "no").append('\n');
-            long age = DebugLog.lastFetchAgeMs();
-            sb.append("Last request from Highway Radar: ")
-              .append(age < 0 ? "none this session" : (age / 1000) + "s ago").append('\n');
-        }
-
-        if (sources) {
-            sb.append("\n[Alert sources]\n");
-            for (String s : SOURCES) {
-                SourceStatus.Entry e = SourceStatus.get(s);
-                sb.append("  ").append(s).append(": ");
-                if (e == null) {
-                    sb.append("no data yet\n");
-                } else if (e.lastError != null) {
-                    sb.append(e.count).append(" items, error: ").append(e.lastError).append('\n');
-                } else {
-                    sb.append(e.count).append(" items");
-                    if (e.lastUpdateMs > 0) {
-                        sb.append(", ok ").append((System.currentTimeMillis() - e.lastUpdateMs) / 1000).append("s ago");
-                    }
-                    sb.append('\n');
-                }
-            }
-            String summary = DebugLog.lastFetchSummary();
-            if (summary != null) sb.append("  last ").append(summary).append('\n');
-            Map<String, Integer> types = DebugLog.lastFetchTypes();
-            if (!types.isEmpty()) {
-                sb.append("Alert types sent to Highway Radar (category names only):\n");
-                for (Map.Entry<String, Integer> t : types.entrySet()) {
-                    sb.append("  ").append(t.getKey()).append(" x").append(t.getValue()).append('\n');
-                }
-            }
-        }
-
-        if (activity) {
-            sb.append("\n[Recent activity]\n");
-            List<String> events = DebugLog.recentEvents();
-            if (events.isEmpty()) {
-                sb.append("  (none yet)\n");
-            } else {
-                for (String line : events) sb.append(line).append('\n');
-            }
-            String[] crash = CrashLog.readSummary(ctx);
-            sb.append("Last crash: ").append(crash == null ? "none" : crash[1]).append('\n');
-        }
+        if (appDevice) appDeviceSection(ctx, sb);
+        if (hr)        highwayRadarSection(ctx, sb);
+        if (sources)   sourcesSection(sb);
+        if (activity)  activitySection(ctx, sb);
 
         return sb.toString();
     }
 
+    private static void appDeviceSection(Context ctx, StringBuilder sb) {
+        sb.append("\n[App]\n");
+        sb.append("SABRE Plus ").append(BuildConfig.VERSION_NAME)
+          .append(" (build ").append(BuildConfig.VERSION_CODE)
+          .append(", ").append(BuildConfig.DEBUG ? "debug" : "release").append(")\n");
+        sb.append("Package: ").append(ctx.getPackageName()).append('\n');
+        long up = App.PROCESS_START_MS > 0 ? System.currentTimeMillis() - App.PROCESS_START_MS : -1;
+        sb.append("App process uptime: ").append(up < 0 ? "unknown" : fmtDur(up)).append('\n');
+        sb.append("Notifications enabled: ").append(bool(notificationsEnabled(ctx))).append('\n');
+        sb.append("Battery-optimization exempt: ").append(bool(batteryExempt(ctx))).append('\n');
+
+        sb.append("\n[Device]\n");
+        sb.append("Android ").append(Build.VERSION.RELEASE)
+          .append(" (API ").append(Build.VERSION.SDK_INT).append(")\n");
+        sb.append("Model: ").append(Build.MANUFACTURER).append(' ').append(Build.MODEL)
+          .append(" (").append(Build.DEVICE).append(")\n");
+        sb.append("ABIs: ").append(join(Build.SUPPORTED_ABIS)).append('\n');
+        sb.append("Locale: ").append(Locale.getDefault())
+          .append(", timezone: ").append(TimeZone.getDefault().getID()).append('\n');
+
+        settingsSection(ctx, sb);
+    }
+
+    private static void settingsSection(Context ctx, StringBuilder sb) {
+        sb.append("\n[Settings]\n");
+        try {
+            ChpConfig cfg = ChpConfig.load(ctx);
+            sb.append("Sources: Caltrans closures ").append(onOff(cfg.lcsEnabled))
+              .append(", wildfires ").append(onOff(cfg.fireEnabled))
+              .append(", chain controls ").append(onOff(cfg.chainsEnabled)).append('\n');
+            sb.append("Update notifications: ").append(onOff(cfg.updateNotifyEnabled)).append('\n');
+            sb.append("Wildfire minimum size: ").append(cfg.fireMinAcres).append("+ acres\n");
+            sb.append("Incident age filter: ").append(cfg.maxAgeMinutes).append(" min\n");
+            sb.append("Waze categories: police ").append(onOff(cfg.wazePolice))
+              .append(", accidents ").append(onOff(cfg.wazeAccidents))
+              .append(", hazards ").append(onOff(cfg.wazeHazards))
+              .append(", jams ").append(onOff(cfg.wazeJams))
+              .append(", closures ").append(onOff(cfg.wazeClosures)).append('\n');
+            sb.append("CHP categories:\n");
+            for (ChpCategory cat : ChpCategory.values()) {
+                String override = cfg.getTypeOverride(cat);
+                sb.append("  ").append(cat.name()).append(": ").append(onOff(cfg.isEnabled(cat)));
+                if (override != null && !override.isEmpty()) sb.append(", shows as ").append(override);
+                sb.append('\n');
+            }
+        } catch (Exception e) {
+            sb.append("(settings unavailable: ").append(e.getClass().getSimpleName()).append(")\n");
+        }
+    }
+
+    private static void highwayRadarSection(Context ctx, StringBuilder sb) {
+        sb.append("\n[Highway Radar]\n");
+        sb.append("Installed: ").append(hrVersion(ctx)).append('\n');
+        sb.append("Plugin service running: ").append(bool(SabreService.RUNNING)).append('\n');
+        long age = DebugLog.lastFetchAgeMs();
+        sb.append("Last request from Highway Radar: ")
+          .append(age < 0 ? "none this session" : fmtAge(age)).append('\n');
+        sb.append("Requests this session: ").append(DebugLog.sessionFetchCount()).append('\n');
+        long interval = DebugLog.lastFetchIntervalMs();
+        sb.append("Recent request interval: ")
+          .append(interval <= 0 ? "n/a" : (interval / 1000) + "s").append('\n');
+        sb.append("We advertise to HR: id=app.sabre.wzsabre, version=").append(BuildConfig.VERSION_NAME)
+          .append(", sources=[chp,waze,lcs,fire,chains]\n");
+        sb.append("Request action: app.sabre.wzsabre.FETCH_REQUEST\n");
+    }
+
+    private static void sourcesSection(StringBuilder sb) {
+        sb.append("\n[Alert sources]\n");
+        for (String s : SOURCES) {
+            SourceStatus.Entry e = SourceStatus.get(s);
+            sb.append("  ").append(s).append(": ");
+            if (e == null) {
+                sb.append("no data yet\n");
+            } else if (e.lastError != null) {
+                sb.append(e.count).append(" items, ERROR: ").append(e.lastError).append('\n');
+            } else {
+                sb.append(e.count).append(" items");
+                if (e.lastUpdateMs > 0) sb.append(", ok ").append(fmtAge(System.currentTimeMillis() - e.lastUpdateMs));
+                sb.append('\n');
+            }
+        }
+        String summary = DebugLog.lastFetchSummary();
+        if (summary != null) sb.append("Last fetch: ").append(summary).append('\n');
+        Map<String, Integer> types = DebugLog.lastFetchTypes();
+        if (types.isEmpty()) {
+            sb.append("Alert types sent to Highway Radar: (none captured yet)\n");
+        } else {
+            sb.append("Alert types sent to Highway Radar (category names only):\n");
+            for (Map.Entry<String, Integer> t : types.entrySet()) {
+                sb.append("  ").append(t.getKey()).append(" x").append(t.getValue()).append('\n');
+            }
+        }
+    }
+
+    private static void activitySection(Context ctx, StringBuilder sb) {
+        sb.append("\n[Recent activity]\n");
+        List<String> events = DebugLog.recentEvents();
+        if (events.isEmpty()) {
+            sb.append("  (none yet)\n");
+        } else {
+            for (String line : events) sb.append(line).append('\n');
+        }
+        String[] crash = CrashLog.readSummary(ctx);
+        sb.append("\n[Last crash]\n");
+        if (crash == null) {
+            sb.append("none\n");
+        } else {
+            sb.append(crash[0]).append('\n').append(crash[1]).append('\n');
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
     private static String hrVersion(Context ctx) {
         try {
-            PackageInfo pi = ctx.getPackageManager().getPackageInfo("com.highwayradar.app", 0);
-            return "yes, v" + pi.versionName;
+            PackageInfo pi = ctx.getPackageManager().getPackageInfo(HR_PKG, 0);
+            long code = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+                    ? pi.getLongVersionCode() : pi.versionCode;
+            return "yes, v" + pi.versionName + " (build " + code + ")";
         } catch (PackageManager.NameNotFoundException e) {
             return "not installed";
         }
+    }
+
+    private static boolean notificationsEnabled(Context ctx) {
+        try {
+            NotificationManager nm = ctx.getSystemService(NotificationManager.class);
+            return nm != null && nm.areNotificationsEnabled();
+        } catch (Exception e) { return false; }
+    }
+
+    private static boolean batteryExempt(Context ctx) {
+        try {
+            PowerManager pm = ctx.getSystemService(PowerManager.class);
+            return pm != null && pm.isIgnoringBatteryOptimizations(ctx.getPackageName());
+        } catch (Exception e) { return false; }
+    }
+
+    private static String bool(boolean b)  { return b ? "yes" : "no"; }
+    private static String onOff(boolean b) { return b ? "on" : "off"; }
+
+    private static String join(String[] arr) {
+        if (arr == null || arr.length == 0) return "?";
+        StringBuilder b = new StringBuilder();
+        for (int i = 0; i < arr.length; i++) { if (i > 0) b.append(", "); b.append(arr[i]); }
+        return b.toString();
+    }
+
+    private static String fmtAge(long ms) {
+        long s = ms / 1000;
+        if (s < 60) return s + "s ago";
+        if (s < 3600) return (s / 60) + "m ago";
+        return (s / 3600) + "h ago";
+    }
+
+    private static String fmtDur(long ms) {
+        long s = ms / 1000;
+        long h = s / 3600, m = (s % 3600) / 60, sec = s % 60;
+        if (h > 0) return h + "h " + m + "m";
+        if (m > 0) return m + "m " + sec + "s";
+        return sec + "s";
     }
 }

--- a/app/src/main/java/app/sabre/wzsabre/LcsSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/LcsSource.java
@@ -147,12 +147,14 @@ public class LcsSource {
                 List<Closure> parsed = fetchDistrict(district);
                 cache.put(district, new CacheEntry(parsed, System.currentTimeMillis()));
                 Log.d(TAG, "D" + district + " refreshed: " + parsed.size() + " closure records");
+                DebugLog.event("lcs D" + district + ": " + parsed.size() + " closures");
                 int total = 0;
                 for (CacheEntry ce : cache.values()) total += ce.closures.size();
                 SourceStatus.success(SabreResponseBuilder.SOURCE_LCS, total);
             } catch (Exception e) {
                 Log.w(TAG, "D" + district + " refresh failed: "
                         + e.getClass().getSimpleName() + ": " + e.getMessage());
+                DebugLog.event("lcs D" + district + ": failed " + e.getClass().getSimpleName());
                 SourceStatus.failure(SabreResponseBuilder.SOURCE_LCS,
                         "D" + district + " " + e.getClass().getSimpleName());
             } finally {

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -107,6 +107,7 @@ public class MainActivity extends Activity {
                 .setPositiveButton("Share", (d, w) -> {
                     String report = DiagnosticsReport.build(
                             this, include[0], include[1], include[2], include[3]);
+                    if (BuildConfig.DEBUG) android.util.Log.d("SABREDiag", report);
                     Intent send = new Intent(Intent.ACTION_SEND);
                     send.setType("text/plain");
                     send.putExtra(Intent.EXTRA_SUBJECT, "SABRE Plus diagnostics");

--- a/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
@@ -112,11 +112,13 @@ public class WildfireSource {
                     List<Fire> parsed = fetchAndParse();
                     cache = new Snapshot(parsed, System.currentTimeMillis());
                     Log.d(TAG, "Wildfires refreshed: " + parsed.size() + " active in CA");
+                    DebugLog.event("fire: " + parsed.size() + " active in CA");
                     SourceStatus.success(SabreResponseBuilder.SOURCE_FIRE, parsed.size());
                 } catch (Exception e) {
                     // Keep serving the last good parse on a transient failure.
                     Log.w(TAG, "Wildfire refresh failed (serving cache): "
                             + e.getClass().getSimpleName() + ": " + e.getMessage());
+                    DebugLog.event("fire: refresh failed " + e.getClass().getSimpleName());
                     SourceStatus.failure(SabreResponseBuilder.SOURCE_FIRE, e.getClass().getSimpleName());
                 } finally {
                     refreshing.set(false);

--- a/app/src/main/java/app/sabre/wzsabre/WinterSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/WinterSource.java
@@ -107,11 +107,13 @@ public class WinterSource {
                 for (CacheEntry ce : cache.values()) total += ce.records.size();
                 SourceStatus.success(SabreResponseBuilder.SOURCE_CHAINS, total);
                 Log.d(TAG, "D" + district + " chain controls: " + parsed.size() + " records");
+                DebugLog.event("chains D" + district + ": " + parsed.size() + " records");
             } catch (Exception e) {
                 SourceStatus.failure(SabreResponseBuilder.SOURCE_CHAINS,
                         "D" + district + " " + e.getClass().getSimpleName());
                 Log.w(TAG, "D" + district + " chain-control refresh failed: "
                         + e.getClass().getSimpleName() + ": " + e.getMessage());
+                DebugLog.event("chains D" + district + ": failed " + e.getClass().getSimpleName());
             } finally {
                 flag.set(false);
             }
@@ -136,6 +138,7 @@ public class WinterSource {
             // from getResponseCode() above and surface as an error.
             if (code != HttpsURLConnection.HTTP_OK) {
                 Log.d(TAG, "D" + district + " chain-control feed HTTP " + code + "; treating as no data");
+                DebugLog.event("chains D" + district + ": HTTP " + code + " (no data)");
                 return new ArrayList<>();
             }
             try (InputStream in = conn.getInputStream()) {

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import app.sabre.wzsabre.SabreAlert;
 import app.sabre.wzsabre.AlertMapper;
+import app.sabre.wzsabre.DebugLog;
 import app.sabre.wzsabre.SabreResponseBuilder;
 import app.sabre.wzsabre.SourceStatus;
 
@@ -152,6 +153,7 @@ public final class WazeProtocolSource {
                     cacheLon = lon;
                 } catch (Exception e) {
                     Log.w(TAG, "Waze refresh failed: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+                    DebugLog.event("waze: refresh failed " + e.getClass().getSimpleName());
                     SourceStatus.failure(SabreResponseBuilder.SOURCE_WAZE, e.getClass().getSimpleName());
                     // Don't retry a failure at poll cadence. A rejection already set a
                     // longer backoff in handleAccountRejected; only add the short generic
@@ -182,6 +184,7 @@ public final class WazeProtocolSource {
         SourceStatus.success(SabreResponseBuilder.SOURCE_WAZE, alertCache.size());
         Log.d(TAG, "Waze cache: " + alertCache.size() + " alerts near "
                 + String.format(Locale.US, "%.4f,%.4f", lat, lon));
+        DebugLog.event("waze: cache " + alertCache.size() + " alerts");   // count only, no location
     }
 
     /**
@@ -202,10 +205,12 @@ public final class WazeProtocolSource {
         if (!canRegisterToday() || consecutiveRejections > WazeConstants.MAX_CONSECUTIVE_REJECTIONS) {
             Log.w(TAG, "Account rejected; registration cap/limit reached (" + consecutiveRejections
                     + " consecutive) — backing off without re-registering: " + e.getMessage());
+            DebugLog.event("waze: rejected, cap reached (" + consecutiveRejections + " consecutive)");
             throw e;
         }
         Log.w(TAG, "Account rejected — re-registering (attempt " + consecutiveRejections + "): "
                 + e.getMessage());
+        DebugLog.event("waze: rejected, re-registering (attempt " + consecutiveRejections + ")");
         session = null;
         clearPersisted();
         recordRegistration();
@@ -217,6 +222,7 @@ public final class WazeProtocolSource {
         long delay = Math.min(BACKOFF_MAX_MS, BACKOFF_BASE_MS * (1L << (step - 1)));
         backoffUntilMs = SystemClock.elapsedRealtime() + delay;
         Log.d(TAG, "Waze refresh backing off " + (delay / 1000) + "s");
+        DebugLog.event("waze: backing off " + (delay / 1000) + "s");
     }
 
     private boolean canRegisterToday() {

--- a/app/src/test/java/app/sabre/wzsabre/DebugLogTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/DebugLogTest.java
@@ -59,10 +59,10 @@ public class DebugLogTest {
 
     @Test
     public void event_ringBufferCapsAndKeepsMostRecent() {
-        for (int i = 0; i < 100; i++) DebugLog.event("evt" + i);
+        for (int i = 0; i < 300; i++) DebugLog.event("evt" + i);
         List<String> ev = DebugLog.recentEvents();
-        assertTrue("capped at 60", ev.size() <= 60);
-        assertTrue("keeps most recent", ev.get(ev.size() - 1).contains("evt99"));
+        assertTrue("capped at 150", ev.size() <= 150);
+        assertTrue("keeps most recent", ev.get(ev.size() - 1).contains("evt299"));
         assertFalse("drops oldest", ev.get(0).contains("evt0 "));
     }
 


### PR DESCRIPTION
Expands the diagnostics report with device ABIs, a full settings dump, HR version + polling cadence, the alert-type histogram, and a 150-event activity timeline (per-source refreshes, Waze session events, service lifecycle). Curated DebugLog events wired into every source; still only counts/type names/errors, never location or personal data. Verified the live report on API 30. v1.9.1.