### PR TITLE
v1.9.5: cut Caltrans data use, drop contained wildfires, add a Pages site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.9.5] - 2026-08-04
+
+### Fixed
+- **Uses far less mobile data.** The Caltrans lane-closure feeds are the largest thing the plugin downloads (the Los Angeles district feed alone is about 15 MB, and Caltrans does not compress it), and the plugin was re-downloading every district near you every 5 minutes while you drove, even when nothing had changed. A driver in Los Angeles could use roughly 280 MB per hour. The plugin now asks Caltrans "has this changed since last time?" and downloads nothing when the answer is no, and it refreshes closures every 15 minutes instead of every 5. Established closures last hours, so nothing useful is lost. Typical data use drops by roughly 4x to 10x depending on where you drive. Chain controls got the same "only download it if it changed" treatment.
+- **Contained and stale wildfires no longer show as live hazards.** The national wildfire feed keeps flagging incidents as active long after they are out, so the map could show fires that were already fully contained, plus leftovers like a training exercise from eight months earlier and records marked "false alarm". On the live feed the day this was fixed, 9 of 91 "active" California records were this kind of noise, including a 69,352 acre fire that had been 100% contained for over two weeks. Fires that are still burning are never hidden, including large ones that burn for months.
+
 ## [1.9.4] - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Android 7.0+](https://img.shields.io/badge/Android-7.0%2B-3DDC84?logo=android&logoColor=white)](#requirements)
 
