### PR TITLE
Fix: answer official wzsabre action names (cached HR registration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.9.2] - 2026-07-10
+
+### Fixed
+- **Fixes "plugin installed but no alerts" for anyone who used the original wzsabre first.** Highway Radar remembers a plugin by its ID and keeps the original wzsabre's cached setup even after you switch to SABRE Plus, so it kept asking for data using wzsabre's request name, which SABRE Plus did not answer (Highway Radar showed "Crowd-sourced alerts problems" and never sent a request). SABRE Plus now also answers the original wzsabre's request names, so Highway Radar starts receiving alerts immediately, with no need to re-detect the plugin.
+
 ## [1.9.1] - 2026-07-10
 
 ### Changed
@@ -156,6 +161,7 @@ Restored the plugin on Android 15/16 (foreground-service start fixes) and rewrot
 
 Initial release: CHP live incidents + Waze crowdsourced alerts for Highway Radar.
 
+[1.9.2]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.9.2
 [1.9.1]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.9.1
 [1.9]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.9
 [1.8.5]: https://github.com/nicglazkov/highway-radar-sabre-plus/releases/tag/v1.8.5

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 21
-        versionName = "1.9.1"
+        versionCode = 22
+        versionName = "1.9.2"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,6 +75,13 @@
             <intent-filter>
                 <action android:name="app.sabre.HANDSHAKE" />
                 <action android:name="app.sabre.wzsabre.HANDSHAKE" />
+                <!-- Official wzsabre action names: HR may have cached a wzsabre
+                     registration (same package id) and fires these at us. -->
+                <action android:name="app.sabre.wzsabre.REQUEST" />
+                <action android:name="app.sabre.wzsabre.REPORT" />
+                <action android:name="app.sabre.wzsabre.CONFIRM" />
+                <action android:name="app.sabre.wzsabre.DISCARD" />
+                <!-- Our older action names, kept for any HR that cached them. -->
                 <action android:name="app.sabre.wzsabre.FETCH_REQUEST" />
                 <action android:name="app.sabre.wzsabre.SUBMIT_REPORT" />
                 <action android:name="app.sabre.wzsabre.CONFIRM_REPORT" />

