### PR TITLE
v1.9.4: Privacy policy + in-app Privacy summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.9.4] - 2026-07-12
+
+### Added
+- A **Privacy** button in the settings screen. It shows a plain-language summary of what the app does and does not do with data (no servers, no accounts, no analytics, everything on-device; only the Waze feature sends your approximate location, over an anonymous session, to fetch nearby alerts) and links to the full privacy policy. A new PRIVACY.md documents the same in detail.
+
 ## [1.9.3] - 2026-07-10
 
 ### Changed

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,60 @@
+# Privacy Policy
+
+_Last updated: 2026-07-12_
+
+SABRE Plus is a free, open-source Highway Radar plugin. It has **no servers, no accounts, and no analytics**, and it **collects no personal data**. Everything it does runs on your own device. This document explains, in plain terms, exactly what stays on your device, what leaves it, and what never happens.
+
+## The short version
+
+- SABRE Plus does not have a backend. There is nothing for us to collect, because there is nowhere for your data to go that we control.
+- We do not use analytics, crash-reporting services, advertising, or trackers of any kind.
+- We do not create accounts, assign user IDs, or read your device's advertising ID.
+- We do not store your location history, and we never sell or share data.
+
+## What is stored on your device
+
+All of this is kept locally in the app's private storage and never transmitted by us:
+
+- **Your settings** (which sources and categories are on, the age filter, wildfire size, and so on).
+- **An anonymous Waze session.** To use the Waze feature, the app registers an anonymous session with Waze (no name, email, phone, or account). A session token is cached on your device so it does not have to re-register every time.
+- **A short diagnostics log.** The app keeps a small in-memory record of recent activity (counts, category names, source health, and errors) to help troubleshooting. It is only ever sent anywhere if **you** tap **Share diagnostics** and choose to share it. It contains no location, street names, alert IDs, or personal data.
+- **A local crash log.** If the app crashes, a summary is written to a private file so you can optionally include it when reporting a bug. It stays on your device unless you choose to share it.
+
+## What leaves your device
+
+To show you road conditions, the app fetches data from public and third-party sources. These requests go directly from your device to those services; they do not pass through any server of ours.
+
+| Service | What is requested | Is your location sent? |
+|---|---|---|
+| **California Highway Patrol** (`media.chp.ca.gov`) | The statewide incident feed | No. The whole-state feed is fetched and filtered on your device. |
+| **Caltrans** (`dot.ca.gov`) | Lane-closure and chain-control feeds for the districts near you | No. Which district feeds to fetch is worked out on your device; your coordinates are not sent. |
+| **Wildfire feed / NIFC** (`arcgis.com`) | Active California wildfires | No. All active California fires are fetched and filtered on your device. |
+| **Waze** (`waze.com`) | Nearby crowd-sourced alerts | **Yes.** To return alerts near you, the app sends your **approximate location** (a map area around you) to Waze over an anonymous session. |
+| **GitHub** (`api.github.com`) | A check for a newer version of the app | No. This is a standard version check and sends no location. |
+
+As with any app that uses the internet, each service you contact can see your device's public **IP address**, and their use of it is governed by their own privacy policies. The Waze feature is the only case where your approximate location leaves the device. If you prefer not to send any location to Waze, you can turn the Waze source off in Highway Radar's settings.
+
+## What we never do
+
+- No analytics or usage tracking.
+- No advertising or ad identifiers.
+- No accounts, sign-ins, or user identifiers.
+- No location history or profiles.
+- No selling, renting, or sharing of data with anyone.
+
+## Permissions
+
+The app requests only what it needs to relay alerts while you drive (internet access, a foreground-service notification, wake lock, exact alarms to keep the service reachable, and an optional battery-optimization exemption). It does **not** request access to your contacts, camera, microphone, photos, or precise device location; the location it uses for filtering comes from Highway Radar's request, not from a location permission of its own.
+
+## Children
+
+This app is a navigation utility for drivers and is not directed at children.
+
+## Changes
+
+If this policy changes, the update will be committed to this file in the public repository, and the "Last updated" date above will change.
+
+## Contact
+
+Questions or concerns: open an issue at
+https://github.com/nicglazkov/highway-radar-sabre-plus/issues

--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ Pull requests welcome. Run the test suite before submitting:
 
 ---
 