+**Website: [nicglazkov.github.io/highway-radar-sabre-plus](https://nicglazkov.github.io/highway-radar-sabre-plus/)**
+
 An open-source **Highway Radar SABRE plugin** for California, and a drop-in **wzsabre** replacement: it brings live CHP incidents, Waze crowdsourced alerts, Caltrans lane closures, active wildfires, and winter chain controls to [Highway Radar](https://www.highwayradar.com/) via the SABRE plugin protocol.
 
 > **Package ID: `app.sabre.wzsabre`** (the same as wzsabre), so Highway Radar discovers this plugin automatically without any reconfiguration.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ An open-source **Highway Radar SABRE plugin** for California, and a drop-in **wz
 |--------|------|----------------|
 | **CHP Live Feed** | Accidents, road closures, debris, officer on road, weather hazards, directly from the California Highway Patrol statewide XML feed | Every HR map refresh |
 | **Waze** | Crowdsourced police, accidents, hazards, road closures | Every HR map refresh |
-| **Caltrans Closures (LCS)** | Lane and road closures that are physically in place right now (CHP code 1097), from the per-district Caltrans Lane Closure System feeds | Cached, refreshed every 5 min |
-| **Wildfires** | Active California wildfires (name, size, containment) from the interagency WFIGS feed, shown as road hazards near the fire | Cached, refreshed every 5 min |
+| **Caltrans Closures (LCS)** | Lane and road closures that are physically in place right now (CHP code 1097), from the per-district Caltrans Lane Closure System feeds | Cached, refreshed every 15 min |
+| **Wildfires** | Active California wildfires (name, size, containment) from the interagency WFIGS feed, shown as road hazards near the fire. Contained and stale records are filtered out | Cached, refreshed every 5 min |
 | **Chain Controls** | Caltrans winter chain requirements (R-1/R-2/R-3) on mountain routes, shown as slippery-road hazards | Cached, refreshed every 5 min |
 
 All sources run in parallel and feed into the standard HR crowdsourced-alerts layer, the same map overlay that wzsabre used to power.
@@ -175,8 +175,8 @@ flowchart TD
         direction LR
         CHP["🚔 CHP Live Feed<br/>sa.xml statewide<br/>radius + age + category filter"]
         WAZE["🚗 Waze<br/>mobile RT protobuf<br/>register, login, query<br/>delta-merged cache"]
-        LCS["🚧 Caltrans LCS<br/>per-district closure XML<br/>code 1097 only · cached 5 min"]
-        FIRE["🔥 Wildfires<br/>WFIGS active CA fires<br/>size filter · cached 5 min"]
+        LCS["🚧 Caltrans LCS<br/>per-district closure XML<br/>code 1097 only · cached 15 min<br/>conditional GET"]
+        FIRE["🔥 Wildfires<br/>WFIGS active CA fires<br/>contained/stale filtered<br/>size filter · cached 5 min"]
         CHAINS["❄️ Chain controls<br/>per-district CC XML<br/>R-1/R-2/R-3 · cached 5 min"]
     end
 
@@ -210,8 +210,8 @@ flowchart TD
 
 - **CHP**: fetches `https://media.chp.ca.gov/sa_xml/sa.xml`, filters by radius and incident age, applies your category settings.
 - **Waze**: emulates the Waze mobile app's binary "RT" protocol. It registers an anonymous Waze session, logs in, and queries crowd-sourced alerts over Waze's protobuf API (the older live-map/georss API is now blocked). The RT feed is session-stateful (each alert is sent once, then removed when it clears), so query results are merged into a persistent alert cache rather than replacing it, this keeps alerts from disappearing as you drive. A series of progressively smaller map viewports is queried so the server doesn't thin out minor alerts near you, the session is pre-warmed at start to cut first-load latency, and Waze alert subtypes (e.g. *car stopped on shoulder*, *heavy traffic*) are passed through to Highway Radar verbatim rather than flattened.
-- **Caltrans LCS**: fetches the per-district lane-closure feeds (`https://cwwp2.dot.ca.gov/data/d<N>/lcs/lcsStatusD<NN>.xml`) for whichever districts cover your location. Only closures that are physically established (CHP code 1097 set, not picked up or canceled) are shown; shoulder-only closures are skipped. Closures longer than 2 km get a pin at each end. The ~4 MB feeds are parsed in the background and cached for 5 minutes, so they never delay a Highway Radar request.
-- **Wildfires**: active California wildfires from the interagency WFIGS "Current Wildland Fire Incident Locations" feed (NIFC-hosted ArcGIS), filtered to active wildfires in California. Each is shown as a road hazard at the fire's location with its name, size, and containment. Background-cached like the other sources. Optional minimum-size filter in settings.
+- **Caltrans LCS**: fetches the per-district lane-closure feeds (`https://cwwp2.dot.ca.gov/data/d<N>/lcs/lcsStatusD<NN>.xml`) for whichever districts cover your location. Only closures that are physically established (CHP code 1097 set, not picked up or canceled) are shown; shoulder-only closures are skipped. Closures longer than 2 km get a pin at each end. The feeds are large (1 MB to 16 MB per district, uncompressed by Caltrans), so they are parsed in the background and never delay a Highway Radar request. They are refreshed every 15 minutes using a conditional request, so an unchanged feed downloads nothing at all: this keeps mobile data use down, which matters most in districts with very large feeds.
+- **Wildfires**: active California wildfires from the interagency WFIGS "Current Wildland Fire Incident Locations" feed (NIFC-hosted ArcGIS), filtered to active wildfires in California. Each is shown as a road hazard at the fire's location with its name, size, and containment. Fires the feed still flags as active but that are fully contained, along with stale leftovers and non-incident records such as training exercises, are filtered out. Background-cached like the other sources. Optional minimum-size filter in settings.
 - **Chain controls**: Caltrans winter chain-control status from the per-district CWWP feeds (`https://cwwp2.dot.ca.gov/data/d<N>/cc/ccStatusD<NN>.xml`). Records at level R-1/R-2/R-3 (in service) are shown as slippery-road hazards; off-season the feed is all R-0 so nothing shows.
 - **SABRE protocol**: a broadcast-intent IPC protocol defined by Highway Radar. Our plugin responds to `FETCH_REQUEST` broadcasts with a JSON payload containing `SabreFetchResponseAlert` objects.
 
@@ -225,7 +225,7 @@ Pull requests welcome. Run the test suite before submitting:
 ./gradlew test
 ```
 
-228 unit tests cover the SABRE response format, alert type mapping (incl. Waze category filters), the Waze alert cache (delta merge + soft-delete), in-band Waze error classification, shrinking-box geometry, crowd-confirmation tracking, CHP XML parsing, Caltrans LCS and chain-control parsing and filtering, wildfire (WFIGS) parsing, cross-source de-duplication, the update-check version compare, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup, and [CHANGELOG.md](CHANGELOG.md) for release history.
+242 unit tests cover the SABRE response format, alert type mapping (incl. Waze category filters), the Waze alert cache (delta merge + soft-delete), in-band Waze error classification, shrinking-box geometry, crowd-confirmation tracking, CHP XML parsing, Caltrans LCS and chain-control parsing and filtering, wildfire (WFIGS) parsing, cross-source de-duplication, the update-check version compare, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup, and [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 24
-        versionName = "1.9.4"
+        versionCode = 25
+        versionName = "1.9.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/ConditionalGet.java
+++ b/app/src/main/java/app/sabre/wzsabre/ConditionalGet.java
@@ -1,0 +1,52 @@
+package app.sabre.wzsabre;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * HTTP cache validators for a single feed, so a background refresh can ask the server
+ * "has this changed?" instead of re-downloading a body it already holds.
+ *
+ * <p>This matters most for the Caltrans district feeds: they are multi-megabyte (D7
+ * measured at 15.7 MB on 2026-08-04), they are refreshed while the driver is moving,
+ * and the CWWP server does not gzip them. It does send {@code ETag} and
+ * {@code Last-Modified} and answers {@code If-None-Match} with a 0-byte 304, so an
+ * unchanged feed costs nothing instead of megabytes of cellular data.
+ *
+ * <p>Validators are committed only after a body has been read <em>and</em> parsed, the
+ * same ordering {@link CHPSource} uses: committing early would leave validators that
+ * match content the cache never received, so the next refresh would 304 onto a cache
+ * that was never updated.
+ *
+ * <p>Fields are volatile because a refresh thread writes them while another may read.
+ */
+final class ConditionalGet {
+
+    private volatile String etag;
+    private volatile String lastModified;
+
+    /**
+     * Headers for the next GET.
+     *
+     * @param haveCachedBody whether a parsed body is currently held. When false the
+     *                       result is empty: a 304 would leave nothing to serve.
+     */
+    Map<String, String> requestHeaders(boolean haveCachedBody) {
+        String e = etag, lm = lastModified;
+        if (!haveCachedBody || (e == null && lm == null)) return Collections.emptyMap();
+        Map<String, String> headers = new LinkedHashMap<>(4);
+        if (e != null)  headers.put("If-None-Match", e);
+        if (lm != null) headers.put("If-Modified-Since", lm);
+        return headers;
+    }
+
+    /**
+     * Adopt the validators from a response whose body was read and parsed successfully.
+     * Nulls are stored as-is so validators never outlive the response that set them.
+     */
+    void commit(String etag, String lastModified) {
+        this.etag = etag;
+        this.lastModified = lastModified;
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/LcsSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/LcsSource.java
@@ -36,8 +36,14 @@ import javax.net.ssl.HttpsURLConnection;
 public class LcsSource {
     private static final String TAG = "LcsSource";
 
-    private static final long CACHE_TTL_MS       = 5 * 60_000L;   // refresh cadence
-    private static final long CACHE_MAX_SERVE_MS = 30 * 60_000L;  // never serve staler than this
+    // Refresh cadence. These feeds are the app's largest network cost by far — the
+    // district XML is multi-megabyte (D7 measured at 15.7 MB on 2026-08-04) and CWWP
+    // does not gzip it, so at the old 5-minute cadence a driver near several district
+    // boundaries could pull well over 100 MB of cellular data per hour. An established
+    // 1097 closure lasts hours, so 15 minutes loses nothing a driver would notice, and
+    // the conditional GET makes an unchanged feed free on top of that.
+    private static final long CACHE_TTL_MS       = 15 * 60_000L;  // refresh cadence
+    private static final long CACHE_MAX_SERVE_MS = 60 * 60_000L;  // never serve staler than this
     private static final int  TIMEOUT_MS         = 25_000;
     /** Closures whose schedule ended more than this long ago are treated as ghosts. */
     private static final long END_OVERRUN_GRACE_SEC = 4 * 3600L;
@@ -106,6 +112,7 @@ public class LcsSource {
 
     private final Map<Integer, CacheEntry> cache = new ConcurrentHashMap<>();
     private final Map<Integer, AtomicBoolean> refreshing = new ConcurrentHashMap<>();
+    private final Map<Integer, ConditionalGet> validators = new ConcurrentHashMap<>();
     private final ExecutorService refreshExec = Executors.newSingleThreadExecutor();
 
     /**
@@ -145,9 +152,22 @@ public class LcsSource {
         refreshExec.submit(() -> {
             try {
                 List<Closure> parsed = fetchDistrict(district);
-                cache.put(district, new CacheEntry(parsed, System.currentTimeMillis()));
-                Log.d(TAG, "D" + district + " refreshed: " + parsed.size() + " closure records");
-                DebugLog.event("lcs D" + district + ": " + parsed.size() + " closures");
+                if (parsed == null) {
+                    // 304 Not Modified: the feed we already hold is still current, so
+                    // just mark it fresh. This is the whole point of the conditional
+                    // GET — an unchanged multi-megabyte feed costs zero bytes.
+                    CacheEntry held = cache.get(district);
+                    if (held != null) {
+                        cache.put(district, new CacheEntry(held.closures, System.currentTimeMillis()));
+                        Log.d(TAG, "D" + district + " unchanged (304): " + held.closures.size()
+                                + " closure records kept");
+                        DebugLog.event("lcs D" + district + ": unchanged (304)");
+                    }
+                } else {
+                    cache.put(district, new CacheEntry(parsed, System.currentTimeMillis()));
+                    Log.d(TAG, "D" + district + " refreshed: " + parsed.size() + " closure records");
+                    DebugLog.event("lcs D" + district + ": " + parsed.size() + " closures");
+                }
                 int total = 0;
                 for (CacheEntry ce : cache.values()) total += ce.closures.size();
                 SourceStatus.success(SabreResponseBuilder.SOURCE_LCS, total);
@@ -163,14 +183,30 @@ public class LcsSource {
         });
     }
 
+    /** @return parsed closures, or {@code null} when the server replies 304 Not Modified. */
     private List<Closure> fetchDistrict(int district) throws Exception {
         URL url = new URL(feedUrl(district));
         HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
         conn.setConnectTimeout(TIMEOUT_MS);
         conn.setReadTimeout(TIMEOUT_MS);
         conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Linux; Android 14)");
-        try (InputStream in = conn.getInputStream()) {
-            return parse(in);
+        ConditionalGet cg = validators.computeIfAbsent(district, d -> new ConditionalGet());
+        for (Map.Entry<String, String> h
+                : cg.requestHeaders(cache.get(district) != null).entrySet()) {
+            conn.setRequestProperty(h.getKey(), h.getValue());
+        }
+        try {
+            if (conn.getResponseCode() == HttpsURLConnection.HTTP_NOT_MODIFIED) return null;
+            String etag = conn.getHeaderField("ETag");
+            String lastModified = conn.getHeaderField("Last-Modified");
+            List<Closure> parsed;
+            try (InputStream in = conn.getInputStream()) {
+                parsed = parse(in);
+            }
+            // Commit only after the body parsed, so a mid-stream failure can't leave
+            // validators matching content this cache never received.
+            cg.commit(etag, lastModified);
+            return parsed;
         } finally {
             conn.disconnect();
         }

--- a/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
@@ -47,6 +47,16 @@ public class WildfireSource {
 
     private static final long CACHE_TTL_MS       = 5 * 60_000L;   // fires update slowly
     private static final long CACHE_MAX_SERVE_MS = 60 * 60_000L;  // never serve staler than this
+
+    // ── Liveness thresholds (see isLiveHazard) ────────────────────────────────
+    /** Past this age, a record with no meaningful size is feed residue, not a fire. */
+    private static final long   STALE_RECORD_MS = 30L * 24 * 60 * 60 * 1000L;
+    /** Below this, an old record is a spot fire that was out the same day. */
+    private static final double MIN_LIVE_ACRES  = 10.0;
+    /** Name markers for feed entries that are not wildfires. */
+    private static final String[] NON_INCIDENT_MARKERS = {
+        "TRAINING", "FALSE ALARM", "DRILL", "PRESCRIBED"
+    };
     private static final int  CONNECT_TIMEOUT_MS = 8_000;
     private static final int  READ_TIMEOUT_MS    = 8_000;
 
@@ -88,13 +98,56 @@ public class WildfireSource {
         if (snap == null || (System.currentTimeMillis() - snap.timeMs) > CACHE_MAX_SERVE_MS) {
             return new ArrayList<>();
         }
+        return selectAlerts(snap.fires, lat, lon, radiusMeters, minAcres,
+                System.currentTimeMillis());
+    }
+
+    /** Which cached fires become alerts for this request. Package-private for tests. */
+    static List<SabreAlert> selectAlerts(List<Fire> fires, double lat, double lon,
+                                         double radiusMeters, int minAcres, long nowMs) {
         List<SabreAlert> out = new ArrayList<>();
-        for (Fire f : snap.fires) {
+        for (Fire f : fires) {
+            if (!isLiveHazard(f, nowMs)) continue;
             if (minAcres > 0 && f.sizeAcres >= 0 && f.sizeAcres < minAcres) continue;
             if (CHPSource.haversineMeters(lat, lon, f.lat, f.lon) > radiusMeters) continue;
             out.add(toAlert(f));
         }
         return out;
+    }
+
+    /**
+     * Whether a parsed record is still a live hazard worth drawing.
+     *
+     * <p>WFIGS leaves {@code ActiveFireCandidate=1} set long after a fire is out, so
+     * the "active" query also returns fully contained fires, months-old leftovers, and
+     * non-incident records. Observed live on 2026-08-04: 9 of 91 "active" California
+     * records were noise, including a 69,352-acre fire 100% contained 16 days earlier.
+     *
+     * <p>The rules stay deliberately conservative — a fire that is still burning must
+     * never be dropped. Age alone is not disqualifying, because large fires legitimately
+     * burn for months (the 2024 Park Fire took 64 days to reach containment).
+     */
+    static boolean isLiveHazard(Fire f, long nowMs) {
+        // Contained means the perimeter is fully held: no longer a spreading hazard.
+        // A negative value is "unknown", which must not be read as contained.
+        if (f.pctContained >= 100.0) return false;
+        if (isNonIncident(f.name)) return false;
+        // Stale *and* inconsequential: sub-acre or never-sized records that the feed
+        // simply never retired. A real fire this old would still be reporting a size.
+        long ageMs = nowMs - f.reportTs * 1000L;
+        if (ageMs > STALE_RECORD_MS && (f.sizeAcres < 0 || f.sizeAcres < MIN_LIVE_ACRES)) {
+            return false;
+        }
+        return true;
+    }
+
+    /** Feed housekeeping entries that are not wildfires at all. */
+    private static boolean isNonIncident(String name) {
+        String n = name.toUpperCase(Locale.US);
+        for (String marker : NON_INCIDENT_MARKERS) {
+            if (n.contains(marker)) return true;
+        }
+        return false;
     }
 
     /** Warm the cache at service start. */

--- a/app/src/main/java/app/sabre/wzsabre/WinterSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/WinterSource.java
@@ -70,6 +70,7 @@ public class WinterSource {
 
     private final Map<Integer, CacheEntry> cache = new ConcurrentHashMap<>();
     private final Map<Integer, AtomicBoolean> refreshing = new ConcurrentHashMap<>();
+    private final Map<Integer, ConditionalGet> validators = new ConcurrentHashMap<>();
     private final ExecutorService refreshExec = Executors.newSingleThreadExecutor();
 
     /** Active chain controls within the radius, served from the district caches. */
@@ -102,12 +103,23 @@ public class WinterSource {
         refreshExec.submit(() -> {
             try {
                 List<ChainControl> parsed = fetchDistrict(district);
-                cache.put(district, new CacheEntry(parsed, System.currentTimeMillis()));
+                if (parsed == null) {
+                    // 304 Not Modified: keep the records we hold and just mark them
+                    // fresh. Must not fall through to the empty-list path below, which
+                    // would clear real chain controls mid-storm.
+                    CacheEntry held = cache.get(district);
+                    if (held != null) {
+                        cache.put(district, new CacheEntry(held.records, System.currentTimeMillis()));
+                        DebugLog.event("chains D" + district + ": unchanged (304)");
+                    }
+                } else {
+                    cache.put(district, new CacheEntry(parsed, System.currentTimeMillis()));
+                    Log.d(TAG, "D" + district + " chain controls: " + parsed.size() + " records");
+                    DebugLog.event("chains D" + district + ": " + parsed.size() + " records");
+                }
                 int total = 0;
                 for (CacheEntry ce : cache.values()) total += ce.records.size();
                 SourceStatus.success(SabreResponseBuilder.SOURCE_CHAINS, total);
-                Log.d(TAG, "D" + district + " chain controls: " + parsed.size() + " records");
-                DebugLog.event("chains D" + district + ": " + parsed.size() + " records");
             } catch (Exception e) {
                 SourceStatus.failure(SabreResponseBuilder.SOURCE_CHAINS,
                         "D" + district + " " + e.getClass().getSimpleName());
@@ -120,14 +132,23 @@ public class WinterSource {
         });
     }
 
+    /** @return parsed records, or {@code null} when the server replies 304 Not Modified. */
     private List<ChainControl> fetchDistrict(int district) throws Exception {
         URL url = new URL(feedUrl(district));
         HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
         conn.setConnectTimeout(TIMEOUT_MS);
         conn.setReadTimeout(TIMEOUT_MS);
         conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Linux; Android 14)");
+        ConditionalGet cg = validators.computeIfAbsent(district, d -> new ConditionalGet());
+        for (Map.Entry<String, String> h
+                : cg.requestHeaders(cache.get(district) != null).entrySet()) {
+            conn.setRequestProperty(h.getKey(), h.getValue());
+        }
         try {
             int code = conn.getResponseCode();
+            // Checked before the non-200 branch below: a 304 means "unchanged", not
+            // "no data", and must keep the cached records rather than blank them.
+            if (code == HttpsURLConnection.HTTP_NOT_MODIFIED) return null;
             // Districts with no chain-control program (D4 Bay Area, D5 Central Coast,
             // D12 Orange County) return a non-200 for their cc feed. It used to be 404;
             // as of 2026 Caltrans returns 500. Treat ANY non-200 as "no chain controls
@@ -141,9 +162,16 @@ public class WinterSource {
                 DebugLog.event("chains D" + district + ": HTTP " + code + " (no data)");
                 return new ArrayList<>();
             }
+            String etag = conn.getHeaderField("ETag");
+            String lastModified = conn.getHeaderField("Last-Modified");
+            List<ChainControl> parsed;
             try (InputStream in = conn.getInputStream()) {
-                return parse(in);
+                parsed = parse(in);
             }
+            // Commit only after a successful parse, so validators never match content
+            // the cache did not actually receive.
+            cg.commit(etag, lastModified);
+            return parsed;
         } finally {
             conn.disconnect();
         }

--- a/app/src/test/java/app/sabre/wzsabre/ConditionalGetTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/ConditionalGetTest.java
@@ -1,0 +1,67 @@
+package app.sabre.wzsabre;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+/**
+ * Validator bookkeeping for conditional GET.
+ *
+ * <p>The Caltrans district feeds are large (D7 measured at 15.7 MB on 2026-08-04) and
+ * are re-fetched while a driver is moving, so re-downloading an unchanged feed is the
+ * app's single biggest use of cellular data. The CWWP server sends ETag and
+ * Last-Modified and answers If-None-Match with a 0-byte 304 (verified live), which
+ * these rules turn into actual savings.
+ */
+public class ConditionalGetTest {
+
+    @Test
+    public void sendsNothingBeforeFirstResponse() {
+        ConditionalGet cg = new ConditionalGet();
+        assertTrue("no validators yet, so nothing to ask about",
+                cg.requestHeaders(true).isEmpty());
+    }
+
+    @Test
+    public void sendsNothingWithoutACachedBody() {
+        // A 304 when we hold no parsed body would leave the source with nothing to
+        // serve, so never ask conditionally until there is something to fall back on.
+        ConditionalGet cg = new ConditionalGet();
+        cg.commit("\"abc\"", "Tue, 04 Aug 2026 22:58:14 GMT");
+        assertTrue(cg.requestHeaders(false).isEmpty());
+    }
+
+    @Test
+    public void sendsBothValidatorsOnceCached() {
+        ConditionalGet cg = new ConditionalGet();
+        cg.commit("\"6a726e86-439d7b\"", "Tue, 04 Aug 2026 22:58:14 GMT");
+
+        Map<String, String> headers = cg.requestHeaders(true);
+        assertEquals("\"6a726e86-439d7b\"", headers.get("If-None-Match"));
+        assertEquals("Tue, 04 Aug 2026 22:58:14 GMT", headers.get("If-Modified-Since"));
+    }
+
+    @Test
+    public void sendsOnlyTheValidatorsTheServerProvided() {
+        ConditionalGet cg = new ConditionalGet();
+        cg.commit("\"only-etag\"", null);
+
+        Map<String, String> headers = cg.requestHeaders(true);
+        assertEquals("\"only-etag\"", headers.get("If-None-Match"));
+        assertNull("must not invent a date the server never sent",
+                headers.get("If-Modified-Since"));
+    }
+
+    @Test
+    public void forgetsValidatorsWhenServerStopsSendingThem() {
+        ConditionalGet cg = new ConditionalGet();
+        cg.commit("\"abc\"", "Tue, 04 Aug 2026 22:58:14 GMT");
+        cg.commit(null, null);   // server dropped both on a later response
+        assertTrue("stale validators must not outlive the response that set them",
+                cg.requestHeaders(true).isEmpty());
+    }
+}

--- a/app/src/test/java/app/sabre/wzsabre/WildfireSourceTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/WildfireSourceTest.java
@@ -96,4 +96,95 @@ public class WildfireSourceTest {
         // Unknown size/containment → name only
         assertEquals("Wildfire: RIDGE FIRE", WildfireSource.describe(fires.get(1)));
     }
+
+    // ── Selection: which parsed fires actually get drawn ──────────────────────
+    //
+    // WFIGS leaves ActiveFireCandidate=1 on records long after the fire is out, so
+    // the raw feed carries fully contained fires, months-old leftovers, and
+    // non-incident records (training exercises, false alarms). Drawing those as live
+    // road hazards is the bug these cover. Observed live on 2026-08-04: 9 of 91
+    // "active" CA records were noise, including a 69,352-acre fire 100% contained
+    // 16 days earlier.
+
+    private static final double LAT = 39.0, LON = -121.0;   // request centre
+    private static final long NOW_MS = 1_785_000_000_000L;
+    private static final long DAY_MS = 86_400_000L;
+
+    /** Fire at the request centre, so radius never decides these cases. */
+    private static WildfireSource.Fire fire(
+            String name, double acres, double pctContained, long ageDays) {
+        return new WildfireSource.Fire("id-" + name, name, LAT, LON, acres, pctContained,
+                (NOW_MS - ageDays * DAY_MS) / 1000L);
+    }
+
+    private static List<SabreAlert> select(WildfireSource.Fire... fires) {
+        return WildfireSource.selectAlerts(
+                java.util.Arrays.asList(fires), LAT, LON, 50_000, 0, NOW_MS);
+    }
+
+    @Test
+    public void select_dropsFullyContainedFire() {
+        assertEquals("a 100% contained fire is not a live road hazard",
+                0, select(fire("BISCAR", 69352, 100, 16)).size());
+    }
+
+    @Test
+    public void select_keepsNearlyContainedFire() {
+        assertEquals("99% contained is still burning",
+                1, select(fire("LOOMIS", 656, 99, 23)).size());
+    }
+
+    @Test
+    public void select_keepsFireWithUnknownContainment() {
+        assertEquals("unknown containment must not be read as contained",
+                1, select(fire("GREEN", 10, -1, 1)).size());
+    }
+
+    @Test
+    public void select_dropsNonIncidentRecords() {
+        assertEquals("training exercises and false alarms are not fires", 0,
+                select(fire("WILDFIRE TRAINING", 0.01, -1, 208),
+                       fire("FALSE ALARM", 0.1, -1, 3)).size());
+    }
+
+    @Test
+    public void select_dropsStaleTinyRecord() {
+        assertEquals("a months-old sub-acre leftover is not a live hazard",
+                0, select(fire("GRADE", 0.1, -1, 60)).size());
+    }
+
+    @Test
+    public void select_keepsLongBurningLargeFire() {
+        // Big fires legitimately burn for months (2024 Park Fire: 64 days to
+        // containment). Age alone must never drop one.
+        assertEquals("large uncontained fire survives regardless of age",
+                1, select(fire("PARK", 429603, 65, 60)).size());
+    }
+
+    @Test
+    public void select_keepsFreshUnknownSizeRecord() {
+        // Most WFIGS records report no size for the first day or two.
+        assertEquals("a new fire with no size yet is still shown",
+                1, select(fire("LAC-272069", -1, -1, 1)).size());
+    }
+
+    @Test
+    public void select_appliesMinAcresButKeepsUnknownSize() {
+        List<SabreAlert> out = WildfireSource.selectAlerts(
+                java.util.Arrays.asList(
+                        fire("SMALL", 5, -1, 1),
+                        fire("BIG", 5000, -1, 1),
+                        fire("UNSIZED", -1, -1, 1)),
+                LAT, LON, 50_000, 100, NOW_MS);
+        assertEquals("below-threshold dropped, unknown-size kept", 2, out.size());
+    }
+
+    @Test
+    public void select_appliesRadius() {
+        WildfireSource.Fire far = new WildfireSource.Fire(
+                "far", "FAR", LAT + 2.0, LON, 500, 10, NOW_MS / 1000L);
+        assertEquals("fire outside the radius is dropped",
+                0, WildfireSource.selectAlerts(
+                        java.util.Arrays.asList(far), LAT, LON, 50_000, 0, NOW_MS).size());
+    }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,726 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SABRE Plus: CHP, Waze and Caltrans alerts for Highway Radar</title>
+<meta name="description" content="A free, open-source Highway Radar SABRE plugin for California. Adds live CHP incidents, Waze crowd alerts, Caltrans lane closures, active wildfires and winter chain controls to your Highway Radar map. Drop-in wzsabre replacement, Android 7.0+.">
+<link rel="canonical" href="https://nicglazkov.github.io/highway-radar-sabre-plus/">
+<meta name="theme-color" content="#E6E7E4" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#111316" media="(prefers-color-scheme: dark)">
+
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://nicglazkov.github.io/highway-radar-sabre-plus/">
+<meta property="og:title" content="SABRE Plus: CHP, Waze and Caltrans alerts for Highway Radar">
+<meta property="og:description" content="Five California road feeds on your Highway Radar map. Free, open source, no account, no ads. A drop-in wzsabre replacement.">
+<meta property="og:image" content="https://nicglazkov.github.io/highway-radar-sabre-plus/social-preview.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="SABRE Plus for Highway Radar">
+<meta name="twitter:description" content="Five California road feeds on your Highway Radar map. Free and open source.">
+<meta name="twitter:image" content="https://nicglazkov.github.io/highway-radar-sabre-plus/social-preview.png">
+<link rel="icon" href="screenshots/app-icon.png">
+<link rel="apple-touch-icon" href="screenshots/app-icon.png">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "SABRE Plus",
+  "alternateName": "Highway Radar SABRE Plus",
+  "applicationCategory": "TravelApplication",
+  "operatingSystem": "Android 7.0+",
+  "url": "https://nicglazkov.github.io/highway-radar-sabre-plus/",
+  "downloadUrl": "https://github.com/nicglazkov/highway-radar-sabre-plus/releases/latest",
+  "license": "https://opensource.org/licenses/MIT",
+  "isAccessibleForFree": true,
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  "description": "An open-source Highway Radar SABRE plugin for California. Adds live CHP incidents, Waze crowd-sourced alerts, Caltrans lane closures, active wildfires and winter chain controls to the Highway Radar map. A drop-in replacement for wzsabre.",
+  "author": { "@type": "Person", "name": "Nic Glazkov" }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {"@type":"Question","name":"Is SABRE Plus a replacement for wzsabre?",
+     "acceptedAnswer":{"@type":"Answer","text":"Yes. It uses the same plugin ID Highway Radar looks for, so Highway Radar finds it automatically. Because Android allows only one app per ID, uninstall wzsabre first, then install SABRE Plus. Your Highway Radar settings are unaffected."}},
+    {"@type":"Question","name":"Does SABRE Plus cost anything?",
+     "acceptedAnswer":{"@type":"Answer","text":"No. It is free and open source under the MIT license, with no account, no ads and no in-app purchases."}},
+    {"@type":"Question","name":"What data does SABRE Plus collect?",
+     "acceptedAnswer":{"@type":"Answer","text":"None. There are no servers, no accounts and no analytics. Everything runs on your device. Only the Waze feature sends your approximate location, over an anonymous session, so it can return alerts near you."}},
+    {"@type":"Question","name":"Which areas does it cover?",
+     "acceptedAnswer":{"@type":"Answer","text":"California. CHP incidents and Caltrans closures are statewide, chain controls cover the mountain routes, and Waze alerts work anywhere Waze has coverage."}},
+    {"@type":"Question","name":"Why is it not on Google Play?",
+     "acceptedAnswer":{"@type":"Answer","text":"It has to use the exact package ID that Highway Radar's plugin discovery looks for, which is already taken on Google Play. You install the APK directly from GitHub Releases, or let Obtainium keep it updated for you."}}
+  ]
+}
+</script>
+
+<style>
+/* ─────────────────────────────────────────────────────────────────────────
+   SABRE Plus landing page.
+   Palette and type come from California highway hardware: a Caltrans
+   changeable message sign (amber LED on night asphalt) mounted over a
+   concrete-grey page. No webfonts and no third-party requests, which keeps
+   the page consistent with an app that ships no trackers.
+   ───────────────────────────────────────────────────────────────────────── */
+:root {
+  --asphalt:   #0B0C0E;   /* inside of the sign housing */
+  --amber:     #FFB000;   /* Caltrans CMS amber LED */
+  --amber-dim: #6E4B00;   /* unlit element */
+  --spade:     #0B6E4F;   /* California route shield green */
+  --concrete:  #E6E7E4;   /* page surface, K-rail grey */
+  --panel:     #F2F3F0;
+  --ink:       #1B1D20;
+  --ink-soft:  #55595E;
+  --rule:      #C9CBC6;
+  --stripe:    #F2C14E;   /* lane paint */
+
+  --display: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+             "Helvetica Neue", Arial, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", "Cascadia Mono",
+          "Roboto Mono", Menlo, Consolas, monospace;
+
+  --measure: 68rem;
+  --gap: clamp(3.5rem, 8vw, 6.5rem);
+}
+
+/* Night driving. The sign is the constant; the road around it goes dark. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --concrete: #111316;
+    --panel:    #191C20;
+    --ink:      #E9EAE7;
+    --ink-soft: #9AA0A6;
+    --rule:     #2C3036;
+    --spade:    #3FA37B;
+  }
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  background: var(--concrete);
+  color: var(--ink);
+  font-family: var(--display);
+  font-size: clamp(1rem, 0.96rem + 0.2vw, 1.0625rem);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; }
+
+:where(a, button, summary):focus-visible {
+  outline: 3px solid var(--spade);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+img { max-width: 100%; height: auto; display: block; }
+
+.wrap { width: min(100% - 2.5rem, var(--measure)); margin-inline: auto; }
+
+/* ── Eyebrow / section labels: the data face, used like a spec sheet ────── */
+.label {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin: 0 0 0.75rem;
+}
+
+h1, h2, h3 { line-height: 1.08; letter-spacing: -0.025em; margin: 0; }
+h1 { font-size: clamp(2.1rem, 1.2rem + 4.2vw, 4rem); font-weight: 800; }
+h2 { font-size: clamp(1.6rem, 1.1rem + 2.2vw, 2.5rem); font-weight: 800; }
+h3 { font-size: 1.0625rem; font-weight: 700; letter-spacing: -0.01em; }
+
+/* ── Masthead ──────────────────────────────────────────────────────────── */
+.masthead {
+  position: sticky; top: 0; z-index: 20;
+  background: color-mix(in srgb, var(--concrete) 88%, transparent);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--rule);
+}
+.masthead .wrap {
+  display: flex; align-items: center; gap: 0.75rem;
+  min-height: 3.5rem;
+}
+.mark { display: flex; align-items: center; gap: 0.6rem; text-decoration: none; font-weight: 800; letter-spacing: -0.02em; }
+.mark img { width: 26px; height: 26px; border-radius: 6px; }
+.masthead nav { margin-left: auto; display: flex; align-items: center; gap: 1.25rem; }
+.masthead nav a { font-family: var(--mono); font-size: 0.8125rem; text-decoration: none; color: var(--ink-soft); }
+.masthead nav a:hover { color: var(--ink); }
+.masthead .btn { color: var(--asphalt); }
+@media (max-width: 34rem) { .nav-hide { display: none; } }
+
+/* ── Buttons ───────────────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex; align-items: center; gap: 0.5rem;
+  font-family: var(--mono); font-size: 0.875rem; font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.7rem 1.15rem;
+  background: var(--amber); color: var(--asphalt);
+  text-decoration: none; border: 1px solid transparent; border-radius: 3px;
+  transition: transform 0.12s ease, filter 0.12s ease;
+}
+.btn:hover { filter: brightness(1.08); transform: translateY(-1px); }
+.btn--ghost {
+  background: transparent; color: var(--ink);
+  border-color: var(--rule);
+}
+.btn--ghost:hover { border-color: var(--ink); filter: none; }
+.btn--lg { font-size: 0.9375rem; padding: 0.95rem 1.5rem; }
+
+/* ── Hero ──────────────────────────────────────────────────────────────── */
+.hero { padding: clamp(3rem, 7vw, 5.5rem) 0 var(--gap); }
+.hero p.lede {
+  font-size: clamp(1.0625rem, 1rem + 0.5vw, 1.25rem);
+  color: var(--ink-soft);
+  max-width: 44ch;
+  margin: 1.25rem 0 0;
+}
+.actions { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 2rem; }
+.hero .terms {
+  font-family: var(--mono); font-size: 0.8125rem; color: var(--ink-soft);
+  margin: 1rem 0 0;
+}
+
+/* ── THE SIGN: the one bold element on the page ────────────────────────── */
+.gantry { margin-top: clamp(2.5rem, 6vw, 4rem); }
+
+.sign {
+  position: relative;
+  background: var(--asphalt);
+  border: 3px solid #3A3D42;
+  border-radius: 5px;
+  padding: clamp(1.1rem, 3.5vw, 2rem) clamp(1rem, 3vw, 2rem);
+  box-shadow: 0 18px 40px -22px rgba(0,0,0,0.85), inset 0 0 0 2px #17191C;
+  overflow: hidden;
+}
+/* The LED grid. Sits over the text so the type reads as lit elements. */
+.sign::after {
+  content: "";
+  position: absolute; inset: 0;
+  background-image:
+    repeating-linear-gradient(to right,  rgba(0,0,0,0.42) 0 1px, transparent 1px 3px),
+    repeating-linear-gradient(to bottom, rgba(0,0,0,0.42) 0 1px, transparent 1px 3px);
+  pointer-events: none;
+}
+.sign__head {
+  font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.22em;
+  text-transform: uppercase; color: var(--amber-dim);
+  display: flex; justify-content: space-between; gap: 1rem;
+  margin-bottom: 0.9rem;
+}
+.sign__msg {
+  font-family: var(--mono);
+  font-size: clamp(0.9rem, 0.5rem + 2.1vw, 1.6rem);
+  font-weight: 700; line-height: 1.5; letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--amber);
+  text-shadow: 0 0 14px rgba(255,176,0,0.45);
+  min-height: 3em;
+  margin: 0;
+}
+.sign__msg span { display: block; }
+.sign__src {
+  font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--amber-dim);
+  margin: 0.9rem 0 0;
+}
+/* The gantry legs, so the sign reads as mounted over the road. */
+.gantry__legs { display: flex; justify-content: space-between; padding: 0 12%; }
+.gantry__legs i {
+  display: block; width: 7px; height: clamp(18px, 3vw, 30px);
+  background: linear-gradient(to bottom, #3A3D42, transparent);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .sign__msg { transition: opacity 0.35s ease; }
+  .sign__msg.is-swapping { opacity: 0.15; }
+}
+
+/* ── Lane-line divider: the road's own way of separating lanes ─────────── */
+.lane {
+  height: 6px; border: 0; margin: 0;
+  background: repeating-linear-gradient(
+    to right, var(--stripe) 0 42px, transparent 42px 76px);
+  opacity: 0.75;
+}
+
+/* ── Sections ──────────────────────────────────────────────────────────── */
+.band { padding: var(--gap) 0; }
+.band > .wrap > h2 + p { color: var(--ink-soft); max-width: 56ch; margin: 1rem 0 0; }
+
+/* ── Source strips: small signs, echoing the hero ──────────────────────── */
+.sources { display: grid; gap: 0.75rem; margin-top: 2.5rem; }
+.source {
+  display: grid;
+  grid-template-columns: auto minmax(0,1fr);
+  gap: 0 1.15rem;
+  align-items: start;
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  border-left: 4px solid var(--amber);
+  border-radius: 3px;
+  padding: 1.15rem 1.25rem;
+}
+.source__tag {
+  font-family: var(--mono); font-size: 0.6875rem; font-weight: 700;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  background: var(--asphalt); color: var(--amber);
+  padding: 0.3rem 0.5rem; border-radius: 2px; white-space: nowrap;
+  grid-row: span 2;
+}
+.source p { margin: 0.35rem 0 0; color: var(--ink-soft); font-size: 0.9375rem; }
+.source__cadence {
+  font-family: var(--mono); font-size: 0.75rem; color: var(--ink-soft);
+  margin-top: 0.5rem;
+}
+@media (max-width: 34rem) {
+  .source { grid-template-columns: minmax(0,1fr); gap: 0.6rem; }
+  .source__tag { grid-row: auto; justify-self: start; }
+}
+
+/* ── Screens ───────────────────────────────────────────────────────────── */
+.screens { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.25rem; margin-top: 2.5rem; }
+.screens figure { margin: 0; }
+.screens img { border: 1px solid var(--rule); border-radius: 6px; background: var(--panel); }
+.screens figcaption {
+  font-family: var(--mono); font-size: 0.75rem; color: var(--ink-soft);
+  margin-top: 0.65rem; line-height: 1.45;
+}
+@media (max-width: 44rem) { .screens { grid-template-columns: 1fr; max-width: 22rem; } }
+
+/* ── Install: numbered because it genuinely is a sequence ──────────────── */
+.warn {
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  border-left: 4px solid var(--stripe);
+  border-radius: 3px;
+  padding: 1.15rem 1.25rem;
+  margin-top: 2.25rem;
+}
+.warn h3 { margin-bottom: 0.4rem; }
+.warn p { margin: 0; color: var(--ink-soft); font-size: 0.9375rem; }
+
+.steps { list-style: none; counter-reset: step; padding: 0; margin: 2.25rem 0 0; }
+.steps li {
+  counter-increment: step;
+  display: grid; grid-template-columns: auto minmax(0,1fr); gap: 1.15rem;
+  padding: 1.15rem 0; border-top: 1px solid var(--rule);
+}
+.steps li:last-child { border-bottom: 1px solid var(--rule); }
+.steps li::before {
+  content: counter(step, decimal-leading-zero);
+  font-family: var(--mono); font-size: 0.875rem; font-weight: 700;
+  color: var(--amber-dim);
+}
+@media (prefers-color-scheme: dark) { .steps li::before { color: var(--amber); } }
+.steps p { margin: 0.35rem 0 0; color: var(--ink-soft); font-size: 0.9375rem; }
+
+/* ── Privacy ledger ────────────────────────────────────────────────────── */
+.ledger { margin-top: 2.5rem; border-top: 1px solid var(--rule); }
+.ledger div {
+  display: flex; align-items: baseline; gap: 1rem;
+  padding: 0.85rem 0; border-bottom: 1px solid var(--rule);
+  font-family: var(--mono); font-size: 0.875rem;
+}
+.ledger dt { flex: 1; margin: 0; color: var(--ink); }
+.ledger dd { margin: 0; color: var(--spade); font-weight: 600; letter-spacing: 0.04em; text-align: right; }
+.ledger dd.is-note { color: var(--ink-soft); font-weight: 400; }
+
+/* ── FAQ ───────────────────────────────────────────────────────────────── */
+.faq { margin-top: 2.5rem; border-top: 1px solid var(--rule); }
+.faq details { border-bottom: 1px solid var(--rule); }
+.faq summary {
+  cursor: pointer; list-style: none;
+  padding: 1.15rem 2rem 1.15rem 0; position: relative;
+  font-weight: 700; letter-spacing: -0.01em;
+}
+.faq summary::-webkit-details-marker { display: none; }
+.faq summary::after {
+  content: "+"; position: absolute; right: 0.25rem; top: 50%;
+  transform: translateY(-50%);
+  font-family: var(--mono); font-weight: 400; color: var(--ink-soft);
+}
+.faq details[open] summary::after { content: "\2013"; }
+.faq p { margin: 0 0 1.25rem; color: var(--ink-soft); max-width: 62ch; font-size: 0.9375rem; }
+
+/* ── Closing call to action ────────────────────────────────────────────── */
+.closer { padding: var(--gap) 0; text-align: center; }
+.closer .actions { justify-content: center; }
+.closer p { color: var(--ink-soft); max-width: 46ch; margin: 1rem auto 0; }
+
+/* ── Footer ────────────────────────────────────────────────────────────── */
+footer { border-top: 1px solid var(--rule); padding: 2.5rem 0 3.5rem; }
+footer .wrap { display: flex; flex-wrap: wrap; gap: 1rem 2rem; align-items: center; }
+footer a { font-family: var(--mono); font-size: 0.8125rem; color: var(--ink-soft); text-decoration: none; }
+footer a:hover { color: var(--ink); text-decoration: underline; }
+footer .disclaim {
+  font-size: 0.8125rem; color: var(--ink-soft); margin: 1.5rem 0 0;
+  max-width: 70ch; line-height: 1.55;
+}
+</style>
+</head>
+<body>
+
+<header class="masthead">
+  <div class="wrap">
+    <a class="mark" href="./">
+      <img src="screenshots/app-icon.png" alt="">
+      SABRE Plus
+    </a>
+    <nav>
+      <a class="nav-hide" href="#sources">Sources</a>
+      <a class="nav-hide" href="#install">Install</a>
+      <a class="nav-hide" href="#faq">FAQ</a>
+      <a class="btn" href="https://github.com/nicglazkov/highway-radar-sabre-plus/releases/latest">Download</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+
+  <section class="hero">
+    <div class="wrap">
+      <p class="label">Highway Radar plugin &middot; California &middot; Free and open source</p>
+      <h1>CHP, Waze and Caltrans alerts on your Highway&nbsp;Radar map.</h1>
+      <p class="lede">
+        Highway Radar can pull crowd-sourced alerts from a plugin. SABRE Plus is that
+        plugin, wired to five live California feeds instead of one.
+      </p>
+
+      <div class="actions">
+        <a class="btn btn--lg" href="https://github.com/nicglazkov/highway-radar-sabre-plus/releases/latest">
+          Download the APK
+        </a>
+        <a class="btn btn--ghost btn--lg" href="#install">Read the install steps</a>
+      </div>
+      <p class="terms">Android 7.0+ &nbsp;·&nbsp; no account &nbsp;·&nbsp; no ads &nbsp;·&nbsp; no tracking &nbsp;·&nbsp; MIT licensed</p>
+
+      <!-- The signature element: a Caltrans-style changeable message sign
+           cycling the kind of alert each source actually produces. -->
+      <div class="gantry">
+        <div class="sign">
+          <div class="sign__head">
+            <span>Live alert feed</span>
+            <span aria-hidden="true">CA · SABRE</span>
+          </div>
+          <p class="sign__msg" id="signMsg" aria-live="off">
+            <span>Traffic collision, no injury</span>
+            <span>I-80 E at Truckee</span>
+          </p>
+          <p class="sign__src" id="signSrc">Source: CHP live feed</p>
+        </div>
+        <div class="gantry__legs" aria-hidden="true"><i></i><i></i></div>
+      </div>
+    </div>
+  </section>
+
+  <hr class="lane">
+
+  <section class="band" id="sources">
+    <div class="wrap">
+      <p class="label">What it adds</p>
+      <h2>Five feeds, one map layer.</h2>
+      <p>
+        Every source is fetched in parallel, filtered to the area Highway Radar asked
+        about, de-duplicated across sources, and handed over as standard crowd alerts.
+        Turn any of them off in the app.
+      </p>
+
+      <div class="sources">
+        <article class="source">
+          <span class="source__tag">CHP</span>
+          <h3>California Highway Patrol incidents</h3>
+          <p>
+            Collisions, closures, debris, officers on the road and weather hazards,
+            straight from the CHP statewide dispatch feed. Per-category toggles, a
+            maximum incident age, and control over which icon each category uses.
+          </p>
+          <p class="source__cadence">Refreshed every map update</p>
+        </article>
+
+        <article class="source">
+          <span class="source__tag">Waze</span>
+          <h3>Waze crowd reports</h3>
+          <p>
+            Police, accidents, hazards, jams and closures reported by drivers nearby,
+            kept in a rolling cache so alerts do not blink out as you drive past them.
+          </p>
+          <p class="source__cadence">Refreshed every map update</p>
+        </article>
+
+        <article class="source">
+          <span class="source__tag">Caltrans</span>
+          <h3>Lane and road closures</h3>
+          <p>
+            Closures that are physically in place right now, from the Caltrans Lane
+            Closure System. Shoulder work is skipped, and a long closure gets a pin at
+            each end so you see where it starts and stops.
+          </p>
+          <p class="source__cadence">Cached, refreshed every 15 min</p>
+        </article>
+
+        <article class="source">
+          <span class="source__tag">Fire</span>
+          <h3>Active wildfires</h3>
+          <p>
+            Active California wildfires from the interagency WFIGS feed, with name,
+            size and containment. Contained and stale records are filtered out, and you
+            can hide anything under a size you choose.
+          </p>
+          <p class="source__cadence">Cached, refreshed every 5 min</p>
+        </article>
+
+        <article class="source">
+          <span class="source__tag">Chains</span>
+          <h3>Winter chain controls</h3>
+          <p>
+            R-1, R-2 and R-3 chain requirements on the mountain routes, at the
+            checkpoint where they are enforced. I-80, US-50, SR-88, SR-89 and US-395.
+          </p>
+          <p class="source__cadence">Cached, refreshed every 5 min</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <hr class="lane">
+
+  <section class="band">
+    <div class="wrap">
+      <p class="label">On your phone</p>
+      <h2>Settings you control, alerts where you already look.</h2>
+
+      <div class="screens">
+        <figure>
+          <img src="screenshots/settings.png" width="1080" height="2400" loading="lazy"
+               alt="The SABRE Plus settings screen, showing per-category toggles and shows-as overrides.">
+          <figcaption>Toggle any category, and pick the icon Highway Radar draws for it.</figcaption>
+        </figure>
+        <figure>
+          <img src="screenshots/hr_state.png" width="1080" height="2400" loading="lazy"
+               alt="Highway Radar's plugin settings showing SABRE Plus detected and selected.">
+          <figcaption>Highway Radar finds the plugin on its own. Nothing to configure.</figcaption>
+        </figure>
+        <figure>
+          <img src="screenshots/hr-map.png" width="1080" height="2400" loading="lazy"
+               alt="The Highway Radar map with an alert pin fed by the plugin.">
+          <figcaption>Alerts land on the map layer you already watch while driving.</figcaption>
+        </figure>
+      </div>
+    </div>
+  </section>
+
+  <hr class="lane">
+
+  <section class="band" id="install">
+    <div class="wrap">
+      <p class="label">Install</p>
+      <h2>Three steps, about two minutes.</h2>
+
+      <div class="warn">
+        <h3>Already running wzsabre? Uninstall it first.</h3>
+        <p>
+          SABRE Plus replaces wzsabre and has to use the same plugin ID that Highway
+          Radar looks for, so Android will not keep both. Uninstall wzsabre, then
+          install SABRE Plus. Your Highway Radar settings stay exactly as they are.
+        </p>
+      </div>
+
+      <ol class="steps">
+        <li>
+          <div>
+            <h3>Download the APK</h3>
+            <p>
+              Grab the latest build from GitHub Releases. Your browser will ask for
+              permission to install unknown apps, and Play Protect may warn that it does
+              not recognize the app: choose More details, then Install anyway.
+            </p>
+          </div>
+        </li>
+        <li>
+          <div>
+            <h3>Open SABRE Plus once</h3>
+            <p>
+              Allow notifications and the battery-optimization exemption when asked.
+              Without them Android can freeze the plugin in the background and alerts
+              stop arriving.
+            </p>
+          </div>
+        </li>
+        <li>
+          <div>
+            <h3>Pick it in Highway Radar</h3>
+            <p>
+              Open Highway Radar, then Settings, then SABRE, and choose SABRE Plus.
+              Alerts start on the next map refresh.
+            </p>
+          </div>
+        </li>
+      </ol>
+
+      <div class="actions">
+        <a class="btn btn--lg" href="https://github.com/nicglazkov/highway-radar-sabre-plus/releases/latest">Download the APK</a>
+        <a class="btn btn--ghost btn--lg" href="https://github.com/ImranR98/Obtainium">Auto-update with Obtainium</a>
+      </div>
+    </div>
+  </section>
+
+  <hr class="lane">
+
+  <section class="band">
+    <div class="wrap">
+      <p class="label">Privacy</p>
+      <h2>What it does not do.</h2>
+      <p>
+        There is no backend to speak of, because there is no backend. The app talks to
+        public road feeds and to Waze, and that is the whole list.
+      </p>
+
+      <dl class="ledger">
+        <div><dt>Accounts</dt><dd>None</dd></div>
+        <div><dt>Analytics or telemetry</dt><dd>None</dd></div>
+        <div><dt>Ads and trackers</dt><dd>None</dd></div>
+        <div><dt>Servers run by this project</dt><dd>None</dd></div>
+        <div><dt>Data leaving your device</dt><dd class="is-note">Approximate location, to Waze only</dd></div>
+        <div><dt>Source code</dt><dd class="is-note">Public, MIT licensed</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <hr class="lane">
+
+  <section class="band" id="faq">
+    <div class="wrap">
+      <p class="label">Questions</p>
+      <h2>Before you install.</h2>
+
+      <div class="faq">
+        <details open>
+          <summary>Is this a replacement for wzsabre?</summary>
+          <p>
+            Yes. It uses the same plugin ID that Highway Radar's discovery looks for, so
+            Highway Radar picks it up automatically. Android only allows one app to hold
+            that ID, so uninstall wzsabre before installing SABRE Plus.
+          </p>
+        </details>
+        <details>
+          <summary>Does it cost anything?</summary>
+          <p>
+            No. It is free and open source under the MIT license. No account, no ads, no
+            in-app purchases, no premium tier.
+          </p>
+        </details>
+        <details>
+          <summary>Why is it not on Google Play?</summary>
+          <p>
+            The plugin has to use the exact package ID Highway Radar looks for, and that
+            ID is already taken on Play. You install the APK from GitHub Releases
+            instead, or point Obtainium at the repository and let it handle updates.
+          </p>
+        </details>
+        <details>
+          <summary>Does it drain my battery or my data plan?</summary>
+          <p>
+            The plugin runs only while Highway Radar is open and stops itself shortly
+            after you close it. The large Caltrans feeds are cached, refreshed on a long
+            interval, and skipped entirely when Caltrans reports nothing has changed.
+          </p>
+        </details>
+        <details>
+          <summary>Which areas are covered?</summary>
+          <p>
+            California. CHP incidents and Caltrans closures are statewide, chain
+            controls cover the mountain passes, wildfires cover the state, and Waze
+            reports work anywhere Waze does.
+          </p>
+        </details>
+        <details>
+          <summary>Is it affiliated with Highway Radar, Waze, CHP or Caltrans?</summary>
+          <p>
+            No. It is an independent project, not affiliated with, endorsed by or
+            supported by any of them. Do not rely on it for safety-critical decisions.
+          </p>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <section class="closer">
+    <div class="wrap">
+      <h2>Put the whole state on your map.</h2>
+      <p>Free, open source, and about two minutes to set up.</p>
+      <div class="actions">
+        <a class="btn btn--lg" href="https://github.com/nicglazkov/highway-radar-sabre-plus/releases/latest">Download the APK</a>
+        <a class="btn btn--ghost btn--lg" href="https://github.com/nicglazkov/highway-radar-sabre-plus">View the source</a>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<footer>
+  <div class="wrap">
+    <a href="https://github.com/nicglazkov/highway-radar-sabre-plus">GitHub</a>
+    <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/releases">Releases</a>
+    <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/CHANGELOG.md">Changelog</a>
+    <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/PRIVACY.md">Privacy policy</a>
+    <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/issues">Report a problem</a>
+    <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/LICENSE">MIT license</a>
+  </div>
+  <div class="wrap">
+    <p class="disclaim">
+      SABRE Plus is an independent, unofficial project. It is not affiliated with,
+      endorsed by or supported by Waze, Google, the California Highway Patrol, Caltrans
+      or Highway Radar. Road data comes from public feeds and is provided without any
+      guarantee of accuracy or timeliness. Always follow real-world conditions, signage
+      and the law.
+    </p>
+  </div>
+</footer>
+
+<script>
+// Cycle the sign through one representative alert per source. The first message
+// is in the HTML, so the page still says something useful without JavaScript.
+(function () {
+  var msg = document.getElementById('signMsg');
+  var src = document.getElementById('signSrc');
+  if (!msg || !src) return;
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+  var feed = [
+    { lines: ['Traffic collision, no injury', 'I-80 E at Truckee'],       src: 'CHP live feed' },
+    { lines: ['Chains required R-2', 'US-50 at Echo Summit'],             src: 'Caltrans chain control' },
+    { lines: ['Right 2 lanes closed', 'SR-99 N at Elk Grove'],            src: 'Caltrans lane closures' },
+    { lines: ['Wildfire, 12,400 ac, 40% contained', 'SR-32 near Forest Ranch'], src: 'WFIGS active fires' },
+    { lines: ['Police reported ahead', 'I-5 N near Stockton'],            src: 'Waze crowd reports' }
+  ];
+
+  var i = 0;
+  setInterval(function () {
+    i = (i + 1) % feed.length;
+    var next = feed[i];
+    msg.classList.add('is-swapping');
+    setTimeout(function () {
+      msg.innerHTML = '';
+      next.lines.forEach(function (line) {
+        var el = document.createElement('span');
+        el.textContent = line;
+        msg.appendChild(el);
+      });
+      src.textContent = 'Source: ' + next.src;
+      msg.classList.remove('is-swapping');
+    }, 350);
+  }, 3600);
+})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Audit of the live feeds turned up two user-facing problems, both fixed here, plus the landing page.

## Contained and stale wildfires were drawn as live hazards

WFIGS leaves `ActiveFireCandidate=1` set long after a fire is out, and `WildfireSource` filtered only on size and radius. On the live feed on 2026-08-04, **9 of 91 "active" California records were noise**:

| Record | Size | State |
|---|---|---|
| BISCAR | 69,352 ac | 100% contained, 16 days earlier |
| MATEO | 1,335 ac | 100% contained, 49 days earlier |
| SUMMIT, TWAIN, FIELDS, FISH, 3-6 WAGON | various | 100% contained |
| WILDFIRE TRAINING | 0.01 ac | 208 days old |
| FALSE ALARM | 0.1 ac | not a fire |

`selectAlerts` now drops fully contained fires, non-incident records, and stale sub-acre leftovers. Age alone is never disqualifying, since large fires legitimately burn for months (the 2024 Park Fire took 64 days to reach containment). Modelled against the live feed, the filter drops exactly those 9 and keeps all 82 real ones.

## The Caltrans feeds were burning enormous amounts of cellular data

`LcsSource` re-downloaded each in-range district's full XML every 5 minutes while driving, uncompressed and unconditionally, even though CWWP sends `ETag`/`Last-Modified` and answers `If-None-Match` with a 0-byte 304.

Feed sizes measured 2026-08-04: D7 **15.7 MB**, D4 4.4, D8 4.4, D3 3.5, D12 3.5, D5 2.0, D11 1.8, D1 1.7, D10 1.7, D6 1.6, D2 0.6, D9 0.2. The district boxes overlap deliberately, so several are pulled at once:

| Driver | Districts | Per refresh | Before | After |
|---|---|---|---|---|
| Oakland | D3+D4 | 7.9 MB | ~95 MB/h | ~32 MB/h |
| Sacramento | D3+D4+D10 | 9.6 MB | ~115 MB/h | ~38 MB/h |
| **Los Angeles** | D7+D8+D12 | 23.6 MB | **~284 MB/h** | **~94 MB/h** |

The "after" column is the TTL change alone; every unchanged feed on top of that costs zero bytes.

- New `ConditionalGet` holds per-district validators, committed only after a successful parse (same ordering `CHPSource` uses, so a mid-stream failure can't leave validators matching content the cache never received).
- LCS TTL goes 5 to 15 min. An established 1097 closure lasts hours.
- `WinterSource` gets the same treatment, with the 304 checked **before** its non-200 "no chain program in this district" branch, so an unchanged feed can't blank real chain controls mid-storm.

Verified against the live CWWP server with the production HTTP stack: 198 KB on the first fetch, 0 bytes on the second via 304.

## Landing page

`docs/index.html`, served from `/docs`. Single self-contained file, no webfonts or third-party requests, responsive, keyboard-accessible, reduced-motion aware, dark-mode aware. Canonical URL, OG/Twitter cards, and SoftwareApplication + FAQPage structured data.

**Pages still needs to be switched on:** Settings > Pages > Source: deploy from branch `main`, folder `/docs`. The repo homepage field also still points at the old `caltrans-sabre` URL and should become the Pages URL.

## Verification

- 242 tests pass (was 228: +9 wildfire selection, +5 conditional GET)
- `lintDebug` clean
- Both fixes written test-first, each watched failing for the right reason before implementing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwZeY8xWMzHKhiFkFsZGGW