--- a/app/src/main/java/app/sabre/wzsabre/DebugLog.java
+++ b/app/src/main/java/app/sabre/wzsabre/DebugLog.java
@@ -34,6 +34,7 @@ public final class DebugLog {
     private static volatile long lastFetchReceivedMs = 0;
     private static volatile long lastFetchIntervalMs = 0;
     private static volatile int  fetchCount = 0;
+    private static volatile String lastFetchAction = null;
     private static volatile String lastFetchSummary = null;
     private static final Map<String, Integer> lastFetchTypes = new LinkedHashMap<>();
 
@@ -88,6 +89,10 @@ public final class DebugLog {
     public static synchronized int  sessionFetchCount()   { return fetchCount; }
     public static synchronized long lastFetchIntervalMs() { return lastFetchIntervalMs; }
 
+    /** The action HR fired the last fetch on (our FETCH_REQUEST vs official REQUEST). */
+    public static synchronized void   noteFetchAction(String action) { lastFetchAction = action; }
+    public static synchronized String lastFetchAction() { return lastFetchAction; }
+
     public static synchronized String lastFetchSummary() { return lastFetchSummary; }
 
     public static synchronized Map<String, Integer> lastFetchTypes() {
@@ -111,6 +116,7 @@ public final class DebugLog {
         lastFetchReceivedMs = 0;
         lastFetchIntervalMs = 0;
         fetchCount = 0;
+        lastFetchAction = null;
         lastFetchSummary = null;
         lastFetchTypes.clear();
     }

--- a/app/src/main/java/app/sabre/wzsabre/DiagnosticsReport.java
+++ b/app/src/main/java/app/sabre/wzsabre/DiagnosticsReport.java
@@ -115,9 +115,10 @@ public final class DiagnosticsReport {
         long interval = DebugLog.lastFetchIntervalMs();
         sb.append("Recent request interval: ")
           .append(interval <= 0 ? "n/a" : (interval / 1000) + "s").append('\n');
+        String fa = DebugLog.lastFetchAction();
+        sb.append("Fetch action HR uses: ").append(fa == null ? "none received" : fa).append('\n');
         sb.append("We advertise to HR: id=app.sabre.wzsabre, version=").append(BuildConfig.VERSION_NAME)
-          .append(", sources=[chp,waze,lcs,fire,chains]\n");
-        sb.append("Request action: app.sabre.wzsabre.FETCH_REQUEST\n");
+          .append(", request_action=app.sabre.wzsabre.REQUEST, sources=[chp,waze,lcs,fire,chains]\n");
     }
 
     private static void sourcesSection(StringBuilder sb) {

--- a/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
@@ -18,7 +18,13 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
         try {
             if ("app.sabre.HANDSHAKE".equals(action) || "app.sabre.wzsabre.HANDSHAKE".equals(action)) {
                 handleHandshake(context, intent);
-            } else if ("app.sabre.wzsabre.FETCH_REQUEST".equals(action)) {
+            } else if (action != null && action.endsWith("REQUEST")) {
+                // Accept BOTH our own FETCH_REQUEST and the official wzsabre's REQUEST.
+                // Highway Radar caches a plugin registration by package id: a user who
+                // had the official wzsabre first leaves HR firing app.sabre.wzsabre.REQUEST
+                // at us forever (it never re-discovers the same package), so we must
+                // listen for it or that user gets zero data.
+                DebugLog.noteFetchAction(action);
                 ForegroundServiceStarter.start(context, "FETCH_REQUEST", intent.getStringExtra("data"));
             } else if (action != null && action.contains("SHUTDOWN")) {
                 // HR is ending the session (it usually reopens one shortly). Forward
@@ -64,6 +70,7 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
 
     private void handleHandshake(Context context, Intent intent) throws Exception {
         Log.d(TAG, "Handling handshake");
+        DebugLog.event("handshake from HR (discovery)");
         String rawData = intent.getStringExtra("data");
         String responseAction = null;
         if (rawData != null) {
@@ -94,10 +101,14 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
         JSONObject s4 = new JSONObject(); s4.put("id", "fire"); s4.put("name", "Wildfires");          sources.put(s4);
         JSONObject s5 = new JSONObject(); s5.put("id", "chains"); s5.put("name", "Chain Controls");   sources.put(s5);
         response.put("supported_sources", sources);
-        response.put("request_action",  "app.sabre.wzsabre.FETCH_REQUEST");
-        response.put("report_action",   "app.sabre.wzsabre.SUBMIT_REPORT");
-        response.put("confirm_action",  "app.sabre.wzsabre.CONFIRM_REPORT");
-        response.put("discard_action",  "app.sabre.wzsabre.DISCARD_REPORT");
+        // Advertise the SAME action names the official wzsabre uses, so every HR
+        // (whether it re-discovers us or keeps a cached wzsabre registration) fires
+        // the identical actions we listen for. We also still listen for our older
+        // FETCH_REQUEST/SUBMIT_REPORT names for any HR that cached those.
+        response.put("request_action",  "app.sabre.wzsabre.REQUEST");
+        response.put("report_action",   "app.sabre.wzsabre.REPORT");
+        response.put("confirm_action",  "app.sabre.wzsabre.CONFIRM");
+        response.put("discard_action",  "app.sabre.wzsabre.DISCARD");
         response.put("shutdown_action", "app.sabre.wzsabre.SHUTDOWN");
         // alternative_startup_activity lets HR launch us to the foreground so the
         // service can start without hitting Android 15/16 BFSL restrictions. This is


### PR DESCRIPTION
Root cause of Grant's 'installed but no data' (from his diagnostics report + screenshots): HR caches a plugin by package id and kept using the original wzsabre's cached registration (name 'WzSabre', fetch action app.sabre.wzsabre.REQUEST) after he switched to SABRE Plus. We only listened for our own FETCH_REQUEST, so HR's fetches landed nowhere (0 requests received). Now we listen for + advertise the official REQUEST/REPORT/CONFIRM/DISCARD names. Verified on API 30. v1.9.2.