### PR TITLE
v1.9.6: drop em dashes and middots, add a privacy page, fix HR cache guidance

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-# The Gradle wrapper is a shell script — keep LF even on a Windows checkout, or it
+# The Gradle wrapper is a shell script, keep LF even on a Windows checkout, or it
 # breaks on macOS/Linux CI runners (bash: "\r": command not found).
 gradlew text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             echo "signable=true" >> "$GITHUB_OUTPUT"
           else
             echo "signable=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Signing secrets missing/incomplete — skipping automated release. Release manually or add all four secrets (see BUILDING.md)."
+            echo "::warning::Signing secrets missing/incomplete: skipping automated release. Release manually or add all four secrets (see BUILDING.md)."
           fi
 
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ local.properties
 # App module build output
 app/build/
 
-# Signing keys — never commit these
+# Signing keys: never commit these
 *.keystore
 *.jks
 keystore.properties

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,7 +8,7 @@
 | Android SDK | API 35 |
 | JDK | **17+** to run Gradle/AGP (the JBR bundled with Android Studio works). The app code itself targets Java 11. |
 
-No NDK or additional toolchains needed. The Waze protobuf classes are generated automatically on first build from `app/src/main/proto/waze.proto` — no manual protoc step. Debug builds need no keystore; only `assembleRelease` requires a `keystore.properties` at the repo root.
+No NDK or additional toolchains needed. The Waze protobuf classes are generated automatically on first build from `app/src/main/proto/waze.proto`: no manual protoc step. Debug builds need no keystore; only `assembleRelease` requires a `keystore.properties` at the repo root.
 
 ## Clone and build
 
@@ -66,11 +66,11 @@ Current test suites:
 |-------|-------|----------------|
 | `AlertMapperTest` | 55 | CHP/Waze type → SABRE type (injury codes, locale independence, Waze coarse categories) |
 | `ChpConfigTest` | 42 | Category toggles, type overrides, age filter, LogTime parsing (both CHP feed formats) |
-| `SabreProtocolTest` | 38 | HR JSON schema — all 11 required alert fields, type whitelist, nullability, drop-bad-alert semantics |
+| `SabreProtocolTest` | 38 | HR JSON schema, all 11 required alert fields, type whitelist, nullability, drop-bad-alert semantics |
 | `LcsSourceTest` | 27 | Caltrans LCS parsing, 1097/1098/1022 state filtering, shoulder/aux skip, span pins, district selection |
 | `CHPSourceTest` | 18 | XML parsing (incl. entity refs + real feed shape), radius filter, coordinate parsing, haversine |
 | `WildfireSourceTest` | 7 | WFIGS ArcGIS JSON parse (incl. error body + RX filter), SABRE mapping |
-| `WinterSourceTest` | 7 | Chain-control parse, R-0…R-3 active filtering, SABRE mapping |
+| `WinterSourceTest` | 7 | Chain-control parse, R-0 to R-3 active filtering, SABRE mapping |
 | `AlertDeduperTest` | 7 | Cross-source-only pin de-duplication (family + proximity, confirm-fold) |
 | `UpdateCheckerTest` | 4 | Version-comparison logic for the update check |
 | Waze suites | 23 | RT cache delta-merge/soft-delete, in-band error classification, shrinking-box geometry, confirm-ts, RmAlert parsing |
@@ -117,7 +117,7 @@ app/src/main/java/app/sabre/wzsabre/
 ### Package ID = `app.sabre.wzsabre`
 Highway Radar's SABRE discovery whitelists this package ID. Keeping the same ID means HR finds this plugin without requiring any HR-side changes.
 
-### SABRE protocol — `SabreFetchResponseAlert` schema
+### SABRE protocol: `SabreFetchResponseAlert` schema
 HR uses `kotlinx.serialization` with a bitmask that requires **all 11 fields** to be present on every alert object. Missing any field throws `MissingFieldException` in HR and crashes the crowdsourced-alert layer. `SabreResponseBuilder.buildAlert()` enforces this and rejects NaN coordinates and overflowing `report_ts` at build time.
 
 The 11 fields: `alert_source`, `alert_id`, `user_id`, `type`, `lat`, `lon`, `heading_deg`, `street_name` (nullable), `report_ts` (Int, not Long), `confirm_ts` (nullable Int), `confirm_count`.
@@ -133,8 +133,8 @@ a cache and refreshes it on a background thread, and persists/reuses the account
 registers at most once. The protobuf schema lives at `app/src/main/proto/waze.proto` and is
 compiled with `protobuf-javalite` (gradle `com.google.protobuf` plugin).
 
-The RT `/command` endpoint is session-stateful — it sends each alert once, then a
-`"RmAlert,<uuid>"` `old_command` line when it clears — so `WazeAlertCache` **merges** query
+The RT `/command` endpoint is session-stateful, it sends each alert once, then a
+`"RmAlert,<uuid>"` `old_command` line when it clears, so `WazeAlertCache` **merges** query
 deltas (adds upsert, removals soft-delete for 5 min) instead of replacing the cache, which is
 what stops alerts from vanishing mid-drive. Each refresh queries a series of progressively
 smaller boxes (`GeoBoxes`, a shrinking-bbox scan) so the server doesn't thin out
@@ -147,7 +147,7 @@ Lane/road closures come from the per-district Caltrans Lane Closure System feeds
 (`https://cwwp2.dot.ca.gov/data/d<N>/lcs/lcsStatusD<NN>.xml`). `LcsSource` picks districts by
 bounding box around the requested location, streams the ~4 MB XML (never held in memory as a
 string), and keeps a parsed per-district cache (5-min TTL, 30-min max serve age) refreshed on
-a background thread — the HR request path only ever reads the cache. A closure is reported
+a background thread: the HR request path only ever reads the cache. A closure is reported
 only when it is physically in place: CHP code **1097** (established) set, **1098** (picked up)
 and **1022** (canceled) not set; shoulder-only closures are skipped, and closures spanning
 more than 2 km get a pin at both ends.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.9.6] - 2026-08-04
+
+### Added
+- **Better help when Highway Radar keeps using the old plugin.** Highway Radar remembers the plugin it first discovered, so after switching from wzsabre it can keep using the cached registration: it shows the old "WzSabre" name, and in some cases no alerts arrive at all. Restarting Highway Radar usually fixes it, but one user found that only clearing Highway Radar's cache did. The Share diagnostics report, the README and the website now spell out both steps, in order, and warn to use "Clear cache" and not "Clear storage", which would erase your Highway Radar settings.
+- **The privacy policy now has its own web page**, at https://nicglazkov.github.io/highway-radar-sabre-plus/privacy.html. The Privacy button in the app opens that instead of a Markdown file on GitHub, so it is readable on a phone.
+
+### Changed
+- Alert text and status lines now separate their parts with commas instead of a middle dot, so a wildfire reads "Wildfire: PARK FIRE, 1,200 ac, 40% contained".
+
 ## [1.9.5] - 2026-08-04
 
 ### Fixed

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,12 +1,12 @@
 # Privacy Policy
 
-_Last updated: 2026-07-12_
+_Last updated: 2026-08-04_
 
 SABRE Plus is a free, open-source Highway Radar plugin. It has **no servers, no accounts, and no analytics**, and it **collects no personal data**. Everything it does runs on your own device. This document explains, in plain terms, exactly what stays on your device, what leaves it, and what never happens.
 
 ## The short version
 
-- SABRE Plus does not have a backend. There is nothing for us to collect, because there is nowhere for your data to go that we control.
+- The app runs entirely on your phone. There is no server of ours for your data to reach.
 - We do not use analytics, crash-reporting services, advertising, or trackers of any kind.
 - We do not create accounts, assign user IDs, or read your device's advertising ID.
 - We do not store your location history, and we never sell or share data.
@@ -58,3 +58,6 @@ If this policy changes, the update will be committed to this file in the public 
 
 Questions or concerns: open an issue at
 https://github.com/nicglazkov/highway-radar-sabre-plus/issues
+
+This policy is also published as a web page at
+https://nicglazkov.github.io/highway-radar-sabre-plus/privacy.html

--- a/README.md
+++ b/README.md
@@ -135,12 +135,21 @@ If you already have wzsabre installed:
 - On Android 15: open this app first, then HR. The background service must be running before HR requests data.
 
 **CHP alerts visible but no Waze alerts**
-- Waze requires a real internet connection. On the very first use the plugin registers an anonymous Waze session in the background; Waze alerts can take ~10–20 seconds to appear that first time. After that the session and a live alert cache are kept warm and pre-loaded at start, so alerts appear within a second or two on subsequent sessions.
+- Waze requires a real internet connection. On the very first use the plugin registers an anonymous Waze session in the background; Waze alerts can take 10 to 20 seconds to appear that first time. After that the session and a live alert cache are kept warm and pre-loaded at start, so alerts appear within a second or two on subsequent sessions.
 - Check that the app has network permission (it should request none explicitly; all network access is in the background service).
 
-**No alerts at all**
-- Confirm HR is using the correct plugin: HR → Settings → SABRE → should show "SABRE Plus".
-- Check that no alert categories are all turned off in the app settings.
+**No alerts at all, or Highway Radar still shows "WzSabre"**
+
+Highway Radar remembers the plugin it discovered and keeps using that cached registration after you swap wzsabre for SABRE Plus. Work through these in order:
+
+1. Confirm HR is using the correct plugin: HR → Settings → SABRE → should show "SABRE Plus".
+2. Check that the alert categories are not all turned off in the app settings.
+3. Fully close and reopen Highway Radar (swipe it away from recents, then launch it again). This makes HR re-run plugin discovery.
+4. **If it still does not work, clear Highway Radar's cache:** Android **Settings → Apps → Highway Radar → Storage → Clear cache**, then open Highway Radar again. This drops the stale registration and forces a fresh discovery. Reported by a user as the step that finally worked.
+
+> ⚠️ Use **Clear cache**, not **Clear storage**. Clear storage would erase your Highway Radar settings.
+
+Tapping **Share diagnostics** in the SABRE Plus app tells you which of these applies: it reports whether HR has re-detected SABRE Plus or is still running off a cached registration.
 
 ---
 
@@ -154,8 +163,8 @@ The graph shows the full path from a Highway Radar request to alerts on its map.
 
 **Jump to the source for each step**
 
-- Plugin pipeline: [MainBroadcastReceiver](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java) · [ForegroundServiceStarter](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/ForegroundServiceStarter.java) · [SabreService](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/SabreService.java) · [SabreResponseBuilder](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java)
-- Sources: [CHP](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/CHPSource.java) · [Waze](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java) · [Caltrans LCS](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/LcsSource.java) · [Wildfires](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/WildfireSource.java) · [Chain controls](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/WinterSource.java)
+- Plugin pipeline: [MainBroadcastReceiver](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java) | [ForegroundServiceStarter](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/ForegroundServiceStarter.java) | [SabreService](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/SabreService.java) | [SabreResponseBuilder](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java)
+- Sources: [CHP](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/CHPSource.java) | [Waze](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java) | [Caltrans LCS](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/LcsSource.java) | [Wildfires](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/WildfireSource.java) | [Chain controls](https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/app/src/main/java/app/sabre/wzsabre/WinterSource.java)
 
 <details>
 <summary><b>Interactive version</b> (zoom and clickable nodes, on the GitHub website)</summary>
@@ -168,7 +177,7 @@ flowchart TD
     HR -- "2. REQUEST / FETCH_REQUEST<br/>lat, lon, radius" --> RCV
 
     RCV["MainBroadcastReceiver<br/>listens for wzsabre and<br/>legacy action names"]
-    RCV -. "handshake reply:<br/>id · 5 sources · action names" .-> HR
+    RCV -. "handshake reply:<br/>id, 5 sources, action names" .-> HR
     RCV -- "startForegroundService<br/>+ exact-alarm fallback" --> FSS
     FSS["ForegroundServiceStarter"] --> SVC
     SVC["SabreService<br/>foreground service,<br/>reloads settings each fetch"]
@@ -177,9 +186,9 @@ flowchart TD
         direction LR
         CHP["🚔 CHP Live Feed<br/>sa.xml statewide<br/>radius + age + category filter"]
         WAZE["🚗 Waze<br/>mobile RT protobuf<br/>register, login, query<br/>delta-merged cache"]
-        LCS["🚧 Caltrans LCS<br/>per-district closure XML<br/>code 1097 only · cached 15 min<br/>conditional GET"]
-        FIRE["🔥 Wildfires<br/>WFIGS active CA fires<br/>contained/stale filtered<br/>size filter · cached 5 min"]
-        CHAINS["❄️ Chain controls<br/>per-district CC XML<br/>R-1/R-2/R-3 · cached 5 min"]
+        LCS["🚧 Caltrans LCS<br/>per-district closure XML<br/>code 1097 only<br/>cached 15 min<br/>conditional GET"]
+        FIRE["🔥 Wildfires<br/>WFIGS active CA fires<br/>contained/stale filtered<br/>size filter<br/>cached 5 min"]
+        CHAINS["❄️ Chain controls<br/>per-district CC XML<br/>R-1/R-2/R-3<br/>cached 5 min"]
     end
 
     SVC --> CHP & WAZE & LCS & FIRE & CHAINS
@@ -233,7 +242,7 @@ Pull requests welcome. Run the test suite before submitting:
 
 ## Privacy
 