+## Privacy
+
+SABRE Plus has no servers, no accounts, and no analytics, and collects no personal data. Everything runs on your device. It fetches road data from public feeds (CHP, Caltrans, wildfires) and from Waze; only the Waze feature sends your approximate location, over an anonymous session, so it can return nearby alerts. See the full [Privacy Policy](PRIVACY.md).
+
+---
+
 ## Disclaimer
 
 This is an independent, unofficial project. It is **not affiliated with, endorsed by, or supported by** Waze, Google, the California Highway Patrol, Caltrans, or Highway Radar.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 23
-        versionName = "1.9.3"
+        versionCode = 24
+        versionName = "1.9.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -64,6 +64,7 @@ public class MainActivity extends Activity {
         buildDiagnostics();
         buildReportButton();
         buildShareDiagnostics();
+        buildPrivacyButton();
         checkForUpdate();
     }
 
@@ -88,6 +89,41 @@ public class MainActivity extends Activity {
                 } catch (Exception ignored) {}
             }
         });
+    }
+
+    /**
+     * "Privacy" shows a plain-language summary of what the app does and does not do
+     * with data, entirely on-device, plus a link to the full PRIVACY.md policy.
+     * ACTION_VIEW needs no permission. Kept in sync with PRIVACY.md.
+     */
+    private void buildPrivacyButton() {
+        final String policyUrl =
+                "https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/PRIVACY.md";
+        String summary =
+            "SABRE Plus has no servers and no accounts, and collects no personal data. "
+          + "Everything runs on your device.\n\n"
+          + "Stored on your device: your settings, an anonymous Waze session, and a short "
+          + "diagnostics log that is only ever shared when you tap Share diagnostics.\n\n"
+          + "Leaves your device: it fetches road data from public sources (CHP, Caltrans, "
+          + "wildfire feeds) and from Waze. The Waze feature sends your approximate location "
+          + "(a map area around you) to Waze over an anonymous session so it can return nearby "
+          + "alerts. The CHP, Caltrans, and wildfire requests do not send your location. Each "
+          + "service you contact can see your device's IP address, as with any app.\n\n"
+          + "Never: no analytics, no tracking, no advertising, no user IDs, no location history, "
+          + "and nothing is ever sold.\n\n"
+          + "Diagnostics you choose to share contain no location, street names, alert IDs, or "
+          + "personal data.";
+        findViewById(R.id.privacyButton).setOnClickListener(v ->
+            new AlertDialog.Builder(this)
+                .setTitle("Privacy")
+                .setMessage(summary)
+                .setPositiveButton("View full policy", (d, w) -> {
+                    try {
+                        startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(policyUrl)));
+                    } catch (Exception ignored) {}
+                })
+                .setNegativeButton("Close", null)
+                .show());
     }
 
     /**

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -436,6 +436,13 @@
                 android:layout_height="wrap_content"
                 android:text="Report a bug / send feedback"
                 android:layout_marginTop="10dp" />
+
+            <Button
+                android:id="@+id/privacyButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Privacy"
+                android:layout_marginTop="4dp" />
         </LinearLayout>
 
     </LinearLayout>


### PR DESCRIPTION
Adds a plain-language privacy statement ahead of wider sharing, in the repo and surfaced in the app.

## Why
No data is collected. The app has no backend, no accounts, no analytics; everything runs on-device. The only case where location leaves the device is the Waze feature (an approximate map area, over an anonymous session, to fetch nearby alerts). CHP/Caltrans/wildfire requests send no location. Confirmed by the cost/privacy audit and by reading each source (e.g. WildfireSource queries all of CA, no geometry).

## Changes
- **PRIVACY.md**: full policy with a per-source data-flow table (what leaves the device and whether location is included).
- **In-app**: a **Privacy** button in settings opens a summary dialog with a **View full policy** link to PRIVACY.md. Uses ACTION_VIEW, no new permission. Verified rendering on an API 30 emulator.
- **README**: short Privacy section linking the policy.
- Version bump to 1.9.4, CHANGELOG entry.

## Also verified this session (no code change)
The foreground-service stop logic works: it stops within the 20s grace on HR `SHUTDOWN`, and within the 5-min idle watchdog when HR goes silent (force-killed). Reproduced both on API 30. The earlier "ran 2+ hours" field note was HR still polling in the background, which correctly keeps the service alive, not a stuck service.

No em dashes; README stays CRLF. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)