### PR TITLE
v1.9.3: surface HR re-discovery in diagnostics; help "WzSabre" name refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.9.3] - 2026-07-10
+
+### Changed
+- If Highway Radar still shows the old "WzSabre" name after you switch to SABRE Plus, fully closing and reopening Highway Radar now makes it re-detect the plugin and show "SABRE Plus" instead. The Share diagnostics report also explains this: it reports whether Highway Radar has re-detected SABRE Plus, or is still running off the older cached setup (in which case alerts still flow, and a full restart of Highway Radar refreshes the name).
+
 ## [1.9.2] - 2026-07-10
 
 ### Fixed

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 22
-        versionName = "1.9.2"
+        versionCode = 23
+        versionName = "1.9.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/DebugLog.java
+++ b/app/src/main/java/app/sabre/wzsabre/DebugLog.java
@@ -34,6 +34,8 @@ public final class DebugLog {
     private static volatile long lastFetchReceivedMs = 0;
     private static volatile long lastFetchIntervalMs = 0;
     private static volatile int  fetchCount = 0;
+    private static volatile long lastHandshakeMs = 0;
+    private static volatile int  handshakeCount = 0;
     private static volatile String lastFetchAction = null;
     private static volatile String lastFetchSummary = null;
     private static final Map<String, Integer> lastFetchTypes = new LinkedHashMap<>();
@@ -43,6 +45,19 @@ public final class DebugLog {
         EVENTS.addLast(new Ev(System.currentTimeMillis(), msg));
         while (EVENTS.size() > MAX_EVENTS) EVENTS.removeFirst();
     }
+
+    /**
+     * Note that HR sent us a discovery handshake. A handshake this session means HR
+     * re-detected us (registration is current); fetches WITHOUT a handshake mean HR
+     * is running off a cached registration from a previously-installed plugin.
+     */
+    public static synchronized void handshakeReceived() {
+        lastHandshakeMs = System.currentTimeMillis();
+        handshakeCount++;
+        event("handshake from HR (discovery)");
+    }
+
+    public static synchronized int handshakeCount() { return handshakeCount; }
 
     /** Note that Highway Radar asked us for data (drives "HR last requested Ns ago"). */
     public static synchronized void fetchReceived() {
@@ -116,6 +131,8 @@ public final class DebugLog {
         lastFetchReceivedMs = 0;
         lastFetchIntervalMs = 0;
         fetchCount = 0;
+        lastHandshakeMs = 0;
+        handshakeCount = 0;
         lastFetchAction = null;
         lastFetchSummary = null;
         lastFetchTypes.clear();

--- a/app/src/main/java/app/sabre/wzsabre/DiagnosticsReport.java
+++ b/app/src/main/java/app/sabre/wzsabre/DiagnosticsReport.java
@@ -117,6 +117,17 @@ public final class DiagnosticsReport {
           .append(interval <= 0 ? "n/a" : (interval / 1000) + "s").append('\n');
         String fa = DebugLog.lastFetchAction();
         sb.append("Fetch action HR uses: ").append(fa == null ? "none received" : fa).append('\n');
+        sb.append("Handshakes (discovery) this session: ").append(DebugLog.handshakeCount()).append('\n');
+        sb.append("HR registration: ");
+        if (DebugLog.sessionFetchCount() == 0 && DebugLog.handshakeCount() == 0) {
+            sb.append("HR has not contacted the plugin yet this session\n");
+        } else if (DebugLog.handshakeCount() > 0) {
+            sb.append("HR re-detected SABRE Plus (registration is current)\n");
+        } else {
+            sb.append("HR is using a cached registration from a previously-installed plugin "
+                    + "(it may still display an old name like \"WzSabre\"). Data still flows; "
+                    + "fully restart Highway Radar to refresh the name.\n");
+        }
         sb.append("We advertise to HR: id=app.sabre.wzsabre, version=").append(BuildConfig.VERSION_NAME)
           .append(", request_action=app.sabre.wzsabre.REQUEST, sources=[chp,waze,lcs,fire,chains]\n");
     }

--- a/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
@@ -70,7 +70,7 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
 
     private void handleHandshake(Context context, Intent intent) throws Exception {
         Log.d(TAG, "Handling handshake");
-        DebugLog.event("handshake from HR (discovery)");
+        DebugLog.handshakeReceived();
         String rawData = intent.getStringExtra("data");
         String responseAction = null;
         if (rawData != null) {

--- a/app/src/test/java/app/sabre/wzsabre/DebugLogTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/DebugLogTest.java
@@ -72,4 +72,15 @@ public class DebugLogTest {
         DebugLog.fetchReceived();
         assertTrue(DebugLog.lastFetchAgeMs() >= 0);
     }
+
+    @Test
+    public void handshakeReceived_countsAndLogsDiscovery() {
+        assertEquals(0, DebugLog.handshakeCount());
+        DebugLog.handshakeReceived();
+        DebugLog.handshakeReceived();
+        assertEquals("counts each discovery handshake", 2, DebugLog.handshakeCount());
+        // a handshake also drops a curated event so the timeline shows re-discovery
+        String events = DebugLog.recentEvents().toString();
+        assertTrue("logs a discovery event", events.contains("handshake from HR"));
+    }
 }


### PR DESCRIPTION
## What
Answers the open question "can we make Highway Radar purge the stale **WzSabre** name and show **SABRE Plus** instead?" and makes the situation legible in diagnostics.

## Findings (reproduced on API 30, Grant's exact scenario)
Highway Radar caches a plugin's registration by package id and only re-discovers it on a **full restart**, not while its process stays alive. So a user who installed the original wzsabre first keeps seeing "WzSabre" (and, before v1.9.2, got no data) until HR is fully closed and reopened.

- After a full HR force-stop + relaunch, HR sends a discovery handshake, re-detects the plugin, and its Config Status flips from **"WzSabre installed"** to **"SABRE Plus (CHP, Waze, Caltrans) installed"**, then fetches via `app.sabre.wzsabre.REQUEST` and receives alerts.
- v1.9.2 already made data flow regardless of re-discovery; this release makes the state visible and gives the user a concrete way to refresh the name.

## Changes
- **DebugLog**: track discovery handshakes (`handshakeReceived` / `handshakeCount`). A handshake this session means HR re-detected us; fetches without one mean HR is on a cached registration from a previously-installed plugin.
- **MainBroadcastReceiver**: record the handshake via `DebugLog.handshakeReceived()`.
- **DiagnosticsReport**: the "HR registration" line now keys off the handshake signal (the fetch action is `REQUEST` for both cached and re-detected HRs since v1.9.2, so it can't distinguish them). It reports one of: not-contacted / re-detected SABRE Plus / cached registration (may still show "WzSabre"; data still flows, fully restart Highway Radar to refresh the name).
- **CHANGELOG** + version bump to 1.9.3 (build 23).
- **Tests**: `DebugLogTest` covers handshake counting and the discovery event.

Privacy unchanged: still no location, street names, alert IDs, or personal data anywhere in diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)