-SABRE Plus has no servers, no accounts, and no analytics, and collects no personal data. Everything runs on your device. It fetches road data from public feeds (CHP, Caltrans, wildfires) and from Waze; only the Waze feature sends your approximate location, over an anonymous session, so it can return nearby alerts. See the full [Privacy Policy](PRIVACY.md).
+SABRE Plus has no servers, no accounts, and no analytics, and collects no personal data. Everything runs on your device. It fetches road data from public feeds (CHP, Caltrans, wildfires) and from Waze; only the Waze feature sends your approximate location, over an anonymous session, so it can return nearby alerts. See the full [Privacy Policy](https://nicglazkov.github.io/highway-radar-sabre-plus/privacy.html).
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 25
-        versionName = "1.9.5"
+        versionCode = 26
+        versionName = "1.9.6"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -48,11 +48,11 @@ android {
             // Without this guard a first-time cloner running `assembleRelease` hits
             // a cryptic "Keystore file not set" failure; instead they get an unsigned
             // release APK plus the warning below. Maintainers keep a keystore.properties
-            // at the repo root (storeFile/storePassword/keyAlias/keyPassword) — see BUILDING.md.
+            // at the repo root (storeFile/storePassword/keyAlias/keyPassword), see BUILDING.md.
             if (keystorePropsFile.exists()) {
                 signingConfig = signingConfigs.getByName("release")
             } else {
-                logger.warn("keystore.properties not found — building an UNSIGNED release APK. " +
+                logger.warn("keystore.properties not found: building an UNSIGNED release APK. " +
                         "Add keystore.properties at the repo root to sign (see BUILDING.md).")
             }
         }

--- a/app/src/main/java/app/sabre/wzsabre/AlertDeduper.java
+++ b/app/src/main/java/app/sabre/wzsabre/AlertDeduper.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 /**
  * Collapses duplicate pins that DIFFERENT sources report for the same real-world
- * event — e.g. a CHP accident and a Waze accident at the same intersection, or a
+ * event: e.g. a CHP accident and a Waze accident at the same intersection, or a
  * CHP closure and a Caltrans LCS closure on the same segment.
  *
  * <p>Two alerts are duplicates when they come from different sources, share an alert

--- a/app/src/main/java/app/sabre/wzsabre/AlertMapper.java
+++ b/app/src/main/java/app/sabre/wzsabre/AlertMapper.java
@@ -88,7 +88,7 @@ public class AlertMapper {
         if (t.contains("SILVER") || t.contains("MISSING")) return null;
         if (t.contains("ESCORT")) return "HAZARD_ON_ROAD_SLIPPERY";
 
-        // Unknown — return as generic road hazard rather than drop it
+        // Unknown: return as generic road hazard rather than drop it
         return "HAZARD_ON_ROAD_DEBRIS";
     }
 
@@ -123,7 +123,7 @@ public class AlertMapper {
                         ? "POLICE_HIDDEN" : "POLICE_VISIBLE";
 
             case "CAMERA":
-                // Fixed/mobile speed & red-light cameras — flag for enforcement awareness.
+                // Fixed/mobile speed & red-light cameras, flag for enforcement awareness.
                 return "POLICE_HIDDEN";
 
             case "ACCIDENT":

--- a/app/src/main/java/app/sabre/wzsabre/AltStartupActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/AltStartupActivity.java
@@ -14,7 +14,7 @@ import android.util.Log;
  * Why this exists: on Android 15/16, starting a foreground service from a
  * background broadcast receiver is BFSL-restricted. But when HR launches this
  * activity, our app is momentarily in the foreground, so starting the service
- * here is always allowed — a reliable escape hatch that complements the
+ * here is always allowed: a reliable escape hatch that complements the
  * exact-alarm bypass in {@link ForegroundServiceStarter}.
  *
  * The activity starts the service, optionally bounces back to HR (if HR passed
@@ -27,13 +27,13 @@ public class AltStartupActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Log.d(TAG, "Launched — starting service from foreground");
+        Log.d(TAG, "Launched: starting service from foreground");
 
         ForegroundServiceStarter.start(this, null, null);
 
         // If HR told us how to return to it, do so (matches official 2.2 behaviour).
         // This activity is exported, so restrict the callback target to Highway Radar
-        // — otherwise any app could make us launch an arbitrary component (confused
+        //: otherwise any app could make us launch an arbitrary component (confused
         // deputy) with us as the attributed source.
         try {
             String cbApp  = getIntent().getStringExtra("callback_app");

--- a/app/src/main/java/app/sabre/wzsabre/BootReceiver.java
+++ b/app/src/main/java/app/sabre/wzsabre/BootReceiver.java
@@ -22,7 +22,7 @@ public class BootReceiver extends BroadcastReceiver {
         String action = intent.getAction();
         if (!Intent.ACTION_BOOT_COMPLETED.equals(action)
                 && !Intent.ACTION_MY_PACKAGE_REPLACED.equals(action)) return;
-        Log.d(TAG, action + " — starting SabreService");
+        Log.d(TAG, action + ": starting SabreService");
         // Both actions are exempt from BFSL, but route through the starter so the
         // exact-alarm / WorkManager fallbacks apply if the direct start is denied.
         ForegroundServiceStarter.start(context, null, null);

--- a/app/src/main/java/app/sabre/wzsabre/CHPSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/CHPSource.java
@@ -28,14 +28,14 @@ import javax.net.ssl.HttpsURLConnection;
  * and NEVER fetched on the Highway Radar request path. Earlier this was a blocking
  * network call: a slow/hung CHP fetch (the feed sits behind a flaky load balancer)
  * could occupy the shared fetch thread pool and starve Waze/LCS, and any single
- * failure returned zero CHP alerts for that cycle — so incidents flapped in and out
+ * failure returned zero CHP alerts for that cycle, so incidents flapped in and out
  * while driving through cell dead zones. Now {@link #fetchAlerts} returns the last
  * good parse instantly and a stale fetch only affects freshness, never availability.
  */
 public class CHPSource {
     private static final String TAG     = "CHPSource";
     private static final String CHP_URL = "https://media.chp.ca.gov/sa_xml/sa.xml";
-    // Background thread, so the timeouts don't gate the HR response — but still bounded
+    // Background thread, so the timeouts don't gate the HR response, but still bounded
     // so a hung fetch can't pin the refresh thread indefinitely.
     private static final int CONNECT_TIMEOUT_MS = 8_000;
     private static final int READ_TIMEOUT_MS    = 8_000;
@@ -113,7 +113,7 @@ public class CHPSource {
                     SourceStatus.success(SabreResponseBuilder.SOURCE_CHP,
                             cache == null ? 0 : cache.size());
                 } catch (Exception e) {
-                    // Keep serving the last good parse — a transient failure must not
+                    // Keep serving the last good parse, a transient failure must not
                     // blank CHP for the whole cycle.
                     Log.w(TAG, "CHP refresh failed (serving cache): "
                             + e.getClass().getSimpleName() + ": " + e.getMessage());
@@ -134,7 +134,7 @@ public class CHPSource {
         conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
         conn.setReadTimeout(READ_TIMEOUT_MS);
         conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Linux; Android 14)");
-        // Only send validators when we actually hold a cached parse — otherwise a 304
+        // Only send validators when we actually hold a cached parse, otherwise a 304
         // would leave us with nothing to serve.
         if (cache != null) {
             if (etag != null)         conn.setRequestProperty("If-None-Match", etag);
@@ -152,7 +152,7 @@ public class CHPSource {
                 while ((n = reader.read(buf)) != -1) sb.append(buf, 0, n);
             }
             List<Incident> parsed = parseAll(sb.toString());
-            // Commit the validators only after a successful read+parse — if the body
+            // Commit the validators only after a successful read+parse, if the body
             // read throws mid-stream, the old cache and its (still-matching) validators
             // stay in sync, so the next request re-fetches rather than 304-ing onto a
             // cache that was never updated.
@@ -225,7 +225,7 @@ public class CHPSource {
                 // high, leaving malformed XML at the end. Salvage every complete <Log>
                 // parsed so far instead of dropping all of them (which would yield zero
                 // alerts exactly when the roads are busiest).
-                Log.w(TAG, "CHP feed truncated mid-stream — salvaged " + incidents.size()
+                Log.w(TAG, "CHP feed truncated mid-stream, salvaged " + incidents.size()
                         + " complete records before the cut");
                 break;
             }

--- a/app/src/main/java/app/sabre/wzsabre/ChpConfig.java
+++ b/app/src/main/java/app/sabre/wzsabre/ChpConfig.java
@@ -126,7 +126,7 @@ public class ChpConfig {
     }
 
     // ── Factory methods ───────────────────────────────────────────────────────
-    /** All categories enabled, max age 60 min — for use in unit tests. */
+    /** All categories enabled, max age 60 min, for use in unit tests. */
     public static ChpConfig loadDefaults() {
         return new ChpConfig();
     }

--- a/app/src/main/java/app/sabre/wzsabre/CrashLog.java
+++ b/app/src/main/java/app/sabre/wzsabre/CrashLog.java
@@ -13,7 +13,7 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * Records the most recent uncaught exception to a private file so the settings
- * diagnostics panel can surface "last crash" — turns a vague "it crashed" report
+ * diagnostics panel can surface "last crash", turns a vague "it crashed" report
  * into something actionable. Stays entirely on-device; never transmitted.
  */
 public final class CrashLog {

--- a/app/src/main/java/app/sabre/wzsabre/DiagnosticsReport.java
+++ b/app/src/main/java/app/sabre/wzsabre/DiagnosticsReport.java
@@ -125,8 +125,12 @@ public final class DiagnosticsReport {
             sb.append("HR re-detected SABRE Plus (registration is current)\n");
         } else {
             sb.append("HR is using a cached registration from a previously-installed plugin "
-                    + "(it may still display an old name like \"WzSabre\"). Data still flows; "
-                    + "fully restart Highway Radar to refresh the name.\n");
+                    + "(it may still display an old name like \"WzSabre\"). Data still flows. "
+                    + "To refresh it: fully close and reopen Highway Radar. If that does not "
+                    + "work, or no alerts arrive at all, clear Highway Radar's cache in "
+                    + "Android Settings, Apps, Highway Radar, Storage, Clear cache. Use Clear "
+                    + "cache, NOT Clear storage: Clear storage would erase your Highway Radar "
+                    + "settings.\n");
         }
         sb.append("We advertise to HR: id=app.sabre.wzsabre, version=").append(BuildConfig.VERSION_NAME)
           .append(", request_action=app.sabre.wzsabre.REQUEST, sources=[chp,waze,lcs,fire,chains]\n");

--- a/app/src/main/java/app/sabre/wzsabre/ForegroundServiceStarter.java
+++ b/app/src/main/java/app/sabre/wzsabre/ForegroundServiceStarter.java
@@ -67,7 +67,7 @@ final class ForegroundServiceStarter {
             Log.d(TAG, "startForegroundService succeeded");
         } catch (Exception e) {
             Log.w(TAG, "startForegroundService denied (BFSL): " + e.getMessage()
-                    + " — trying exact-alarm bypass");
+                    + ": trying exact-alarm bypass");
             if (tryExactAlarm(context, intent)) {
                 Log.d(TAG, "Scheduled exact-alarm FGS start");
                 return;
@@ -88,7 +88,7 @@ final class ForegroundServiceStarter {
             AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
             if (am == null) return false;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !am.canScheduleExactAlarms()) {
-                Log.w(TAG, "Cannot schedule exact alarms — permission not granted");
+                Log.w(TAG, "Cannot schedule exact alarms, permission not granted");
                 return false;
             }
             // Vary the request code by the payload too: two FETCH_REQUESTs in quick

--- a/app/src/main/java/app/sabre/wzsabre/LcsSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/LcsSource.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.net.ssl.HttpsURLConnection;
 
 /**
- * Caltrans LCS (Lane Closure System) source — live lane and road closures from
+ * Caltrans LCS (Lane Closure System) source, live lane and road closures from
  * the per-district feeds at
  * {@code https://cwwp2.dot.ca.gov/data/d<N>/lcs/lcsStatusD<NN>.xml}.
  *
@@ -36,7 +36,7 @@ import javax.net.ssl.HttpsURLConnection;
 public class LcsSource {
     private static final String TAG = "LcsSource";
 
-    // Refresh cadence. These feeds are the app's largest network cost by far — the
+    // Refresh cadence. These feeds are the app's largest network cost by far, the
     // district XML is multi-megabyte (D7 measured at 15.7 MB on 2026-08-04) and CWWP
     // does not gzip it, so at the old 5-minute cadence a driver near several district
     // boundaries could pull well over 100 MB of cellular data per hour. An established
@@ -155,7 +155,7 @@ public class LcsSource {
                 if (parsed == null) {
                     // 304 Not Modified: the feed we already hold is still current, so
                     // just mark it fresh. This is the whole point of the conditional
-                    // GET — an unchanged multi-megabyte feed costs zero bytes.
+                    // GET: an unchanged multi-megabyte feed costs zero bytes.
                     CacheEntry held = cache.get(district);
                     if (held != null) {
                         cache.put(district, new CacheEntry(held.closures, System.currentTimeMillis()));
@@ -215,7 +215,7 @@ public class LcsSource {
     // ── Streaming XML parse ──────────────────────────────────────────────────
 
     /**
-     * Streaming parse — the feed is ~4 MB, so it is consumed directly from the
+     * Streaming parse: the feed is ~4 MB, so it is consumed directly from the
      * stream rather than read into a String. Field tag names in the schema are
      * globally unique (beginLatitude vs endLatitude etc.), so no section
      * tracking is needed; text accumulates per element like CHPSource.
@@ -277,7 +277,7 @@ public class LcsSource {
             try {
                 eventType = parser.next();
             } catch (Exception e) {
-                Log.w(TAG, "LCS feed parse error — salvaged " + out.size() + " records");
+                Log.w(TAG, "LCS feed parse error, salvaged " + out.size() + " records");
                 break;
             }
         }
@@ -309,7 +309,7 @@ public class LcsSource {
     }
 
     /**
-     * True when only shoulders/median are closed (no travel lane affected) —
+     * True when only shoulders/median are closed (no travel lane affected),
      * e.g. lanesClosed = "RShoulder". "3, RShoulder", "All", "Left HOV" and
      * turn-lane closures still count as lane closures.
      */
@@ -317,7 +317,7 @@ public class LcsSource {
         String l = c.lanesClosed;
         if (l == null || l.isEmpty()) return false;
         String lower = l.toLowerCase(Locale.US);
-        // "aux" (Auxiliary) is a travel lane — closing it is a real lane closure even
+        // "aux" (Auxiliary) is a travel lane, closing it is a real lane closure even
         // when the value carries no digit (e.g. "Median, LShoulder, Auxiliary").
         if (lower.contains("all") || lower.contains("hov") || lower.contains("turn")
                 || lower.contains("aux")) return false;
@@ -362,7 +362,7 @@ public class LcsSource {
         if (!c.locationName.isEmpty()) sb.append(" @ ").append(c.locationName);
         if (!c.nearbyPlace.isEmpty()) sb.append(" (").append(c.nearbyPlace).append(')');
         if (!c.lanesClosed.isEmpty() && !"Full".equalsIgnoreCase(c.typeOfClosure))
-            sb.append(" · lanes: ").append(c.lanesClosed);
+            sb.append(", lanes: ").append(c.lanesClosed);
         return sb.toString();
     }
 }

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
 /**
  * Settings screen for the CHP alert feed.
  *
- * Category rows are inflated programmatically — one per ChpCategory — so
+ * Category rows are inflated programmatically, one per ChpCategory, so
  * adding a new category requires no layout changes.
  *
  * All changes are saved to SharedPreferences immediately (no "Save" button
@@ -82,7 +82,7 @@ public class MainActivity extends Activity {
             try {
                 startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
             } catch (Exception e) {
-                // No browser / template unavailable — fall back to the issues list.
+                // No browser / template unavailable, fall back to the issues list.
                 try {
                     startActivity(new Intent(Intent.ACTION_VIEW,
                             Uri.parse("https://github.com/nicglazkov/highway-radar-sabre-plus/issues")));
@@ -93,12 +93,12 @@ public class MainActivity extends Activity {
 
     /**
      * "Privacy" shows a plain-language summary of what the app does and does not do
-     * with data, entirely on-device, plus a link to the full PRIVACY.md policy.
-     * ACTION_VIEW needs no permission. Kept in sync with PRIVACY.md.
+     * with data, entirely on-device, plus a link to the full privacy policy.
+     * ACTION_VIEW needs no permission. Kept in sync with PRIVACY.md and docs/privacy.html.
      */
     private void buildPrivacyButton() {
         final String policyUrl =
-                "https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/PRIVACY.md";
+                "https://nicglazkov.github.io/highway-radar-sabre-plus/privacy.html";
         String summary =
             "SABRE Plus has no servers and no accounts, and collects no personal data. "
           + "Everything runs on your device.\n\n"
@@ -284,7 +284,7 @@ public class MainActivity extends Activity {
             container.addView(row);
         }
 
-        // Last crash (if any) — tap to clear.
+        // Last crash (if any): tap to clear.
         String[] crash = CrashLog.readSummary(this);
         if (crash != null) {
             TextView cr = new TextView(this);
@@ -311,9 +311,9 @@ public class MainActivity extends Activity {
     private static String formatStatus(String label, SourceStatus.Entry e) {
         if (e == null || !e.ran) return label + ": not fetched yet";
         StringBuilder sb = new StringBuilder(label).append(": ");
-        if (e.lastUpdateMs > 0) sb.append(e.count).append(" · ").append(ago(e.lastUpdateMs));
+        if (e.lastUpdateMs > 0) sb.append(e.count).append(", ").append(ago(e.lastUpdateMs));
         else sb.append("no data yet");
-        if (e.lastError != null) sb.append(" · error: ").append(e.lastError);
+        if (e.lastError != null) sb.append(", error: ").append(e.lastError);
         return sb.toString();
     }
 
@@ -386,7 +386,7 @@ public class MainActivity extends Activity {
 
     private void updateServiceStatus() {
         TextView tv = findViewById(R.id.serviceStatus);
-        tv.setText("Plugin ready · runs while Highway Radar is open");
+        tv.setText("Plugin ready, runs while Highway Radar is open");
     }
 
     // ── Category rows ─────────────────────────────────────────────────────────
@@ -425,7 +425,7 @@ public class MainActivity extends Activity {
             typeRow.setVisibility(enabled ? View.VISIBLE : View.GONE);
             setRowAlpha(row, enabled);
 
-            // Switch listener — save immediately
+            // Switch listener: save immediately
             sw.setOnCheckedChangeListener((CompoundButton btn, boolean isChecked) -> {
                 config.setEnabled(cat, isChecked);
                 config.save(this);
@@ -433,7 +433,7 @@ public class MainActivity extends Activity {
                 setRowAlpha(row, isChecked);
             });
 
-            // Spinner listener — save immediately
+            // Spinner listener: save immediately
             typeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                 @Override
                 public void onItemSelected(AdapterView<?> parent, View view, int pos, long id) {

--- a/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
@@ -31,7 +31,7 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
                 // to the service so it stops after a short grace period; a new session
                 // within the window cancels the stop. If the service isn't running
                 // there's nothing to shut down, so we don't start it just to stop it.
-                Log.d(TAG, "Shutdown received — forwarding to service");
+                Log.d(TAG, "Shutdown received: forwarding to service");
                 if (SabreService.RUNNING) {
                     try {
                         context.startService(new Intent(context, SabreService.class)
@@ -60,7 +60,7 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
 
     /**
      * Reads a numeric extra regardless of how it was typed: adb's --ef sends a
-     * Float, --ed a Double — getDoubleExtra() silently returns the default for a
+     * Float, --ed a Double. getDoubleExtra() silently returns the default for a
      * Float extra, which made the documented --ef test commands no-ops.
      */
     private static double numberExtra(Intent intent, String key, double dflt) {
@@ -85,7 +85,7 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
         if (responseAction == null)
             responseAction = intent.getStringExtra("response_action");
         if (responseAction == null) {
-            Log.e(TAG, "No response_action in handshake — cannot respond");
+            Log.e(TAG, "No response_action in handshake, cannot respond");
             return;
         }
         String pkg = context.getPackageName();

--- a/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreResponseBuilder.java
@@ -29,8 +29,8 @@ public class SabreResponseBuilder {
 
     /**
      * Highway Radar's package. Every reply broadcast is explicitly targeted at it
-     * (Intent.setPackage) so the alert payload — a list of alerts centered on the
-     * driver's location — is delivered only to HR and cannot be harvested by any
+     * (Intent.setPackage) so the alert payload, a list of alerts centered on the
+     * driver's location, is delivered only to HR and cannot be harvested by any
      * other app that registers a receiver for the (publicly known) response action.
      */
     public static final String HR_PACKAGE = "com.highwayradar.app";
@@ -45,14 +45,14 @@ public class SabreResponseBuilder {
      */
     public static final double HEADING_UNKNOWN = -720.0;
 
-    /** Max alerts per response batch — matches the official wzsabre (200). */
+    /** Max alerts per response batch, matches the official wzsabre (200). */
     public static final int MAX_ALERTS_PER_BATCH = 200;
 
     /**
      * Alert type strings HR's renderer accepts. This is the union of (a) the
      * canonical SABRE types our CHP/LCS sources emit and (b) the full Waze alert
      * type + subtype vocabulary, which the official wzsabre passes through raw to
-     * the same HR app — so HR is known to handle every string here. An alert whose
+     * the same HR app, so HR is known to handle every string here. An alert whose
      * type is outside this set can only be a bug in our own mapping, so {@link
      * #build} drops it rather than risk HR's renderer on an unexpected string.
      *
@@ -115,7 +115,7 @@ public class SabreResponseBuilder {
      * <pre>
      * {
      *   "request_id": String,        // required, non-null
-     *   "error_message": null,       // nullable String — present but null
+     *   "error_message": null,       // nullable String: present but null
      *   "response": {
      *     "n_batches": Int,           // required
      *     "batch_id":  Int,           // required
@@ -127,9 +127,9 @@ public class SabreResponseBuilder {
      *         "lat":           Double,   // required
      *         "lon":           Double,   // required
      *         "heading_deg":   Double,   // required
-     *         "street_name":   String?,  // nullable String — present (may be null)
+     *         "street_name":   String?,  // nullable String: present (may be null)
      *         "report_ts":     Int,      // required; must fit in Int (not Long)
-     *         "confirm_ts":    Int?      // nullable Int — present (may be null)
+     *         "confirm_ts":    Int?      // nullable Int: present (may be null)
      *       }                            // NB: no user_id / confirm_count (HR dropped them; strict parser rejects extras)
      *     ]
      *   }
@@ -159,14 +159,14 @@ public class SabreResponseBuilder {
         List<SabreAlert> alerts = batchAlerts;
 
         // One malformed alert must never take down the whole response (HR would
-        // get nothing and show "plugin not responding") — drop it and keep the rest.
+        // get nothing and show "plugin not responding"), drop it and keep the rest.
         JSONArray alertsArray = new JSONArray();
         for (SabreAlert a : alerts) {
             if (a == null || !isValidType(a.type)) continue;
             try {
                 alertsArray.put(buildAlert(a));
             } catch (RuntimeException | JSONException ignored) {
-                // invalid coords / report_ts / NaN heading — skip this alert only.
+                // invalid coords / report_ts / NaN heading, skip this alert only.
                 // JSONException is caught too: JSONObject.put(double) throws it (a
                 // checked exception, not a RuntimeException) on a NaN/Infinite value.
             }

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -28,12 +28,12 @@ public class SabreService extends Service {
     private static final int NOTIFICATION_ID = 1;
 
     // Update-check (sideloaded app, no Play auto-update): at most once/day, and a
-    // notification at most once per new version — deliberately not spammy.
+    // notification at most once per new version, deliberately not spammy.
     private static final String UPDATE_CHANNEL_ID = "SabreUpdateChannel";
     private static final int    UPDATE_NOTIFICATION_ID = 2;
     private static final long   UPDATE_CHECK_INTERVAL_MS = 24 * 3600_000L;
 
-    /** Live while the service exists — lets MainBroadcastReceiver decide whether a
+    /** Live while the service exists, lets MainBroadcastReceiver decide whether a
      *  SHUTDOWN needs forwarding (no point starting the service just to stop it). */
     static volatile boolean RUNNING = false;
 
@@ -47,7 +47,7 @@ public class SabreService extends Service {
     private static final long SHUTDOWN_GRACE_MS = 20_000L;      // HR said bye; brief wait for a re-open
     private final Handler lifecycleHandler = new Handler(Looper.getMainLooper());
     private final Runnable stopRunnable = () -> {
-        Log.d(TAG, "Highway Radar idle/closed — stopping service");
+        Log.d(TAG, "Highway Radar idle/closed, stopping service");
         RUNNING = false;   // stop accepting SHUTDOWN forwards that would resurrect us
         stopForeground(STOP_FOREGROUND_REMOVE);
         stopSelf();
@@ -86,11 +86,11 @@ public class SabreService extends Service {
         wazeSource = new app.sabre.wzsabre.waze.WazeProtocolSource(this);
         createNotificationChannel();
         startForeground(NOTIFICATION_ID, buildForegroundNotification());
-        chpSource.prewarm();          // statewide feed — no location needed
-        // Only warm wildfires if the source is enabled — otherwise it's a wasted
+        chpSource.prewarm();          // statewide feed: no location needed
+        // Only warm wildfires if the source is enabled, otherwise it's a wasted
         // network fetch on every service start for a disabled source.
         if (ChpConfig.load(this).fireEnabled) fireSource.prewarm();
-        prewarmFromLastLocation();    // Waze — needs last known location
+        prewarmFromLastLocation();    // Waze: needs last known location
         maybeCheckForUpdate();        // throttled; notifies once per new version
         armIdleStop();                // stop if no HR activity arrives
         Log.d(TAG, "Service started");
@@ -174,16 +174,16 @@ public class SabreService extends Service {
         String action = intent != null ? intent.getStringExtra("action") : null;
 
         // HR is ending the session. Wait a short grace period in case it immediately
-        // opens a new one (its normal behaviour), then stop — a fresh FETCH/handshake
+        // opens a new one (its normal behaviour), then stop, a fresh FETCH/handshake
         // within the window re-arms the idle timer and cancels this stop.
         if (action != null && action.contains("SHUTDOWN")) {
-            Log.d(TAG, "SHUTDOWN received — stopping after grace period");
+            Log.d(TAG, "SHUTDOWN received, stopping after grace period");
             scheduleStop(SHUTDOWN_GRACE_MS);
             return START_STICKY;
         }
 
         // Any other start (fetch, handshake pre-warm, boot, or a system restart with
-        // a null intent) means HR still wants us — cancel any pending stop and
+        // a null intent) means HR still wants us, cancel any pending stop and
         // re-arm the idle watchdog.
         armIdleStop();
         if (action != null && action.contains("FETCH_REQUEST")) {
@@ -200,7 +200,7 @@ public class SabreService extends Service {
     // ANR-killed. Both overloads exist across API 34 (int) and 35 (int,int).
     @Override
     public void onTimeout(int startId) {
-        Log.w(TAG, "FGS onTimeout — stopping cleanly");
+        Log.w(TAG, "FGS onTimeout, stopping cleanly");
         RUNNING = false;
         lifecycleHandler.removeCallbacks(stopRunnable);
         stopForeground(STOP_FOREGROUND_REMOVE);
@@ -235,7 +235,7 @@ public class SabreService extends Service {
         DebugLog.fetchReceived();
         requestExecutor.submit(() -> {
             // Parsed up front so the catch block can still answer HR with an error
-            // response — an unanswered request makes HR show "plugin not responding".
+            // response: an unanswered request makes HR show "plugin not responding".
             String requestId = null, responseAction = null;
             try {
                 JSONObject req = new JSONObject(data);
@@ -384,7 +384,7 @@ public class SabreService extends Service {
     /**
      * One synthetic alert of each SABRE type, lined up ~120m north of (lat,lon) and
      * spread east-west, so driving north makes Highway Radar pop them all as stacked
-     * cards — used to visually confirm HR renders every alert type correctly.
+     * cards: used to visually confirm HR renders every alert type correctly.
      */
     private List<SabreAlert> buildTestAlerts(double lat, double lon) {
         String[][] specs = {
@@ -415,7 +415,7 @@ public class SabreService extends Service {
     private void sendFetchResponse(String responseAction, String requestId,
                                     List<SabreAlert> alerts) throws JSONException {
         // Split into batches of MAX_ALERTS_PER_BATCH, each its own broadcast, with
-        // n_batches/batch_id set — mirrors the official wzsabre. Always ≥1 batch
+        // n_batches/batch_id set: mirrors the official wzsabre. Always ≥1 batch
         // (an empty list still sends one empty batch so HR sees a response).
         int n = alerts.size();
         int batchSize = SabreResponseBuilder.MAX_ALERTS_PER_BATCH;
@@ -431,7 +431,7 @@ public class SabreService extends Service {
             sendBroadcast(intent);
             Log.d(TAG, "Response batch " + (i + 1) + "/" + nBatches + " sent to: " + responseAction);
             // The full payload (driver-centered alert list) is only logged in debug
-            // builds — it's noise and a minor privacy leak into bugreports otherwise.
+            // builds: it's noise and a minor privacy leak into bugreports otherwise.
             if (BuildConfig.DEBUG) Log.d(TAG, "Response JSON: " + responseJson);
         }
     }
@@ -456,7 +456,7 @@ public class SabreService extends Service {
          .setContentTitle("SABRE Plus")
          .setContentText("Providing CHP, Waze, and Caltrans road alerts to Highway Radar")
          .setVisibility(Notification.VISIBILITY_PUBLIC);
-        // setForegroundServiceBehavior is API 31 (S), not Q — guarding at Q threw
+        // setForegroundServiceBehavior is API 31 (S), not Q, guarding at Q threw
         // NoSuchMethodError on Android 10/11, killing the service on those devices.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
             b.setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE);

--- a/app/src/main/java/app/sabre/wzsabre/SourceStatus.java
+++ b/app/src/main/java/app/sabre/wzsabre/SourceStatus.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * screen can show a diagnostics panel (last update, item count, last error) even
  * though the sources live inside {@link SabreService}. Both run in the same
  * process, so a static map is sufficient; state is lost on process death, which
- * is fine — it reflects the current session.
+ * is fine: it reflects the current session.
  *
  * <p>Each {@link Entry} is immutable and swapped in atomically, so a reader always
  * sees a self-consistent snapshot (never, say, a fresh count next to a stale error).

--- a/app/src/main/java/app/sabre/wzsabre/UpdateChecker.java
+++ b/app/src/main/java/app/sabre/wzsabre/UpdateChecker.java
@@ -11,7 +11,7 @@ import javax.net.ssl.HttpsURLConnection;
 /**
  * Checks GitHub Releases for a newer version. Since the app is sideloaded (no Play
  * Store auto-update), this powers both the in-app "update available" card and a
- * once-per-version notification. No auth needed — the public releases endpoint is
+ * once-per-version notification. No auth needed: the public releases endpoint is
  * used within GitHub's unauthenticated rate limit.
  */
 public final class UpdateChecker {
@@ -31,7 +31,7 @@ public final class UpdateChecker {
         }
     }
 
-    /** Blocking network call — returns null on any failure. Must run off the main thread. */
+    /** Blocking network call: returns null on any failure. Must run off the main thread. */
     public static Result fetchLatest() {
         HttpsURLConnection conn = null;
         try {

--- a/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/WildfireSource.java
@@ -20,12 +20,12 @@ import javax.net.ssl.HttpsURLConnection;
 /**
  * Active California wildfires, from the interagency WFIGS "Current Wildland Fire
  * Incident Locations" ArcGIS feature service (hosted by NIFC). Each fire is a point
- * (point of origin) with name, size, and containment — shown as a road hazard so a
+ * (point of origin) with name, size, and containment, shown as a road hazard so a
  * driver gets a heads-up that there's an active fire near the route.
  *
  * <p>Like the CHP and LCS sources, this is served from a background-refreshed cache
  * and never fetched on the Highway Radar request path. The CAL FIRE incidents feed
- * is Akamai-blocked to non-browser clients, so WFIGS is used instead — it is the
+ * is Akamai-blocked to non-browser clients, so WFIGS is used instead, it is the
  * authoritative interagency source and is openly queryable.
  *
  * <p>NOTE: a fire's point is its origin, not a precise road hazard; a large fire may
@@ -123,7 +123,7 @@ public class WildfireSource {
      * non-incident records. Observed live on 2026-08-04: 9 of 91 "active" California
      * records were noise, including a 69,352-acre fire 100% contained 16 days earlier.
      *
-     * <p>The rules stay deliberately conservative — a fire that is still burning must
+     * <p>The rules stay deliberately conservative, a fire that is still burning must
      * never be dropped. Age alone is not disqualifying, because large fires legitimately
      * burn for months (the 2024 Park Fire took 64 days to reach containment).
      */
@@ -212,9 +212,9 @@ public class WildfireSource {
             throw new Exception("WFIGS query error: " + root.optJSONObject("error"));
         }
         if (root.optBoolean("exceededTransferLimit", false)) {
-            // Server capped the result set — we'd be silently dropping fires. Very
+            // Server capped the result set, we'd be silently dropping fires. Very
             // unlikely for active CA wildfires, but log it rather than hide it.
-            Log.w(TAG, "WFIGS response hit the record cap — some fires may be omitted");
+            Log.w(TAG, "WFIGS response hit the record cap, some fires may be omitted");
         }
         JSONArray features = root.optJSONArray("features");
         if (features == null) return out;
@@ -263,8 +263,8 @@ public class WildfireSource {
     static String describe(Fire f) {
         StringBuilder sb = new StringBuilder("Wildfire");
         if (!f.name.isEmpty()) sb.append(": ").append(f.name);
-        if (f.sizeAcres >= 0) sb.append(" · ").append(formatAcres(f.sizeAcres)).append(" ac");
-        if (f.pctContained >= 0) sb.append(" · ").append((int) Math.round(f.pctContained)).append("% contained");
+        if (f.sizeAcres >= 0) sb.append(", ").append(formatAcres(f.sizeAcres)).append(" ac");
+        if (f.pctContained >= 0) sb.append(", ").append((int) Math.round(f.pctContained)).append("% contained");
         return sb.toString();
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/WinterSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/WinterSource.java
@@ -24,7 +24,7 @@ import javax.net.ssl.HttpsURLConnection;
 
 /**
  * Caltrans chain-control (winter) requirements, from the per-district feeds at
- * {@code https://cwwp2.dot.ca.gov/data/d<N>/cc/ccStatusD<NN>.xml} — the same CWWP
+ * {@code https://cwwp2.dot.ca.gov/data/d<N>/cc/ccStatusD<NN>.xml}: the same CWWP
  * portal and per-district shape as {@link LcsSource}, so district selection and the
  * async-cache pattern are shared.
  *
@@ -230,7 +230,7 @@ public class WinterSource {
             try {
                 eventType = parser.next();
             } catch (Exception e) {
-                Log.w(TAG, "chain-control feed parse error — salvaged " + out.size() + " records");
+                Log.w(TAG, "chain-control feed parse error, salvaged " + out.size() + " records");
                 break;
             }
         }
@@ -261,7 +261,7 @@ public class WinterSource {
 
     static String describe(ChainControl c) {
         StringBuilder sb = new StringBuilder("Chains ").append(c.status);
-        if (!c.route.isEmpty()) sb.append(" · ").append(c.route);
+        if (!c.route.isEmpty()) sb.append(", ").append(c.route);
         if (!c.locationName.isEmpty()) sb.append(" @ ").append(c.locationName);
         if (!c.nearbyPlace.isEmpty()) sb.append(" (").append(c.nearbyPlace).append(')');
         return sb.toString();

--- a/app/src/main/java/app/sabre/wzsabre/waze/AlertQueryResult.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/AlertQueryResult.java
@@ -7,8 +7,8 @@ import java.util.List;
  * AddAlertAction elements) and the uuids it removed (as "RmAlert," old_command
  * lines). Mirrors wzsabre 2.2 wazemo.AlertQueryResult.
  *
- * The RT /command endpoint is session-stateful — it only sends an alert once per
- * session, then a removal when it clears — so callers must MERGE these deltas into
+ * The RT /command endpoint is session-stateful, it only sends an alert once per
+ * session, then a removal when it clears, so callers must MERGE these deltas into
  * a persistent cache rather than treat each result as a full snapshot. See
  * {@link WazeAlertCache}.
  */

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeAlertCache.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeAlertCache.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Persistent uuid-keyed alert cache with soft-delete — ported verbatim from the
+ * Persistent uuid-keyed alert cache with soft-delete, ported verbatim from the
  * official wzsabre 2.2 {@code WazeAlertFetcher} (alertCache + softDeleted +
  * submitAlerts + purgeExpiredSoftDeletes + isSoftDeleteExpired + return filter).
  *

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java
@@ -24,8 +24,8 @@ import app.sabre.wzsabre.SourceStatus;
  * approach Waze now blocks with HTTP 403). Mints an anonymous Waze account, logs
  * in, and queries crowd-sourced alerts.
  *
- * <p>Because an RT query long-polls (up to ~10.5s) — longer than HR's response
- * budget — fetches are served from a cache that is refreshed asynchronously in the
+ * <p>Because an RT query long-polls (up to ~10.5s): longer than HR's response
+ * budget: fetches are served from a cache that is refreshed asynchronously in the
  * background. The first HR request after a cold start returns no Waze data; once
  * the background refresh completes (~10s) every subsequent request is served
  * instantly from the warm cache. {@link #prewarm} kicks that refresh off at
@@ -33,7 +33,7 @@ import app.sabre.wzsabre.SourceStatus;
  *
  * <p>The RT {@code /command} endpoint is session-stateful (each alert is sent once
  * per session, then a "RmAlert," removal when it clears), so query results are
- * MERGED into a persistent {@link WazeAlertCache} rather than replacing it — see
+ * MERGED into a persistent {@link WazeAlertCache} rather than replacing it, see
  * that class for why the previous replace-each-time behaviour lost alerts mid-drive.
  *
  * <p>The account credentials + device fingerprint are persisted and the live
@@ -48,13 +48,13 @@ public final class WazeProtocolSource {
     private static final double REFRESH_MOVE_KM   = 4.0;      // ...or if the center moved this far
     private static final double CACHE_DISCARD_KM  = 25.0;     // don't serve (or keep) a cache from far away
     // Don't serve a cache that hasn't been refreshable for this long (e.g. network
-    // outage / Waze down) — stale police/accident alerts presented as current are
+    // outage / Waze down): stale police/accident alerts presented as current are
     // worse than no Waze data.
     private static final long   CACHE_MAX_SERVE_AGE_MS = 10 * 60_000L;
 
     // Zoom levels queried per refresh (WazeAlertFetcher default maxSteps=5) and the
     // total wall-clock budget for the box loop (mirrors the official's per-slot
-    // withTimeout of ~10s — whatever boxes complete in time are merged, the rest
+    // withTimeout of ~10s: whatever boxes complete in time are merged, the rest
     // wait for the next refresh).
     private static final int  SHRINK_STEPS    = 5;
     private static final long QUERY_BUDGET_MS = 10_000L;
@@ -87,7 +87,7 @@ public final class WazeProtocolSource {
     // triggerRefreshIfStale, so it must be volatile (and a plain long can tear on 32-bit).
     private int           consecutiveRejections = 0;
     private volatile long backoffUntilMs        = 0L;
-    // The community last written to prefs — avoids rewriting identical credentials
+    // The community last written to prefs, avoids rewriting identical credentials
     // on every ~12s refresh.
     private String persistedCommunity = null;
 
@@ -135,7 +135,7 @@ public final class WazeProtocolSource {
 
     private void triggerRefreshIfStale(double lat, double lon, double radiusMeters) {
         long now = SystemClock.elapsedRealtime();
-        if (now < backoffUntilMs) return;   // in rejection backoff — don't hammer Waze
+        if (now < backoffUntilMs) return;   // in rejection backoff: don't hammer Waze
         boolean moved = cacheTimeMs != 0 && haversineKm(lat, lon, cacheLat, cacheLon) > REFRESH_MOVE_KM;
         boolean stale = cacheTimeMs == 0 || (now - cacheTimeMs) > CACHE_TTL_MS || moved;
         if (stale && refreshing.compareAndSet(false, true)) {
@@ -174,11 +174,11 @@ public final class WazeProtocolSource {
         } catch (WazeExceptions.AccountRejectedException e) {
             handleAccountRejected(e, lat, lon, radiusMeters);
         } catch (WazeExceptions.SessionExpiredException e) {
-            Log.w(TAG, "Session expired — re-logging in: " + e.getMessage());
+            Log.w(TAG, "Session expired: re-logging in: " + e.getMessage());
             if (session != null) session.invalidateSession();   // keep creds, just re-login
             queryArea(ensureSession(lat, lon), lat, lon, radiusMeters);
         }
-        // Reached only on a fully successful refresh — clear any rejection backoff.
+        // Reached only on a fully successful refresh, clear any rejection backoff.
         consecutiveRejections = 0;
         backoffUntilMs = 0L;
         SourceStatus.success(SabreResponseBuilder.SOURCE_WAZE, alertCache.size());
@@ -189,7 +189,7 @@ public final class WazeProtocolSource {
 
     /**
      * Recover from a rejected account. Backs off before the next refresh regardless,
-     * and only mints a replacement account while under the per-day cap — so a
+     * and only mints a replacement account while under the per-day cap, so a
      * persistent rejection can't burn the anonymous-account quota. Once the cap or
      * the consecutive-rejection ceiling is hit, gives up this cycle (cache unchanged)
      * and lets the growing backoff throttle retries.
@@ -197,18 +197,18 @@ public final class WazeProtocolSource {
     private void handleAccountRejected(Exception e, double lat, double lon, double radiusMeters)
             throws Exception {
         // Once the 24h registration window rolls over, forgive the consecutive-rejection
-        // ceiling — otherwise a run of rejections could lock Waze out for the rest of
+        // ceiling: otherwise a run of rejections could lock Waze out for the rest of
         // the service's life even after the daily cap has reset.
         if (regWindowRolledOver()) consecutiveRejections = 0;
         consecutiveRejections++;
         setBackoff();
         if (!canRegisterToday() || consecutiveRejections > WazeConstants.MAX_CONSECUTIVE_REJECTIONS) {
             Log.w(TAG, "Account rejected; registration cap/limit reached (" + consecutiveRejections
-                    + " consecutive) — backing off without re-registering: " + e.getMessage());
+                    + " consecutive): backing off without re-registering: " + e.getMessage());
             DebugLog.event("waze: rejected, cap reached (" + consecutiveRejections + " consecutive)");
             throw e;
         }
-        Log.w(TAG, "Account rejected — re-registering (attempt " + consecutiveRejections + "): "
+        Log.w(TAG, "Account rejected: re-registering (attempt " + consecutiveRejections + "): "
                 + e.getMessage());
         DebugLog.event("waze: rejected, re-registering (attempt " + consecutiveRejections + ")");
         session = null;
@@ -257,7 +257,7 @@ public final class WazeProtocolSource {
     private void queryArea(WazeSession s, double lat, double lon, double radiusMeters) throws Exception {
         long sessionBefore = s.currentServerSessionId();
         s.prepareForArea(lat, lon);
-        // Credentials exist now (register/login just ran) — persist immediately so a
+        // Credentials exist now (register/login just ran), persist immediately so a
         // failure in the box loop below can't lose a freshly minted account and force
         // a wasteful re-register on the next run. Only write when they actually changed.
         WazeCredentials creds = s.getCredentials();
@@ -269,7 +269,7 @@ public final class WazeProtocolSource {
         // sends no RmAlert for alerts that cleared while we were logged out, so the
         // stale cache must be dropped to avoid ghosts in Highway Radar. Defer that
         // clear until the FIRST box query succeeds: if the box loop fails right after
-        // a re-login (cell dead zone — exactly when re-logins happen), we keep serving
+        // a re-login (cell dead zone, exactly when re-logins happen), we keep serving
         // the old cache instead of blanking Waze for up to CACHE_MAX_SERVE_AGE_MS.
         boolean sessionChanged = s.currentServerSessionId() != sessionBefore;
         boolean cleared = false;
@@ -355,7 +355,7 @@ public final class WazeProtocolSource {
                 .apply();
     }
 
-    /** Clear only the credential/device keys — the registration-rate counter
+    /** Clear only the credential/device keys, the registration-rate counter
      *  (reg_count / reg_window_start) must survive so the per-day cap still holds. */
     private void clearPersisted() {
         ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java
@@ -134,7 +134,7 @@ final class WazeRtCodec {
     /**
      * Extracts removed-alert uuids from a batch. The RT server signals a cleared
      * alert with an {@code old_command} line of the form {@code "RmAlert,<uuid>"}
-     * (NOT a RemoveAlertAction message — verified in wzsabre 2.2
+     * (NOT a RemoveAlertAction message: verified in wzsabre 2.2
      * WazeProto.parseRemovedAlertIds). Strip the prefix and trim to get the uuid.
      */
     static List<String> parseRemovedAlertIds(WazeProto.Batch batch) {

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
@@ -12,12 +12,12 @@ import java.util.Map;
 /**
  * One Waze "RT" protocol session: mints an anonymous account (register), logs in,
  * and runs alert queries. Single-slot, synchronous (runs on the caller's worker
- * thread). Ported from wzsabre 2.2 wazemo.WazeSession (fetch path only — no
+ * thread). Ported from wzsabre 2.2 wazemo.WazeSession (fetch path only: no
  * reporting/keepalive/pooling).
  *
  * No backend or pre-shared credentials are needed: register() asks Waze itself for
  * a fresh username/password. Credentials + device can be injected (persisted across
- * runs) so we don't re-register on every fetch — Waze caps anonymous accounts per day.
+ * runs) so we don't re-register on every fetch, Waze caps anonymous accounts per day.
  */
 final class WazeSession {
     private static final String TAG = "WazeRT";
@@ -45,7 +45,7 @@ final class WazeSession {
     WazeCredentials getCredentials() { return credentials; }
     DeviceIdentity  getDevice()      { return device; }
 
-    /** Server session id (0 if not logged in) — lets the caller detect a re-login. */
+    /** Server session id (0 if not logged in), lets the caller detect a re-login. */
     long currentServerSessionId() { return session != null ? session.serverSessionId : 0L; }
 
     /** Drop the logged-in session but KEEP credentials, so the next call re-logs in
@@ -56,7 +56,7 @@ final class WazeSession {
      * Inspect a parsed response batch for in-band errors the server returns with an
      * HTTP 200: a {@code ServerError} element, or a {@code LoginError}. Without this,
      * a server that invalidates the session but replies 200 looks like success and
-     * the session zombies — {@code lastRequestMs} keeps updating so it never idles
+     * the session zombies: {@code lastRequestMs} keeps updating so it never idles
      * out, and no alerts are ever merged again. Mirrors the official's checkErrors.
      */
     static void checkErrors(WazeProto.Batch batch)
@@ -78,7 +78,7 @@ final class WazeSession {
                 if (code >= 500)
                     throw new WazeExceptions.WazeOperationException(
                             "server error " + code + ": " + err.getDescription());
-                // Informational / unknown (incl. the proto default code 0) — the
+                // Informational / unknown (incl. the proto default code 0), the
                 // official ignores these; a normal 200 batch can legitimately carry
                 // one, so do NOT fail the whole refresh over it.
                 Log.w(TAG, "Ignoring non-fatal server error " + code + ": " + err.getDescription());
@@ -89,7 +89,7 @@ final class WazeSession {
 
     /**
      * Map a Waze auth-error type to an exception. Transient server-side problems
-     * (INTERNAL_ISSUES / UNKNOWN) are operational — they must NOT nuke a good account
+     * (INTERNAL_ISSUES / UNKNOWN) are operational, they must NOT nuke a good account
      * by triggering a re-register; only genuine credential/authorization failures do.
      */
     private static void throwForLoginError(WazeProto.LoginError.AuthErrorType t)
@@ -160,7 +160,7 @@ final class WazeSession {
         WazeHttpClient.HttpResult r = http.post(url(WazeConstants.PATH_LOGIN),
                 body.getBytes(StandardCharsets.UTF_8), headers);
         // A 4xx here means Waze no longer accepts these credentials (anonymous
-        // accounts get purged) — classify as AccountRejected so the caller clears
+        // accounts get purged): classify as AccountRejected so the caller clears
         // the persisted account and re-registers instead of failing forever.
         if (r.code >= 400 && r.code < 500)
             throw new WazeExceptions.AccountRejectedException("login HTTP " + r.code);
@@ -171,7 +171,7 @@ final class WazeSession {
         checkErrors(batch);   // in-band LoginError → specific exception, not blanket reject
         for (WazeProto.Element el : batch.getElementList()) {
             // A login failure can arrive nested in the LoginResponse oneof (not just
-            // as a top-level LoginError element) — classify it too, so a transient
+            // as a top-level LoginError element), classify it too, so a transient
             // INTERNAL_ISSUES doesn't fall through to the blanket AccountRejected
             // below and needlessly re-register.
             if (el.hasLoginResponse() && el.getLoginResponse().hasLoginError())
@@ -234,7 +234,7 @@ final class WazeSession {
     /**
      * Register (if no credentials) + log in (if no valid session) + run the
      * SeeMe/SetMood/Location/MapDisplayed handshake. Call once before a run of
-     * {@link #queryBox} calls — mirrors the official, which handshakes per login,
+     * {@link #queryBox} calls: mirrors the official, which handshakes per login,
      * not per query.
      */
     void prepareForArea(double lat, double lon) throws Exception {

--- a/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
@@ -2,7 +2,7 @@
 <!--
   Launcher foreground: a road receding toward an amber radar beacon.
   Adaptive-icon canvas is 108x108 with a 66dp-diameter safe zone centered at
-  (54,54) — all content stays within ~radius 32 so circular masks never clip it.
+  (54,54): all content stays within ~radius 32 so circular masks never clip it.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,7 +30,7 @@
                 android:id="@+id/serviceStatus"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Service starting…"
+                android:text="Service starting..."
                 android:textSize="13sp"
                 android:textColor="#BBDEFB"
                 android:layout_marginTop="4dp" />

--- a/app/src/test/java/app/sabre/wzsabre/AlertDeduperTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/AlertDeduperTest.java
@@ -50,7 +50,7 @@ public class AlertDeduperTest {
 
     @Test
     public void sameSourceCoLocatedNotMerged() {
-        // Two distinct CHP accidents ~30m apart at an interchange must BOTH survive —
+        // Two distinct CHP accidents ~30m apart at an interchange must BOTH survive,
         // only cross-source duplicates are collapsed.
         List<SabreAlert> in = Arrays.asList(
                 a("chp_1", SabreResponseBuilder.SOURCE_CHP, "ACCIDENT_MAJOR", LAT, LON, 0),

--- a/app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java
@@ -65,7 +65,7 @@ public class AlertMapperTest {
     @Test
     public void mapping_isLocaleIndependent_turkish() {
         // On a Turkish/Azeri device, default-locale "silver".toUpperCase() dots the i
-        // (→ "SİLVER"), so contains("SILVER") would silently fail — un-suppressing
+        // (→ "SİLVER"), so contains("SILVER") would silently fail, un-suppressing
         // Silver Alerts and misrouting other 'i'-bearing types. Mapping must uppercase
         // with Locale.US. These inputs carry a lowercase i, the trigger condition.
         Locale prev = Locale.getDefault();
@@ -108,7 +108,7 @@ public class AlertMapperTest {
     @Test public void chp_nonInjury()       { assertEquals("ACCIDENT_MINOR",  AlertMapper.fromChpLogType("1182 NON-INJURY TC")); }
     @Test public void chp_hitAndRun()       { assertEquals("ACCIDENT_MINOR",  AlertMapper.fromChpLogType("20002 HIT AND RUN")); }
 
-    // Real feed LogType strings for every collision code — must map to the correct
+    // Real feed LogType strings for every collision code, must map to the correct
     // ACCIDENT severity, not fall through to the HAZARD_ON_ROAD_DEBRIS catch-all.
     // (Regression: 1180/1181 injury collisions were rendering as road debris.)
     @Test public void chp_1179_realString()   { assertEquals("ACCIDENT_MAJOR", AlertMapper.fromChpLogType("1179-Trfc Collision-1141 Enrt")); }

--- a/app/src/test/java/app/sabre/wzsabre/ChpConfigTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/ChpConfigTest.java
@@ -14,7 +14,7 @@ public class ChpConfigTest {
 
     private static final double LAT = 37.7749, LON = -122.4194, R = 50_000;
 
-    // XML templates — incident inside radius SF
+    // XML templates: incident inside radius SF
     private String xml(String logType, String logTime) {
         return "<?xml version=\"1.0\"?><CHP_INCIDENTS><INCIDENTS Area=\"SF\">" +
                "<Log ID=\"TST-1\">" +

--- a/app/src/test/java/app/sabre/wzsabre/LcsSourceTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/LcsSourceTest.java
@@ -152,7 +152,7 @@ public class LcsSourceTest {
 
     @Test
     public void isActive_overrunWithinGrace_staysActive() throws Exception {
-        // ended 1h ago by schedule but still 1097 — crews running late
+        // ended 1h ago by schedule but still 1097, crews running late
         LcsSource.Closure c = parse(feed(record("A-1", 37.3, -122.4, 37.31, -122.41,
                 "Full", "All", NOW - 86400, NOW - 3600, false, true, false, false))).get(0);
         assertTrue(LcsSource.isActive(c, NOW));
@@ -271,7 +271,7 @@ public class LcsSourceTest {
         LcsSource.Closure c = activeClosure();
         c.typeOfClosure = "Lane";
         c.lanesClosed = "2, RShoulder";
-        assertEquals("SR-1 Lane closure @ San Bruno Ave (Half Moon Bay) · lanes: 2, RShoulder",
+        assertEquals("SR-1 Lane closure @ San Bruno Ave (Half Moon Bay), lanes: 2, RShoulder",
                 LcsSource.describe(c));
     }
 

--- a/app/src/test/java/app/sabre/wzsabre/SabreProtocolTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/SabreProtocolTest.java
@@ -220,7 +220,7 @@ public class SabreProtocolTest {
 
     @Test
     public void build_dropsUnknownType_keepsValidAlerts() throws Exception {
-        // An unknown SABRE type string would crash HR's renderer — never send it.
+        // An unknown SABRE type string would crash HR's renderer, never send it.
         SabreAlert bad = new SabreAlert("bad", "chp", "TOTALLY_BOGUS_TYPE",
                 34.0, -118.0, 0.0, null, NOW_SECONDS);
         SabreAlert badNull = new SabreAlert("bad2", "chp", null,

--- a/app/src/test/java/app/sabre/wzsabre/WildfireSourceTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/WildfireSourceTest.java
@@ -57,7 +57,7 @@ public class WildfireSourceTest {
 
     @Test(expected = Exception.class)
     public void parse_arcgisErrorBody_throws() throws Exception {
-        // ArcGIS returns HTTP 200 with an error body on a bad query — must NOT be
+        // ArcGIS returns HTTP 200 with an error body on a bad query, must NOT be
         // treated as "0 fires" (which would hide the outage in diagnostics).
         WildfireSource.parse("{\"error\":{\"code\":400,\"message\":\"Invalid field\"}}");
     }
@@ -91,7 +91,7 @@ public class WildfireSourceTest {
     @Test
     public void describe_formatsSizeAndContainment() throws Exception {
         List<WildfireSource.Fire> fires = WildfireSource.parse(JSON);
-        assertEquals("Wildfire: PARK FIRE · 1,200 ac · 40% contained",
+        assertEquals("Wildfire: PARK FIRE, 1,200 ac, 40% contained",
                 WildfireSource.describe(fires.get(0)));
         // Unknown size/containment → name only
         assertEquals("Wildfire: RIDGE FIRE", WildfireSource.describe(fires.get(1)));

--- a/app/src/test/java/app/sabre/wzsabre/WinterSourceTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/WinterSourceTest.java
@@ -106,6 +106,6 @@ public class WinterSourceTest {
     public void describe_format() throws Exception {
         WinterSource.ChainControl c = parse(feed(
                 record("i", 38.46, -120.04, "SR-4", "BEAR VALLEY", "Arnold", true, "R-2"))).get(0);
-        assertEquals("Chains R-2 · SR-4 @ BEAR VALLEY (Arnold)", WinterSource.describe(c));
+        assertEquals("Chains R-2, SR-4 @ BEAR VALLEY (Arnold)", WinterSource.describe(c));
     }
 }

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeAlertCacheTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeAlertCacheTest.java
@@ -39,7 +39,7 @@ public class WazeAlertCacheTest {
     public void mergesDeltasAcrossQueries() {
         WazeAlertCache cache = new WazeAlertCache();
         cache.submit(adds(alert("A", 0), alert("B", 0)));
-        // Second query is a DELTA — only the new alert. A and B must survive.
+        // Second query is a DELTA, only the new alert. A and B must survive.
         cache.submit(adds(alert("C", 0)));
         assertEquals(Arrays.asList("A", "B", "C"), uuids(cache.snapshot()));
     }

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeSessionErrorTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeSessionErrorTest.java
@@ -93,7 +93,7 @@ public class WazeSessionErrorTest {
     @Test
     public void informationalServerError_isIgnored() throws Exception {
         // A non-relogin ServerError with an informational code (incl. the proto
-        // default 0) must NOT fail the whole refresh — the official ignores these,
+        // default 0) must NOT fail the whole refresh, the official ignores these,
         // and a normal 200 batch can legitimately carry one.
         WazeSession.checkErrors(serverError(0, "advisory: scheduled maintenance"));
         WazeSession.checkErrors(serverError(204, "no content"));

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,6 +45,8 @@
   "mainEntity": [
     {"@type":"Question","name":"Is SABRE Plus a replacement for wzsabre?",
      "acceptedAnswer":{"@type":"Answer","text":"Yes. It uses the same plugin ID Highway Radar looks for, so Highway Radar finds it automatically. Because Android allows only one app per ID, uninstall wzsabre first, then install SABRE Plus. Your Highway Radar settings are unaffected."}},
+    {"@type":"Question","name":"SABRE Plus is installed but no alerts arrive, or Highway Radar still shows WzSabre. What do I do?",
+     "acceptedAnswer":{"@type":"Answer","text":"Highway Radar caches the plugin registration it first discovered and keeps using it after you switch. Fully close and reopen Highway Radar so it runs discovery again. If that does not fix it, clear Highway Radar's cache: Android Settings, Apps, Highway Radar, Storage, Clear cache. Use Clear cache, not Clear storage, because Clear storage erases your Highway Radar settings."}},
     {"@type":"Question","name":"Does SABRE Plus cost anything?",
      "acceptedAnswer":{"@type":"Answer","text":"No. It is free and open source under the MIT license, with no account, no ads and no in-app purchases."}},
     {"@type":"Question","name":"What data does SABRE Plus collect?",
@@ -57,315 +59,7 @@
 }
 </script>
 
-<style>
-/* ─────────────────────────────────────────────────────────────────────────
-   SABRE Plus landing page.
-   Palette and type come from California highway hardware: a Caltrans
-   changeable message sign (amber LED on night asphalt) mounted over a
-   concrete-grey page. No webfonts and no third-party requests, which keeps
-   the page consistent with an app that ships no trackers.
-   ───────────────────────────────────────────────────────────────────────── */
-:root {
-  --asphalt:   #0B0C0E;   /* inside of the sign housing */
-  --amber:     #FFB000;   /* Caltrans CMS amber LED */
-  --amber-dim: #6E4B00;   /* unlit element */
-  --spade:     #0B6E4F;   /* California route shield green */
-  --concrete:  #E6E7E4;   /* page surface, K-rail grey */
-  --panel:     #F2F3F0;
-  --ink:       #1B1D20;
-  --ink-soft:  #55595E;
-  --rule:      #C9CBC6;
-  --stripe:    #F2C14E;   /* lane paint */
-
-  --display: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
-             "Helvetica Neue", Arial, sans-serif;
-  --mono: ui-monospace, SFMono-Regular, "SF Mono", "Cascadia Mono",
-          "Roboto Mono", Menlo, Consolas, monospace;
-
-  --measure: 68rem;
-  --gap: clamp(3.5rem, 8vw, 6.5rem);
-}
-
-/* Night driving. The sign is the constant; the road around it goes dark. */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --concrete: #111316;
-    --panel:    #191C20;
-    --ink:      #E9EAE7;
-    --ink-soft: #9AA0A6;
-    --rule:     #2C3036;
-    --spade:    #3FA37B;
-  }
-}
-
-*, *::before, *::after { box-sizing: border-box; }
-
-html { -webkit-text-size-adjust: 100%; }
-
-body {
-  margin: 0;
-  background: var(--concrete);
-  color: var(--ink);
-  font-family: var(--display);
-  font-size: clamp(1rem, 0.96rem + 0.2vw, 1.0625rem);
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-}
-
-a { color: inherit; }
-
-:where(a, button, summary):focus-visible {
-  outline: 3px solid var(--spade);
-  outline-offset: 3px;
-  border-radius: 2px;
-}
-
-img { max-width: 100%; height: auto; display: block; }
-
-.wrap { width: min(100% - 2.5rem, var(--measure)); margin-inline: auto; }
-
-/* ── Eyebrow / section labels: the data face, used like a spec sheet ────── */
-.label {
-  font-family: var(--mono);
-  font-size: 0.75rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--ink-soft);
-  margin: 0 0 0.75rem;
-}
-
-h1, h2, h3 { line-height: 1.08; letter-spacing: -0.025em; margin: 0; }
-h1 { font-size: clamp(2.1rem, 1.2rem + 4.2vw, 4rem); font-weight: 800; }
-h2 { font-size: clamp(1.6rem, 1.1rem + 2.2vw, 2.5rem); font-weight: 800; }
-h3 { font-size: 1.0625rem; font-weight: 700; letter-spacing: -0.01em; }
-
-/* ── Masthead ──────────────────────────────────────────────────────────── */
-.masthead {
-  position: sticky; top: 0; z-index: 20;
-  background: color-mix(in srgb, var(--concrete) 88%, transparent);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid var(--rule);
-}
-.masthead .wrap {
-  display: flex; align-items: center; gap: 0.75rem;
-  min-height: 3.5rem;
-}
-.mark { display: flex; align-items: center; gap: 0.6rem; text-decoration: none; font-weight: 800; letter-spacing: -0.02em; }
-.mark img { width: 26px; height: 26px; border-radius: 6px; }
-.masthead nav { margin-left: auto; display: flex; align-items: center; gap: 1.25rem; }
-.masthead nav a { font-family: var(--mono); font-size: 0.8125rem; text-decoration: none; color: var(--ink-soft); }
-.masthead nav a:hover { color: var(--ink); }
-.masthead .btn { color: var(--asphalt); }
-@media (max-width: 34rem) { .nav-hide { display: none; } }
-
-/* ── Buttons ───────────────────────────────────────────────────────────── */
-.btn {
-  display: inline-flex; align-items: center; gap: 0.5rem;
-  font-family: var(--mono); font-size: 0.875rem; font-weight: 600;
-  letter-spacing: 0.02em;
-  padding: 0.7rem 1.15rem;
-  background: var(--amber); color: var(--asphalt);
-  text-decoration: none; border: 1px solid transparent; border-radius: 3px;
-  transition: transform 0.12s ease, filter 0.12s ease;
-}
-.btn:hover { filter: brightness(1.08); transform: translateY(-1px); }
-.btn--ghost {
-  background: transparent; color: var(--ink);
-  border-color: var(--rule);
-}
-.btn--ghost:hover { border-color: var(--ink); filter: none; }
-.btn--lg { font-size: 0.9375rem; padding: 0.95rem 1.5rem; }
-
-/* ── Hero ──────────────────────────────────────────────────────────────── */
-.hero { padding: clamp(3rem, 7vw, 5.5rem) 0 var(--gap); }
-.hero p.lede {
-  font-size: clamp(1.0625rem, 1rem + 0.5vw, 1.25rem);
-  color: var(--ink-soft);
-  max-width: 44ch;
-  margin: 1.25rem 0 0;
-}
-.actions { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 2rem; }
-.hero .terms {
-  font-family: var(--mono); font-size: 0.8125rem; color: var(--ink-soft);
-  margin: 1rem 0 0;
-}
-
-/* ── THE SIGN: the one bold element on the page ────────────────────────── */
-.gantry { margin-top: clamp(2.5rem, 6vw, 4rem); }
-
-.sign {
-  position: relative;
-  background: var(--asphalt);
-  border: 3px solid #3A3D42;
-  border-radius: 5px;
-  padding: clamp(1.1rem, 3.5vw, 2rem) clamp(1rem, 3vw, 2rem);
-  box-shadow: 0 18px 40px -22px rgba(0,0,0,0.85), inset 0 0 0 2px #17191C;
-  overflow: hidden;
-}
-/* The LED grid. Sits over the text so the type reads as lit elements. */
-.sign::after {
-  content: "";
-  position: absolute; inset: 0;
-  background-image:
-    repeating-linear-gradient(to right,  rgba(0,0,0,0.42) 0 1px, transparent 1px 3px),
-    repeating-linear-gradient(to bottom, rgba(0,0,0,0.42) 0 1px, transparent 1px 3px);
-  pointer-events: none;
-}
-.sign__head {
-  font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.22em;
-  text-transform: uppercase; color: var(--amber-dim);
-  display: flex; justify-content: space-between; gap: 1rem;
-  margin-bottom: 0.9rem;
-}
-.sign__msg {
-  font-family: var(--mono);
-  font-size: clamp(0.9rem, 0.5rem + 2.1vw, 1.6rem);
-  font-weight: 700; line-height: 1.5; letter-spacing: 0.02em;
-  text-transform: uppercase;
-  color: var(--amber);
-  text-shadow: 0 0 14px rgba(255,176,0,0.45);
-  min-height: 3em;
-  margin: 0;
-}
-.sign__msg span { display: block; }
-.sign__src {
-  font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.18em;
-  text-transform: uppercase; color: var(--amber-dim);
-  margin: 0.9rem 0 0;
-}
-/* The gantry legs, so the sign reads as mounted over the road. */
-.gantry__legs { display: flex; justify-content: space-between; padding: 0 12%; }
-.gantry__legs i {
-  display: block; width: 7px; height: clamp(18px, 3vw, 30px);
-  background: linear-gradient(to bottom, #3A3D42, transparent);
-}
-@media (prefers-reduced-motion: no-preference) {
-  .sign__msg { transition: opacity 0.35s ease; }
-  .sign__msg.is-swapping { opacity: 0.15; }
-}
-
-/* ── Lane-line divider: the road's own way of separating lanes ─────────── */
-.lane {
-  height: 6px; border: 0; margin: 0;
-  background: repeating-linear-gradient(
-    to right, var(--stripe) 0 42px, transparent 42px 76px);
-  opacity: 0.75;
-}
-
-/* ── Sections ──────────────────────────────────────────────────────────── */
-.band { padding: var(--gap) 0; }
-.band > .wrap > h2 + p { color: var(--ink-soft); max-width: 56ch; margin: 1rem 0 0; }
-
-/* ── Source strips: small signs, echoing the hero ──────────────────────── */
-.sources { display: grid; gap: 0.75rem; margin-top: 2.5rem; }
-.source {
-  display: grid;
-  grid-template-columns: auto minmax(0,1fr);
-  gap: 0 1.15rem;
-  align-items: start;
-  background: var(--panel);
-  border: 1px solid var(--rule);
-  border-left: 4px solid var(--amber);
-  border-radius: 3px;
-  padding: 1.15rem 1.25rem;
-}
-.source__tag {
-  font-family: var(--mono); font-size: 0.6875rem; font-weight: 700;
-  letter-spacing: 0.12em; text-transform: uppercase;
-  background: var(--asphalt); color: var(--amber);
-  padding: 0.3rem 0.5rem; border-radius: 2px; white-space: nowrap;
-  grid-row: span 2;
-}
-.source p { margin: 0.35rem 0 0; color: var(--ink-soft); font-size: 0.9375rem; }
-.source__cadence {
-  font-family: var(--mono); font-size: 0.75rem; color: var(--ink-soft);
-  margin-top: 0.5rem;
-}
-@media (max-width: 34rem) {
-  .source { grid-template-columns: minmax(0,1fr); gap: 0.6rem; }
-  .source__tag { grid-row: auto; justify-self: start; }
-}
-
-/* ── Screens ───────────────────────────────────────────────────────────── */
-.screens { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.25rem; margin-top: 2.5rem; }
-.screens figure { margin: 0; }
-.screens img { border: 1px solid var(--rule); border-radius: 6px; background: var(--panel); }
-.screens figcaption {
-  font-family: var(--mono); font-size: 0.75rem; color: var(--ink-soft);
-  margin-top: 0.65rem; line-height: 1.45;
-}
-@media (max-width: 44rem) { .screens { grid-template-columns: 1fr; max-width: 22rem; } }
-
-/* ── Install: numbered because it genuinely is a sequence ──────────────── */
-.warn {
-  background: var(--panel);
-  border: 1px solid var(--rule);
-  border-left: 4px solid var(--stripe);
-  border-radius: 3px;
-  padding: 1.15rem 1.25rem;
-  margin-top: 2.25rem;
-}
-.warn h3 { margin-bottom: 0.4rem; }
-.warn p { margin: 0; color: var(--ink-soft); font-size: 0.9375rem; }
-
-.steps { list-style: none; counter-reset: step; padding: 0; margin: 2.25rem 0 0; }
-.steps li {
-  counter-increment: step;
-  display: grid; grid-template-columns: auto minmax(0,1fr); gap: 1.15rem;
-  padding: 1.15rem 0; border-top: 1px solid var(--rule);
-}
-.steps li:last-child { border-bottom: 1px solid var(--rule); }
-.steps li::before {
-  content: counter(step, decimal-leading-zero);
-  font-family: var(--mono); font-size: 0.875rem; font-weight: 700;
-  color: var(--amber-dim);
-}
-@media (prefers-color-scheme: dark) { .steps li::before { color: var(--amber); } }
-.steps p { margin: 0.35rem 0 0; color: var(--ink-soft); font-size: 0.9375rem; }
-
-/* ── Privacy ledger ────────────────────────────────────────────────────── */
-.ledger { margin-top: 2.5rem; border-top: 1px solid var(--rule); }
-.ledger div {
-  display: flex; align-items: baseline; gap: 1rem;
-  padding: 0.85rem 0; border-bottom: 1px solid var(--rule);
-  font-family: var(--mono); font-size: 0.875rem;
-}
-.ledger dt { flex: 1; margin: 0; color: var(--ink); }
-.ledger dd { margin: 0; color: var(--spade); font-weight: 600; letter-spacing: 0.04em; text-align: right; }
-.ledger dd.is-note { color: var(--ink-soft); font-weight: 400; }
-
-/* ── FAQ ───────────────────────────────────────────────────────────────── */
-.faq { margin-top: 2.5rem; border-top: 1px solid var(--rule); }
-.faq details { border-bottom: 1px solid var(--rule); }
-.faq summary {
-  cursor: pointer; list-style: none;
-  padding: 1.15rem 2rem 1.15rem 0; position: relative;
-  font-weight: 700; letter-spacing: -0.01em;
-}
-.faq summary::-webkit-details-marker { display: none; }
-.faq summary::after {
-  content: "+"; position: absolute; right: 0.25rem; top: 50%;
-  transform: translateY(-50%);
-  font-family: var(--mono); font-weight: 400; color: var(--ink-soft);
-}
-.faq details[open] summary::after { content: "\2013"; }
-.faq p { margin: 0 0 1.25rem; color: var(--ink-soft); max-width: 62ch; font-size: 0.9375rem; }
-
-/* ── Closing call to action ────────────────────────────────────────────── */
-.closer { padding: var(--gap) 0; text-align: center; }
-.closer .actions { justify-content: center; }
-.closer p { color: var(--ink-soft); max-width: 46ch; margin: 1rem auto 0; }
-
-/* ── Footer ────────────────────────────────────────────────────────────── */
-footer { border-top: 1px solid var(--rule); padding: 2.5rem 0 3.5rem; }
-footer .wrap { display: flex; flex-wrap: wrap; gap: 1rem 2rem; align-items: center; }
-footer a { font-family: var(--mono); font-size: 0.8125rem; color: var(--ink-soft); text-decoration: none; }
-footer a:hover { color: var(--ink); text-decoration: underline; }
-footer .disclaim {
-  font-size: 0.8125rem; color: var(--ink-soft); margin: 1.5rem 0 0;
-  max-width: 70ch; line-height: 1.55;
-}
-</style>
+<link rel="stylesheet" href="style.css">
 </head>
 <body>
 
@@ -388,7 +82,6 @@ footer .disclaim {
 
   <section class="hero">
     <div class="wrap">
-      <p class="label">Highway Radar plugin &middot; California &middot; Free and open source</p>
       <h1>CHP, Waze and Caltrans alerts on your Highway&nbsp;Radar map.</h1>
       <p class="lede">
         Highway Radar can pull crowd-sourced alerts from a plugin. SABRE Plus is that
@@ -401,7 +94,7 @@ footer .disclaim {
         </a>
         <a class="btn btn--ghost btn--lg" href="#install">Read the install steps</a>
       </div>
-      <p class="terms">Android 7.0+ &nbsp;·&nbsp; no account &nbsp;·&nbsp; no ads &nbsp;·&nbsp; no tracking &nbsp;·&nbsp; MIT licensed</p>
+      <p class="terms">Android 7.0+, no account, no ads, no tracking, MIT licensed</p>
 
       <!-- The signature element: a Caltrans-style changeable message sign
            cycling the kind of alert each source actually produces. -->
@@ -409,7 +102,7 @@ footer .disclaim {
         <div class="sign">
           <div class="sign__head">
             <span>Live alert feed</span>
-            <span aria-hidden="true">CA · SABRE</span>
+            <span aria-hidden="true">CA SABRE</span>
           </div>
           <p class="sign__msg" id="signMsg" aria-live="off">
             <span>Traffic collision, no injury</span>
@@ -580,8 +273,8 @@ footer .disclaim {
       <p class="label">Privacy</p>
       <h2>What it does not do.</h2>
       <p>
-        There is no backend to speak of, because there is no backend. The app talks to
-        public road feeds and to Waze, and that is the whole list.
+        The app runs entirely on your phone. It reads public road feeds and Waze, and
+        nothing else.
       </p>
 
       <dl class="ledger">
@@ -592,6 +285,10 @@ footer .disclaim {
         <div><dt>Data leaving your device</dt><dd class="is-note">Approximate location, to Waze only</dd></div>
         <div><dt>Source code</dt><dd class="is-note">Public, MIT licensed</dd></div>
       </dl>
+
+      <div class="actions">
+        <a class="btn btn--ghost" href="privacy.html">Read the full privacy policy</a>
+      </div>
     </div>
   </section>
 
@@ -609,6 +306,22 @@ footer .disclaim {
             Yes. It uses the same plugin ID that Highway Radar's discovery looks for, so
             Highway Radar picks it up automatically. Android only allows one app to hold
             that ID, so uninstall wzsabre before installing SABRE Plus.
+          </p>
+        </details>
+        <details>
+          <summary>I installed it but no alerts arrive, or Highway Radar still says "WzSabre"</summary>
+          <p>
+            Highway Radar remembers the plugin it first discovered and keeps using that
+            cached registration after you switch. Fully close and reopen Highway Radar,
+            which makes it run discovery again. If that does not fix it, clear Highway
+            Radar's cache: Android Settings, then Apps, then Highway Radar, then Storage,
+            then Clear cache. Use <strong>Clear cache</strong>, not Clear storage, because
+            Clear storage would erase your Highway Radar settings.
+          </p>
+          <p>
+            Tapping Share diagnostics in the SABRE Plus app tells you which case you are
+            in: it reports whether Highway Radar has re-detected SABRE Plus or is still
+            running off a cached registration.
           </p>
         </details>
         <details>
@@ -671,7 +384,7 @@ footer .disclaim {
     <a href="https://github.com/nicglazkov/highway-radar-sabre-plus">GitHub</a>
     <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/releases">Releases</a>
     <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/CHANGELOG.md">Changelog</a>
-    <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/PRIVACY.md">Privacy policy</a>
+    <a href="privacy.html">Privacy policy</a>
     <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/issues">Report a problem</a>
     <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/LICENSE">MIT license</a>
   </div>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Privacy policy: SABRE Plus for Highway Radar</title>
+<meta name="description" content="SABRE Plus has no servers, no accounts and no analytics, and collects no personal data. This policy sets out exactly what stays on your device, what leaves it, and what never happens.">
+<link rel="canonical" href="https://nicglazkov.github.io/highway-radar-sabre-plus/privacy.html">
+<meta name="theme-color" content="#E6E7E4" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#111316" media="(prefers-color-scheme: dark)">
+
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://nicglazkov.github.io/highway-radar-sabre-plus/privacy.html">
+<meta property="og:title" content="Privacy policy: SABRE Plus">
+<meta property="og:description" content="No servers, no accounts, no analytics, no personal data. Everything runs on your device.">
+<meta property="og:image" content="https://nicglazkov.github.io/highway-radar-sabre-plus/social-preview.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" href="screenshots/app-icon.png">
+<link rel="apple-touch-icon" href="screenshots/app-icon.png">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Privacy policy: SABRE Plus for Highway Radar",
+  "url": "https://nicglazkov.github.io/highway-radar-sabre-plus/privacy.html",
+  "dateModified": "2026-08-04",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "SABRE Plus",
+    "url": "https://nicglazkov.github.io/highway-radar-sabre-plus/"
+  }
+}
+</script>
+
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header class="masthead">
+  <div class="wrap">
+    <a class="mark" href="./">
+      <img src="screenshots/app-icon.png" alt="">
+      SABRE Plus
+    </a>
+    <nav>
+      <a class="nav-hide" href="./#sources">Sources</a>
+      <a class="nav-hide" href="./#install">Install</a>
+      <a class="nav-hide" href="./#faq">FAQ</a>
+      <a class="btn" href="https://github.com/nicglazkov/highway-radar-sabre-plus/releases/latest">Download</a>
+    </nav>
+  </div>
+</header>
+
+<main class="doc">
+  <div class="wrap">
+    <p class="label">Privacy policy</p>
+    <h1>SABRE Plus collects nothing about you.</h1>
+    <p class="stamp">Last updated 2026-08-04</p>
+
+    <p class="intro">
+      SABRE Plus is a free, open-source Highway Radar plugin. It has
+      <strong>no servers, no accounts and no analytics</strong>, and it
+      <strong>collects no personal data</strong>. Everything it does runs on your own
+      device. This page sets out exactly what stays on your device, what leaves it, and
+      what never happens.
+    </p>
+
+    <h2>The short version</h2>
+    <ul>
+      <li>The app runs entirely on your phone. There is no server of ours for your data to reach.</li>
+      <li>No analytics, crash-reporting services, advertising or trackers of any kind.</li>
+      <li>No accounts, no user IDs, and no reading of your device's advertising ID.</li>
+      <li>No location history is stored, and nothing is ever sold or shared.</li>
+    </ul>
+
+    <h2>What is stored on your device</h2>
+    <p>
+      All of this is kept in the app's private storage and is never transmitted by us:
+    </p>
+    <ul>
+      <li>
+        <strong>Your settings.</strong> Which sources and categories are on, the age
+        filter, the wildfire size limit, and so on.
+      </li>
+      <li>
+        <strong>An anonymous Waze session.</strong> To use the Waze feature the app
+        registers an anonymous session with Waze, with no name, email, phone or account.
+        A session token is cached so it does not have to register again every time.
+      </li>
+      <li>
+        <strong>A short diagnostics log.</strong> A small in-memory record of recent
+        activity (counts, category names, source health and errors) to help with
+        troubleshooting. It goes somewhere only if <strong>you</strong> tap
+        <strong>Share diagnostics</strong> and choose where to send it. It contains no
+        location, street names, alert IDs or personal data.
+      </li>
+      <li>
+        <strong>A local crash log.</strong> If the app crashes, a summary is written to a
+        private file so you can include it in a bug report if you want to. It stays on
+        your device unless you share it.
+      </li>
+    </ul>
+
+    <h2>What leaves your device</h2>
+    <p>
+      To show you road conditions, the app fetches data from public and third-party
+      sources. Those requests go straight from your device to those services. They do not
+      pass through any server of ours.
+    </p>
+
+    <div class="tablewrap">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Service</th>
+            <th scope="col">What is requested</th>
+            <th scope="col">Location sent?</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>California Highway Patrol</strong><br><code>media.chp.ca.gov</code></td>
+            <td>The statewide incident feed</td>
+            <td class="ans"><span class="ans-no">No.</span> The whole-state feed is fetched, then filtered on your device.</td>
+          </tr>
+          <tr>
+            <td><strong>Caltrans</strong><br><code>dot.ca.gov</code></td>
+            <td>Lane-closure and chain-control feeds for the districts near you</td>
+            <td class="ans"><span class="ans-no">No.</span> Which districts to fetch is worked out on your device. Your coordinates are not sent.</td>
+          </tr>
+          <tr>
+            <td><strong>Wildfire feed, NIFC</strong><br><code>arcgis.com</code></td>
+            <td>Active California wildfires</td>
+            <td class="ans"><span class="ans-no">No.</span> All active California fires are fetched, then filtered on your device.</td>
+          </tr>
+          <tr>
+            <td><strong>Waze</strong><br><code>waze.com</code></td>
+            <td>Nearby crowd-sourced alerts</td>
+            <td class="ans"><span class="ans-yes">Yes.</span> To return alerts near you, the app sends your approximate location, a map area around you, over an anonymous session.</td>
+          </tr>
+          <tr>
+            <td><strong>GitHub</strong><br><code>api.github.com</code></td>
+            <td>A check for a newer version of the app</td>
+            <td class="ans"><span class="ans-no">No.</span> A standard version check. No location.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p>
+      As with any app that uses the internet, each service you contact can see your
+      device's public <strong>IP address</strong>, and what they do with it is governed by
+      their own privacy policies. Waze is the only case where your approximate location
+      leaves the device. If you would rather send no location to Waze, turn the Waze
+      source off in Highway Radar's settings.
+    </p>
+
+    <h2>What never happens</h2>
+    <ul>
+      <li>No analytics or usage tracking.</li>
+      <li>No advertising or ad identifiers.</li>
+      <li>No accounts, sign-ins or user identifiers.</li>
+      <li>No location history and no profiles.</li>
+      <li>No selling, renting or sharing of data with anyone.</li>
+    </ul>
+
+    <h2>Permissions</h2>
+    <p>
+      The app asks only for what it needs to relay alerts while you drive: internet
+      access, a foreground-service notification, a wake lock, exact alarms to keep the
+      service reachable, and an optional battery-optimization exemption. It does
+      <strong>not</strong> ask for your contacts, camera, microphone, photos or precise
+      device location. The location it filters by comes from Highway Radar's request, not
+      from a location permission of its own.
+    </p>
+
+    <h2>Children</h2>
+    <p>
+      This app is a navigation utility for drivers and is not directed at children.
+    </p>
+
+    <h2>Changes</h2>
+    <p>
+      If this policy changes, the update is committed to
+      <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/PRIVACY.md">PRIVACY.md</a>
+      in the public repository and the date at the top of this page changes with it.
+    </p>
+
+    <h2>Contact</h2>
+    <p>
+      Questions or concerns:
+      <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/issues">open an issue</a>
+      on GitHub.
+    </p>
+  </div>
+</main>
+
+<footer>
+  <div class="wrap">
+    <a href="./">Home</a>
+    <a href="https://github.com/nicglazkov/highway-radar-sabre-plus">GitHub</a>
+    <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/releases">Releases</a>
+    <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/CHANGELOG.md">Changelog</a>
+    <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/issues">Report a problem</a>
+    <a href="https://github.com/nicglazkov/highway-radar-sabre-plus/blob/main/LICENSE">MIT license</a>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,343 @@
+/* ─────────────────────────────────────────────────────────────────────────
+   SABRE Plus landing page.
+   Palette and type come from California highway hardware: a Caltrans
+   changeable message sign (amber LED on night asphalt) mounted over a
+   concrete-grey page. No webfonts and no third-party requests, which keeps
+   the page consistent with an app that ships no trackers.
+   ───────────────────────────────────────────────────────────────────────── */
+:root {
+  --asphalt:   #0B0C0E;   /* inside of the sign housing */
+  --amber:     #FFB000;   /* Caltrans CMS amber LED */
+  --amber-dim: #6E4B00;   /* unlit element */
+  --spade:     #0B6E4F;   /* California route shield green */
+  --concrete:  #E6E7E4;   /* page surface, K-rail grey */
+  --panel:     #F2F3F0;
+  --ink:       #1B1D20;
+  --ink-soft:  #55595E;
+  --rule:      #C9CBC6;
+  --stripe:    #F2C14E;   /* lane paint */
+
+  --display: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+             "Helvetica Neue", Arial, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", "Cascadia Mono",
+          "Roboto Mono", Menlo, Consolas, monospace;
+
+  --measure: 68rem;
+  --gap: clamp(3.5rem, 8vw, 6.5rem);
+}
+
+/* Night driving. The sign is the constant; the road around it goes dark. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --concrete: #111316;
+    --panel:    #191C20;
+    --ink:      #E9EAE7;
+    --ink-soft: #9AA0A6;
+    --rule:     #2C3036;
+    --spade:    #3FA37B;
+  }
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  background: var(--concrete);
+  color: var(--ink);
+  font-family: var(--display);
+  font-size: clamp(1rem, 0.96rem + 0.2vw, 1.0625rem);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: inherit; }
+
+:where(a, button, summary):focus-visible {
+  outline: 3px solid var(--spade);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+img { max-width: 100%; height: auto; display: block; }
+
+.wrap { width: min(100% - 2.5rem, var(--measure)); margin-inline: auto; }
+
+/* ── Eyebrow / section labels: the data face, used like a spec sheet ────── */
+.label {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin: 0 0 0.75rem;
+}
+
+h1, h2, h3 { line-height: 1.08; letter-spacing: -0.025em; margin: 0; }
+h1 { font-size: clamp(2.1rem, 1.2rem + 4.2vw, 4rem); font-weight: 800; }
+h2 { font-size: clamp(1.6rem, 1.1rem + 2.2vw, 2.5rem); font-weight: 800; }
+h3 { font-size: 1.0625rem; font-weight: 700; letter-spacing: -0.01em; }
+
+/* ── Masthead ──────────────────────────────────────────────────────────── */
+.masthead {
+  position: sticky; top: 0; z-index: 20;
+  background: color-mix(in srgb, var(--concrete) 88%, transparent);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--rule);
+}
+.masthead .wrap {
+  display: flex; align-items: center; gap: 0.75rem;
+  min-height: 3.5rem;
+}
+.mark { display: flex; align-items: center; gap: 0.6rem; text-decoration: none; font-weight: 800; letter-spacing: -0.02em; }
+.mark img { width: 26px; height: 26px; border-radius: 6px; }
+.masthead nav { margin-left: auto; display: flex; align-items: center; gap: 1.25rem; }
+.masthead nav a { font-family: var(--mono); font-size: 0.8125rem; text-decoration: none; color: var(--ink-soft); }
+.masthead nav a:hover { color: var(--ink); }
+.masthead .btn { color: var(--asphalt); }
+@media (max-width: 34rem) { .nav-hide { display: none; } }
+
+/* ── Buttons ───────────────────────────────────────────────────────────── */
+.btn {
+  display: inline-flex; align-items: center; gap: 0.5rem;
+  font-family: var(--mono); font-size: 0.875rem; font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.7rem 1.15rem;
+  background: var(--amber); color: var(--asphalt);
+  text-decoration: none; border: 1px solid transparent; border-radius: 3px;
+  transition: transform 0.12s ease, filter 0.12s ease;
+}
+.btn:hover { filter: brightness(1.08); transform: translateY(-1px); }
+.btn--ghost {
+  background: transparent; color: var(--ink);
+  border-color: var(--rule);
+}
+.btn--ghost:hover { border-color: var(--ink); filter: none; }
+.btn--lg { font-size: 0.9375rem; padding: 0.95rem 1.5rem; }
+
+/* ── Hero ──────────────────────────────────────────────────────────────── */
+.hero { padding: clamp(3rem, 7vw, 5.5rem) 0 var(--gap); }
+.hero p.lede {
+  font-size: clamp(1.0625rem, 1rem + 0.5vw, 1.25rem);
+  color: var(--ink-soft);
+  max-width: 44ch;
+  margin: 1.25rem 0 0;
+}
+.actions { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 2rem; }
+.hero .terms {
+  font-family: var(--mono); font-size: 0.8125rem; color: var(--ink-soft);
+  margin: 1rem 0 0;
+}
+
+/* ── THE SIGN: the one bold element on the page ────────────────────────── */
+.gantry { margin-top: clamp(2.5rem, 6vw, 4rem); }
+
+.sign {
+  position: relative;
+  background: var(--asphalt);
+  border: 3px solid #3A3D42;
+  border-radius: 5px;
+  padding: clamp(1.1rem, 3.5vw, 2rem) clamp(1rem, 3vw, 2rem);
+  box-shadow: 0 18px 40px -22px rgba(0,0,0,0.85), inset 0 0 0 2px #17191C;
+  overflow: hidden;
+}
+/* The LED grid. Sits over the text so the type reads as lit elements. */
+.sign::after {
+  content: "";
+  position: absolute; inset: 0;
+  background-image:
+    repeating-linear-gradient(to right,  rgba(0,0,0,0.42) 0 1px, transparent 1px 3px),
+    repeating-linear-gradient(to bottom, rgba(0,0,0,0.42) 0 1px, transparent 1px 3px);
+  pointer-events: none;
+}
+.sign__head {
+  font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.22em;
+  text-transform: uppercase; color: var(--amber-dim);
+  display: flex; justify-content: space-between; gap: 1rem;
+  margin-bottom: 0.9rem;
+}
+.sign__msg {
+  font-family: var(--mono);
+  font-size: clamp(0.9rem, 0.5rem + 2.1vw, 1.6rem);
+  font-weight: 700; line-height: 1.5; letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--amber);
+  text-shadow: 0 0 14px rgba(255,176,0,0.45);
+  min-height: 3em;
+  margin: 0;
+}
+.sign__msg span { display: block; }
+.sign__src {
+  font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--amber-dim);
+  margin: 0.9rem 0 0;
+}
+/* The gantry legs, so the sign reads as mounted over the road. */
+.gantry__legs { display: flex; justify-content: space-between; padding: 0 12%; }
+.gantry__legs i {
+  display: block; width: 7px; height: clamp(18px, 3vw, 30px);
+  background: linear-gradient(to bottom, #3A3D42, transparent);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .sign__msg { transition: opacity 0.35s ease; }
+  .sign__msg.is-swapping { opacity: 0.15; }
+}
+
+/* ── Lane-line divider: the road's own way of separating lanes ─────────── */
+.lane {
+  height: 6px; border: 0; margin: 0;
+  background: repeating-linear-gradient(
+    to right, var(--stripe) 0 42px, transparent 42px 76px);
+  opacity: 0.75;
+}
+
+/* ── Sections ──────────────────────────────────────────────────────────── */
+.band { padding: var(--gap) 0; }
+.band > .wrap > h2 + p { color: var(--ink-soft); max-width: 56ch; margin: 1rem 0 0; }
+
+/* ── Source strips: small signs, echoing the hero ──────────────────────── */
+.sources { display: grid; gap: 0.75rem; margin-top: 2.5rem; }
+.source {
+  display: grid;
+  grid-template-columns: auto minmax(0,1fr);
+  gap: 0 1.15rem;
+  align-items: start;
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  border-left: 4px solid var(--amber);
+  border-radius: 3px;
+  padding: 1.15rem 1.25rem;
+}
+.source__tag {
+  font-family: var(--mono); font-size: 0.6875rem; font-weight: 700;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  background: var(--asphalt); color: var(--amber);
+  padding: 0.3rem 0.5rem; border-radius: 2px; white-space: nowrap;
+  grid-row: span 2;
+}
+.source p { margin: 0.35rem 0 0; color: var(--ink-soft); font-size: 0.9375rem; }
+.source__cadence {
+  font-family: var(--mono); font-size: 0.75rem; color: var(--ink-soft);
+  margin-top: 0.5rem;
+}
+@media (max-width: 34rem) {
+  .source { grid-template-columns: minmax(0,1fr); gap: 0.6rem; }
+  .source__tag { grid-row: auto; justify-self: start; }
+}
+
+/* ── Screens ───────────────────────────────────────────────────────────── */
+.screens { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.25rem; margin-top: 2.5rem; }
+.screens figure { margin: 0; }
+.screens img { border: 1px solid var(--rule); border-radius: 6px; background: var(--panel); }
+.screens figcaption {
+  font-family: var(--mono); font-size: 0.75rem; color: var(--ink-soft);
+  margin-top: 0.65rem; line-height: 1.45;
+}
+@media (max-width: 44rem) { .screens { grid-template-columns: 1fr; max-width: 22rem; } }
+
+/* ── Install: numbered because it genuinely is a sequence ──────────────── */
+.warn {
+  background: var(--panel);
+  border: 1px solid var(--rule);
+  border-left: 4px solid var(--stripe);
+  border-radius: 3px;
+  padding: 1.15rem 1.25rem;
+  margin-top: 2.25rem;
+}
+.warn h3 { margin-bottom: 0.4rem; }
+.warn p { margin: 0; color: var(--ink-soft); font-size: 0.9375rem; }
+
+.steps { list-style: none; counter-reset: step; padding: 0; margin: 2.25rem 0 0; }
+.steps li {
+  counter-increment: step;
+  display: grid; grid-template-columns: auto minmax(0,1fr); gap: 1.15rem;
+  padding: 1.15rem 0; border-top: 1px solid var(--rule);
+}
+.steps li:last-child { border-bottom: 1px solid var(--rule); }
+.steps li::before {
+  content: counter(step, decimal-leading-zero);
+  font-family: var(--mono); font-size: 0.875rem; font-weight: 700;
+  color: var(--amber-dim);
+}
+@media (prefers-color-scheme: dark) { .steps li::before { color: var(--amber); } }
+.steps p { margin: 0.35rem 0 0; color: var(--ink-soft); font-size: 0.9375rem; }
+
+/* ── Privacy ledger ────────────────────────────────────────────────────── */
+.ledger { margin-top: 2.5rem; border-top: 1px solid var(--rule); }
+.ledger div {
+  display: flex; align-items: baseline; gap: 1rem;
+  padding: 0.85rem 0; border-bottom: 1px solid var(--rule);
+  font-family: var(--mono); font-size: 0.875rem;
+}
+.ledger dt { flex: 1; margin: 0; color: var(--ink); }
+.ledger dd { margin: 0; color: var(--spade); font-weight: 600; letter-spacing: 0.04em; text-align: right; }
+.ledger dd.is-note { color: var(--ink-soft); font-weight: 400; }
+
+/* ── FAQ ───────────────────────────────────────────────────────────────── */
+.faq { margin-top: 2.5rem; border-top: 1px solid var(--rule); }
+.faq details { border-bottom: 1px solid var(--rule); }
+.faq summary {
+  cursor: pointer; list-style: none;
+  padding: 1.15rem 2rem 1.15rem 0; position: relative;
+  font-weight: 700; letter-spacing: -0.01em;
+}
+.faq summary::-webkit-details-marker { display: none; }
+.faq summary::after {
+  content: "+"; position: absolute; right: 0.25rem; top: 50%;
+  transform: translateY(-50%);
+  font-family: var(--mono); font-weight: 400; color: var(--ink-soft);
+}
+.faq details[open] summary::after { content: "\2013"; }
+.faq p { margin: 0 0 1.25rem; color: var(--ink-soft); max-width: 62ch; font-size: 0.9375rem; }
+
+/* ── Closing call to action ────────────────────────────────────────────── */
+.closer { padding: var(--gap) 0; text-align: center; }
+.closer .actions { justify-content: center; }
+.closer p { color: var(--ink-soft); max-width: 46ch; margin: 1rem auto 0; }
+
+/* ── Footer ────────────────────────────────────────────────────────────── */
+footer { border-top: 1px solid var(--rule); padding: 2.5rem 0 3.5rem; }
+footer .wrap { display: flex; flex-wrap: wrap; gap: 1rem 2rem; align-items: center; }
+footer a { font-family: var(--mono); font-size: 0.8125rem; color: var(--ink-soft); text-decoration: none; }
+footer a:hover { color: var(--ink); text-decoration: underline; }
+footer .disclaim {
+  font-size: 0.8125rem; color: var(--ink-soft); margin: 1.5rem 0 0;
+  max-width: 70ch; line-height: 1.55;
+}
+
+/* ── Long-form document pages (privacy policy) ─────────────────────────── */
+.doc { padding: clamp(2.5rem, 6vw, 4rem) 0 var(--gap); }
+.doc .wrap { max-width: 46rem; }
+.doc h1 { font-size: clamp(1.9rem, 1.2rem + 3vw, 3rem); }
+.doc .stamp {
+  font-family: var(--mono); font-size: 0.8125rem; color: var(--ink-soft);
+  margin: 1rem 0 0;
+}
+.doc h2 {
+  font-size: clamp(1.25rem, 1rem + 1.2vw, 1.6rem);
+  margin: 3rem 0 0; padding-top: 1.75rem; border-top: 1px solid var(--rule);
+}
+.doc h2:first-of-type { margin-top: 2.5rem; }
+.doc p { margin: 1rem 0 0; }
+.doc ul { margin: 1rem 0 0; padding-left: 1.15rem; }
+.doc li { margin: 0.5rem 0 0; }
+.doc strong { font-weight: 700; }
+.doc .intro { font-size: 1.0625rem; }
+.doc a { color: var(--ink); text-decoration-color: var(--rule); text-underline-offset: 3px; }
+.doc a:hover { text-decoration-color: currentColor; }
+
+.doc .tablewrap { overflow-x: auto; margin-top: 1.5rem; }
+.doc table { border-collapse: collapse; width: 100%; min-width: 34rem; font-size: 0.9375rem; }
+.doc th, .doc td { text-align: left; vertical-align: top; padding: 0.8rem 1rem 0.8rem 0; border-bottom: 1px solid var(--rule); }
+.doc th {
+  font-family: var(--mono); font-size: 0.75rem; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--ink-soft); border-bottom-color: var(--ink-soft);
+}
+.doc td:last-child, .doc th:last-child { padding-right: 0; }
+
+/* A short answer column reads better as data than as prose. */
+.doc .ans { font-family: var(--mono); font-size: 0.8125rem; }
+.doc .ans-no { color: var(--spade); font-weight: 600; }
+.doc .ans-yes { color: #B45309; font-weight: 600; }
+@media (prefers-color-scheme: dark) { .doc .ans-yes { color: var(--amber); } }


### PR DESCRIPTION
Four things.

## Punctuation sweep

Removes every em dash (114 of them), middot, en dash and ellipsis character across the site, the app and the repo, replacing each with a colon, comma or period. Extends the existing user-facing-text rule to source comments and config files as well.

The middots were not purely decorative. Alert text used them as separators, so a wildfire read `Wildfire: PARK FIRE Â· 1,200 ac Â· 40% contained`. It now reads `Wildfire: PARK FIRE, 1,200 ac, 40% contained`. Same change for the LCS lane list, chain-control routes, and the per-source status lines in the app. Tests updated to match.

Verified: zero em dashes, en dashes, middots, bullets or ellipsis characters remain anywhere in the repo.

## Site copy

- Cut the `Highway Radar plugin Â· California Â· Free and open source` eyebrow above the headline.
- Reworded the privacy intro. "There is no backend to speak of, because there is no backend. The app talks to public road feeds and to Waze, and that is the whole list." becomes "The app runs entirely on your phone. It reads public road feeds and Waze, and nothing else." The same roundabout sentence in `PRIVACY.md` got the same treatment.

## Privacy policy has its own page

New `docs/privacy.html`, styled to match the site, with the "what leaves your device" table rebuilt as a real table with a scrollable wrapper. The app's Privacy button and the README now open that instead of a Markdown file on GitHub, so it is readable on a phone. Shared CSS extracted to `docs/style.css` so both pages use one stylesheet.

## Highway Radar cache guidance

HR caches the plugin registration it first discovered, so after switching from wzsabre a restart does not always shake it loose and clearing HR's cache is what actually works. Our diagnostics only advised restarting HR, which was incomplete.

The diagnostics report, the README troubleshooting section and the site FAQ now give both steps in order (restart HR, then clear its cache), and all three warn to use **Clear cache** and **not Clear storage**, since Clear storage would erase the user's Highway Radar settings.

Also closed the two stale issues: #1 (chain controls, shipped in v1.6/v1.7 and never closed) and #2 (PulsePoint, blocked on the AES-encrypted API).

## Verification

- 242 tests pass, `lintDebug` clean
- Both site pages: balanced tags, valid JSON-LD, all local assets resolve

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwZeY8xWMzHKhiFkFsZGGW
