### PR TITLE
v1.10.0: bidirectional user reports (HR map + Waze)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.10.0] - 2026-08-12
+
+### Added
+- **Reports you make in Highway Radar now show on the map, and are sent to Waze.** Before this, when you reported something in Highway Radar the plugin quietly ignored it: the report never appeared on your map and never reached Waze, unlike the original wzsabre. Now the plugin keeps your own report and includes it in every update to Highway Radar for about 30 minutes, so it shows on your map right away regardless of anything else. It also submits the report to Waze the way the Waze app does: it snaps the report to the nearest road in your direction of travel and sends it over an anonymous session. A report reaches Waze when your travel direction lines up with a road, which is the normal case when you are driving; if the direction is unknown the map pin still shows.
+- **Confirming an alert and marking one "not there" now reach Waze.** Tapping the thumbs-up on an alert, or reporting that it is not there, now forwards that to Waze instead of doing nothing.
+
 ## [1.9.6] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ An open-source **Highway Radar SABRE plugin** for California, and a drop-in **wz
 
 All sources run in parallel and feed into the standard HR crowdsourced-alerts layer, the same map overlay that wzsabre used to power.
 
+Reports work both ways, like the original wzsabre. When you report something in Highway Radar, it shows on your map right away and is submitted to Waze (snapped to the road you are on, over an anonymous session). Confirming an alert or marking one "not there" reaches Waze too.
+
 ---
 
 ## Screenshots
@@ -236,7 +238,7 @@ Pull requests welcome. Run the test suite before submitting:
 ./gradlew test
 ```
 
-242 unit tests cover the SABRE response format, alert type mapping (incl. Waze category filters), the Waze alert cache (delta merge + soft-delete), in-band Waze error classification, shrinking-box geometry, crowd-confirmation tracking, CHP XML parsing, Caltrans LCS and chain-control parsing and filtering, wildfire (WFIGS) parsing, cross-source de-duplication, the update-check version compare, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup, and [CHANGELOG.md](CHANGELOG.md) for release history.
+293 unit tests cover the SABRE response format, alert type mapping (incl. Waze category filters and report type mapping), report parsing and the road-snap report path (tile decode, segment match, acceptance), the Waze alert cache (delta merge + soft-delete), in-band Waze error classification, shrinking-box geometry, crowd-confirmation tracking, CHP XML parsing, Caltrans LCS and chain-control parsing and filtering, wildfire (WFIGS) parsing, cross-source de-duplication, the update-check version compare, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup, and [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 26
-        versionName = "1.9.6"
+        versionCode = 27
+        versionName = "1.10.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/AlertMapper.java
+++ b/app/src/main/java/app/sabre/wzsabre/AlertMapper.java
@@ -170,4 +170,81 @@ public class AlertMapper {
         String mapped = fromWazeType(type, subtype);
         return mapped != null ? mapped : raw;
     }
+
+    // ── HR report -> Waze report ────────────────────────────────────────────────
+
+    /**
+     * The render-safe SABRE type to echo a user's own HR report back as, so HR
+     * draws the pin. HR's `type` is already a SABRE type; keep it if it starts with
+     * POLICE/HAZARD/ACCIDENT, otherwise remap (e.g. JAM_* / ROAD_CLOSED ->
+     * HAZARD_ON_ROAD_CONGESTION). Null if unusable.
+     */
+    public static String renderableEchoType(String hrType) {
+        if (hrType == null || hrType.isEmpty()) return null;
+        String u = hrType.toUpperCase(Locale.US);
+        if (u.startsWith("POLICE") || u.startsWith("HAZARD") || u.startsWith("ACCIDENT")) return hrType;
+        String mapped = fromWazeType(topLevel(u), u); // reuse the fetch remap
+        return mapped != null ? mapped : null;
+    }
+
+    /** Best-effort top-level Waze type name from a subtype string, for reuse of fromWazeType. */
+    private static String topLevel(String u) {
+        if (u.startsWith("JAM")) return "JAM";
+        if (u.startsWith("ROAD_CLOSED")) return "ROAD_CLOSED";
+        if (u.startsWith("POLICE")) return "POLICE";
+        if (u.startsWith("ACCIDENT")) return "ACCIDENT";
+        return "HAZARD";
+    }
+
+    /** Which Waze AlertDetails member + subtype enum number a reported HR type maps to. */
+    public static WazeReportSubtype wazeReportSubtype(String hrType) {
+        if (hrType == null) return null;
+        String u = hrType.toUpperCase(Locale.US);
+        if (u.equals("POLICE_HIDDEN") || u.equals("POLICE_HIDING"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.POLICE, 2);
+        if (u.startsWith("POLICE"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.POLICE, 1);
+        if (u.equals("ACCIDENT_MAJOR"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.CRASH, 3);
+        if (u.startsWith("ACCIDENT"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.CRASH, 4);
+        if (u.equals("JAM_STAND_STILL_TRAFFIC"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.TRAFFIC, 2);
+        if (u.equals("JAM_LIGHT_TRAFFIC"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.TRAFFIC, 3);
+        if (u.equals("JAM_MODERATE_TRAFFIC"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.TRAFFIC, 4);
+        if (u.startsWith("JAM"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.TRAFFIC, 5);
+        if (u.startsWith("HAZARD")) {
+            int sub = hazardSubtypeNumber(u);
+            return new WazeReportSubtype(WazeReportSubtype.Kind.HAZARD, sub);
+        }
+        return null; // not reportable to Waze (SOS, weather-only, etc.)
+    }
+
+    private static int hazardSubtypeNumber(String u) {
+        if (u.equals("HAZARD_ON_ROAD_CONSTRUCTION")) return 2;
+        if (u.equals("HAZARD_ON_ROAD_CAR_STOPPED")) return 3;
+        if (u.equals("HAZARD_ON_ROAD_OBJECT")) return 4;
+        if (u.equals("HAZARD_ON_ROAD_POT_HOLE")) return 5;
+        if (u.equals("HAZARD_ON_ROAD_TRAFFIC_LIGHT_FAULT")) return 6;
+        if (u.equals("HAZARD_ON_ROAD_OIL")) return 7;
+        if (u.equals("HAZARD_ON_SHOULDER_ANIMALS")) return 8;
+        if (u.equals("HAZARD_ON_SHOULDER_MISSING_SIGN")) return 9;
+        if (u.equals("HAZARD_ON_ROAD_ROAD_KILL")) return 10;
+        if (u.equals("HAZARD_ON_SHOULDER_CAR_STOPPED")) return 12;
+        if (u.equals("HAZARD_ON_SHOULDER")) return 11;
+        return 1; // HAZARD_REPORT_DEFAULT
+    }
+
+    /** Names the Waze AlertDetails member and subtype enum number for a reported type. */
+    public static final class WazeReportSubtype {
+        public enum Kind { POLICE, CRASH, TRAFFIC, HAZARD }
+        public final Kind kind;
+        public final int subtypeNumber;
+        public WazeReportSubtype(Kind kind, int subtypeNumber) {
+            this.kind = kind; this.subtypeNumber = subtypeNumber;
+        }
+    }
 }

--- a/app/src/main/java/app/sabre/wzsabre/ConfirmDiscardRequest.java
+++ b/app/src/main/java/app/sabre/wzsabre/ConfirmDiscardRequest.java
@@ -1,0 +1,32 @@
+package app.sabre.wzsabre;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/** A confirm (thumbs-up) or discard (not-there) forwarded from HR. */
+public final class ConfirmDiscardRequest {
+    public final double lat, lon;
+    public final String alertId;
+    public final boolean test;
+
+    private ConfirmDiscardRequest(double lat, double lon, String alertId, boolean test) {
+        this.lat = lat; this.lon = lon; this.alertId = alertId; this.test = test;
+    }
+
+    public static ConfirmDiscardRequest fromJson(String data) throws JSONException {
+        JSONObject o = new JSONObject(data);
+        double lat = o.has("lat") ? o.getDouble("lat") : o.getDouble("latitude");
+        double lon = o.has("lon") ? o.getDouble("lon") : o.getDouble("longitude");
+        return new ConfirmDiscardRequest(lat, lon, o.optString("alert_id", null),
+                o.optBoolean("test", false));
+    }
+
+    /** Numeric Waze alert id embedded in alertId ("alert-<id>/<uuid>"), or -1. */
+    public long wazeAlertId() {
+        if (alertId == null) return -1L;
+        String s = alertId.startsWith("alert-") ? alertId.substring("alert-".length()) : alertId;
+        int slash = s.indexOf('/');
+        if (slash >= 0) s = s.substring(0, slash);
+        try { return Long.parseLong(s.trim()); } catch (NumberFormatException e) { return -1L; }
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
@@ -49,6 +49,12 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
                 final double lat = numberExtra(intent, "lat", 37.8044);
                 final double lon = numberExtra(intent, "lon", -122.2712);
                 new Thread(() -> app.sabre.wzsabre.waze.WazeProtocolSource.selfTest(lat, lon)).start();
+            } else if (BuildConfig.DEBUG && action != null && action.endsWith(".REPORT_TEST")) {
+                // Debug-only: exercise the Waze report write path without HR.
+                final double lat = numberExtra(intent, "lat", 37.8044);
+                final double lon = numberExtra(intent, "lon", -122.2712);
+                final String type = intent.hasExtra("type") ? intent.getStringExtra("type") : "POLICE_VISIBLE";
+                new Thread(() -> app.sabre.wzsabre.waze.WazeReporter.selfTest(context, lat, lon, type)).start();
             } else if (BuildConfig.DEBUG && action != null && action.endsWith(".INJECT_TEST")) {
                 // Debug-only: toggle synthetic one-of-each-type alerts to validate HR rendering.
                 SabreService.injectTestAlerts = intent.getBooleanExtra("on", true);

--- a/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
@@ -26,6 +26,10 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
                 // listen for it or that user gets zero data.
                 DebugLog.noteFetchAction(action);
                 ForegroundServiceStarter.start(context, "FETCH_REQUEST", intent.getStringExtra("data"));
+            } else if (classifyReportAction(action) != null) {
+                String kind = classifyReportAction(action);
+                Log.d(TAG, "Report-channel action: " + action + " -> " + kind);
+                ForegroundServiceStarter.start(context, kind, intent.getStringExtra("data"));
             } else if (action != null && action.contains("SHUTDOWN")) {
                 // HR is ending the session (it usually reopens one shortly). Forward
                 // to the service so it stops after a short grace period; a new session
@@ -56,6 +60,20 @@ public class MainBroadcastReceiver extends BroadcastReceiver {
         } catch (Exception e) {
             Log.e(TAG, "Error handling broadcast", e);
         }
+    }
+
+    /**
+     * Classify an HR report-channel action to a normalized label, or null if the
+     * action is not a report/confirm/discard. CONFIRM/DISCARD are checked before
+     * REPORT so the legacy CONFIRM_REPORT/DISCARD_REPORT names do not fall into the
+     * REPORT branch (all three end in "REPORT").
+     */
+    static String classifyReportAction(String action) {
+        if (action == null) return null;
+        if (action.contains("CONFIRM")) return "CONFIRM";
+        if (action.contains("DISCARD")) return "DISCARD";
+        if (action.endsWith("REPORT"))  return "REPORT";
+        return null;
     }
 
     /**

--- a/app/src/main/java/app/sabre/wzsabre/ReportRequest.java
+++ b/app/src/main/java/app/sabre/wzsabre/ReportRequest.java
@@ -1,0 +1,31 @@
+package app.sabre.wzsabre;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/** A user-created report forwarded from HR (app.sabre.wzsabre.REPORT). */
+public final class ReportRequest {
+    public final double lat, lon, headingDeg, altitudeM;
+    public final String type;
+    public final boolean isOpposite;
+    public final int timeDeltaS;
+
+    private ReportRequest(double lat, double lon, double headingDeg, double altitudeM,
+                          String type, boolean isOpposite, int timeDeltaS) {
+        this.lat = lat; this.lon = lon; this.headingDeg = headingDeg; this.altitudeM = altitudeM;
+        this.type = type; this.isOpposite = isOpposite; this.timeDeltaS = timeDeltaS;
+    }
+
+    public static ReportRequest fromJson(String data) throws JSONException {
+        JSONObject o = new JSONObject(data);
+        double lat = o.has("lat") ? o.getDouble("lat") : o.getDouble("latitude");
+        double lon = o.has("lon") ? o.getDouble("lon") : o.getDouble("longitude");
+        String type = o.getString("type");
+        return new ReportRequest(lat, lon,
+                o.optDouble("heading_deg", -720.0),
+                o.optDouble("altitude_m", 0.0),
+                type,
+                o.optBoolean("is_opposite", false),
+                o.optInt("time_delta_s", 0));
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -64,6 +64,8 @@ public class SabreService extends Service {
     private WildfireSource fireSource;
     private WinterSource chainsSource;
     private app.sabre.wzsabre.waze.WazeProtocolSource wazeSource;
+    private final UserReportStore userReportStore = new UserReportStore();
+    private app.sabre.wzsabre.waze.WazeReporter wazeReporter;
 
     // Last fetch location, persisted so the Waze session can be pre-warmed at the
     // next service start (HR's handshake starts the service before its first
@@ -84,6 +86,7 @@ public class SabreService extends Service {
         fireSource = new WildfireSource();
         chainsSource = new WinterSource();
         wazeSource = new app.sabre.wzsabre.waze.WazeProtocolSource(this);
+        wazeReporter = new app.sabre.wzsabre.waze.WazeReporter(this);
         createNotificationChannel();
         startForeground(NOTIFICATION_ID, buildForegroundNotification());
         chpSource.prewarm();          // statewide feed: no location needed
@@ -188,6 +191,16 @@ public class SabreService extends Service {
         armIdleStop();
         if (action != null && action.contains("FETCH_REQUEST")) {
             handleFetchRequest(intent.getStringExtra("data"));
+        }
+        if (action != null && action.equals("REPORT")) {
+            final String data = intent.getStringExtra("data");
+            requestExecutor.submit(() -> handleReport(data));
+        } else if (action != null && action.equals("CONFIRM")) {
+            final String data = intent.getStringExtra("data");
+            requestExecutor.submit(() -> handleConfirmDiscard(data, true));
+        } else if (action != null && action.equals("DISCARD")) {
+            final String data = intent.getStringExtra("data");
+            requestExecutor.submit(() -> handleConfirmDiscard(data, false));
         }
         return START_STICKY;
     }
@@ -343,6 +356,10 @@ public class SabreService extends Service {
                     allAlerts.addAll(buildTestAlerts(testLat, testLon));
                 }
 
+                // Echo the user's own recent reports so HR draws the pin immediately,
+                // independent of whether Waze accepted the report.
+                allAlerts.addAll(userReportStore.activeAlerts(lat, lon, radius, System.currentTimeMillis()));
+
                 // Collapse duplicate pins across sources (e.g. CHP + Waze accident at
                 // the same spot) before sending.
                 int rawCount = allAlerts.size();
@@ -361,6 +378,35 @@ public class SabreService extends Service {
                 }
             }
         });
+    }
+
+    private void handleReport(String data) {
+        try {
+            ReportRequest r = ReportRequest.fromJson(data);
+            // 1) Echo to the HR map immediately (guaranteed pin, independent of Waze).
+            userReportStore.add(r, System.currentTimeMillis());
+            // 2) Push to Waze (best-effort).
+            boolean ok = wazeReporter.submit(r);
+            Log.d(TAG, "Report handled: type=" + r.type + " wazeAccepted=" + ok);
+        } catch (Exception e) {
+            Log.w(TAG, "Bad REPORT payload: " + e.getMessage());
+        }
+    }
+
+    private void handleConfirmDiscard(String data, boolean confirm) {
+        try {
+            ConfirmDiscardRequest c = ConfirmDiscardRequest.fromJson(data);
+            if (c.test) { Log.d(TAG, "test " + (confirm ? "confirm" : "discard") + ", not sending"); return; }
+            long id = c.wazeAlertId();
+            if (confirm) {
+                wazeReporter.confirm(c.lat, c.lon, id);
+            } else {
+                wazeReporter.discard(c.lat, c.lon, id);
+                userReportStore.removeNear(c.lat, c.lon, System.currentTimeMillis()); // drop own echo if any
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Bad CONFIRM/DISCARD payload: " + e.getMessage());
+        }
     }
 
     private void sendErrorResponse(String responseAction, String requestId, Exception cause)

--- a/app/src/main/java/app/sabre/wzsabre/SabreService.java
+++ b/app/src/main/java/app/sabre/wzsabre/SabreService.java
@@ -59,6 +59,11 @@ public class SabreService extends Service {
     // response would come back empty until the queue drained.
     private ExecutorService requestExecutor;
     private ExecutorService fetchExecutor;
+    // REPORT/CONFIRM/DISCARD run here, never on requestExecutor: a slow Waze report
+    // submission (cold-start register/login/handshake can take 10-20s) queued ahead
+    // of a FETCH_REQUEST on a shared single-thread executor would stall that fetch
+    // past HR's ~8s budget, causing a "plugin not responding" banner.
+    private ExecutorService reportExecutor;
     private CHPSource chpSource;
     private LcsSource lcsSource;
     private WildfireSource fireSource;
@@ -81,6 +86,7 @@ public class SabreService extends Service {
         DebugLog.event("service started");
         requestExecutor = Executors.newSingleThreadExecutor();
         fetchExecutor   = Executors.newFixedThreadPool(5);
+        reportExecutor  = Executors.newSingleThreadExecutor();
         chpSource  = new CHPSource();
         lcsSource  = new LcsSource();
         fireSource = new WildfireSource();
@@ -194,13 +200,13 @@ public class SabreService extends Service {
         }
         if (action != null && action.equals("REPORT")) {
             final String data = intent.getStringExtra("data");
-            requestExecutor.submit(() -> handleReport(data));
+            reportExecutor.submit(() -> handleReport(data));
         } else if (action != null && action.equals("CONFIRM")) {
             final String data = intent.getStringExtra("data");
-            requestExecutor.submit(() -> handleConfirmDiscard(data, true));
+            reportExecutor.submit(() -> handleConfirmDiscard(data, true));
         } else if (action != null && action.equals("DISCARD")) {
             final String data = intent.getStringExtra("data");
-            requestExecutor.submit(() -> handleConfirmDiscard(data, false));
+            reportExecutor.submit(() -> handleConfirmDiscard(data, false));
         }
         return START_STICKY;
     }
@@ -232,6 +238,7 @@ public class SabreService extends Service {
         lifecycleHandler.removeCallbacks(stopRunnable);
         if (requestExecutor != null) requestExecutor.shutdownNow();
         if (fetchExecutor   != null) fetchExecutor.shutdownNow();
+        if (reportExecutor  != null) reportExecutor.shutdownNow();
         if (wazeSource != null) wazeSource.shutdown();
         if (lcsSource  != null) lcsSource.shutdown();
         if (chpSource  != null) chpSource.shutdown();

--- a/app/src/main/java/app/sabre/wzsabre/UserReportStore.java
+++ b/app/src/main/java/app/sabre/wzsabre/UserReportStore.java
@@ -24,6 +24,10 @@ public final class UserReportStore {
     public synchronized void add(ReportRequest r, long nowMs) {
         String type = AlertMapper.renderableEchoType(r.type);
         if (type == null) return; // nothing HR would draw
+        // The response builder drops any type not in its VALID_TYPES set. Guarantee the
+        // echo renders by falling back to a known-valid renderable type when the mapped
+        // type is renderable-prefixed but not in that set.
+        if (!SabreResponseBuilder.isValidType(type)) type = "HAZARD_ON_ROAD_DEBRIS";
         String id = "alert-0/userreport-" + nowMs;
         long reportTs = (nowMs / 1000L) - r.timeDeltaS;
         SabreAlert a = new SabreAlert(id, SabreResponseBuilder.SOURCE_WAZE, type,

--- a/app/src/main/java/app/sabre/wzsabre/UserReportStore.java
+++ b/app/src/main/java/app/sabre/wzsabre/UserReportStore.java
@@ -1,0 +1,65 @@
+package app.sabre.wzsabre;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Holds the user's own HR reports for a while so every HR fetch echoes them back
+ * and HR draws the pin, independent of whether Waze accepts the report. In-memory,
+ * thread-safe, entries expire after {@link #TTL_MS}.
+ */
+public final class UserReportStore {
+    public static final long TTL_MS = 30 * 60 * 1000L;
+    private static final double MATCH_RADIUS_M = 120.0;
+
+    private static final class Entry {
+        final SabreAlert alert;
+        final long addedMs;
+        Entry(SabreAlert a, long t) { alert = a; addedMs = t; }
+    }
+
+    private final List<Entry> entries = new ArrayList<>();
+
+    public synchronized void add(ReportRequest r, long nowMs) {
+        String type = AlertMapper.renderableEchoType(r.type);
+        if (type == null) return; // nothing HR would draw
+        String id = "alert-0/userreport-" + nowMs;
+        long reportTs = (nowMs / 1000L) - r.timeDeltaS;
+        SabreAlert a = new SabreAlert(id, SabreResponseBuilder.SOURCE_WAZE, type,
+                r.lat, r.lon, r.headingDeg, null, reportTs, null, 0);
+        entries.add(new Entry(a, nowMs));
+    }
+
+    public synchronized List<SabreAlert> activeAlerts(double lat, double lon,
+                                                      double radiusM, long nowMs) {
+        purge(nowMs);
+        List<SabreAlert> out = new ArrayList<>();
+        for (Entry e : entries) {
+            if (distanceM(lat, lon, e.alert.lat, e.alert.lon) <= radiusM) out.add(e.alert);
+        }
+        return out;
+    }
+
+    public synchronized void removeNear(double lat, double lon, long nowMs) {
+        purge(nowMs);
+        for (Iterator<Entry> it = entries.iterator(); it.hasNext(); ) {
+            Entry e = it.next();
+            if (distanceM(lat, lon, e.alert.lat, e.alert.lon) <= MATCH_RADIUS_M) it.remove();
+        }
+    }
+
+    private void purge(long nowMs) {
+        for (Iterator<Entry> it = entries.iterator(); it.hasNext(); ) {
+            if (nowMs - it.next().addedMs > TTL_MS) it.remove();
+        }
+    }
+
+    private static double distanceM(double lat1, double lon1, double lat2, double lon2) {
+        double mPerDegLat = 110574.0;
+        double mPerDegLon = 111320.0 * Math.cos(Math.toRadians((lat1 + lat2) / 2.0));
+        double dy = (lat1 - lat2) * mPerDegLat;
+        double dx = (lon1 - lon2) * mPerDegLon;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/waze/LatLon.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/LatLon.java
@@ -1,0 +1,15 @@
+package app.sabre.wzsabre.waze;
+
+/**
+ * Minimal lat/lon value type for road-snap geometry (WZDF tile decode, segment
+ * matching). Pure Java, no Android APIs, so it stays plain-JVM testable.
+ */
+final class LatLon {
+    public final double lat;
+    public final double lon;
+
+    LatLon(double lat, double lon) {
+        this.lat = lat;
+        this.lon = lon;
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/waze/ReportResult.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/ReportResult.java
@@ -1,0 +1,14 @@
+package app.sabre.wzsabre.waze;
+
+/** Outcome of a Waze report submission. */
+final class ReportResult {
+    final boolean accepted;
+    final String uuid;
+    final int points;
+    final String error;
+    private ReportResult(boolean a, String u, int p, String e) {
+        accepted = a; uuid = u; points = p; error = e;
+    }
+    static ReportResult ok(String uuid, int points) { return new ReportResult(true, uuid, points, null); }
+    static ReportResult fail(String error) { return new ReportResult(false, null, -1, error); }
+}

--- a/app/src/main/java/app/sabre/wzsabre/waze/RoadGeo.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/RoadGeo.java
@@ -1,0 +1,114 @@
+package app.sabre.wzsabre.waze;
+
+import java.util.List;
+
+/**
+ * Segment-snap geometry: nearest-road matching for a GPS point + heading, used
+ * to attach directional SegmentNodes to a Waze report before submission. Pure
+ * Java (no Android APIs), so it stays plain-JVM testable.
+ *
+ * Ported from wzsabre 2.2 wazemo.GeoUtils (computeHeading / pointToSegmentDist /
+ * minDistToPolyline / findMatchingSegment), adapted from Coord to our LatLon.
+ * Named RoadGeo (not GeoUtils) to avoid clashing with any future GeoBoxes-style
+ * general geo helper in this package.
+ */
+final class RoadGeo {
+    private RoadGeo() {}
+
+    /** Bearing from `a` to `b`, rounded to an int degree in [0,360). */
+    static int computeHeading(LatLon a, LatLon b) {
+        double bearing = Math.toDegrees(Math.atan2(
+                (b.lon - a.lon) * Math.cos(Math.toRadians((a.lat + b.lat) / 2.0)),
+                b.lat - a.lat));
+        return (int) Math.round((bearing + 360.0) % 360.0);
+    }
+
+    /**
+     * Nearest road segment to `pos` among `segs`: the candidate whose minimum
+     * perpendicular distance to `pos` is smallest, restricted to segments whose
+     * heading (forward OR reverse direction) is within `maxAngleDiff` degrees of
+     * `heading` AND whose distance is within `maxDistM` meters. Returns null if
+     * no segment qualifies. `SegmentMatch.reverse` is true when the segment's
+     * reverse-direction heading is the closer match, so the caller can pick the
+     * correct directional from/to node order.
+     */
+    static SegmentMatch findMatchingSegment(LatLon pos, double heading, List<RoadSegment> segs,
+            double maxAngleDiff, double maxDistM) {
+        SegmentMatch best = null;
+        double bestDist = Double.MAX_VALUE;
+        for (RoadSegment seg : segs) {
+            double dist = minDistToPolylineM(pos, seg.points);
+            double fwdAngleDiff = angleDiff180(seg.heading, heading);
+            double backAngleDiff = angleDiff180(seg.heading + 180, heading);
+            if (Math.min(fwdAngleDiff, backAngleDiff) <= maxAngleDiff
+                    && dist <= maxDistM
+                    && dist < bestDist) {
+                best = new SegmentMatch(seg, backAngleDiff < fwdAngleDiff);
+                bestDist = dist;
+            }
+        }
+        return best;
+    }
+
+    /**
+     * Absolute angular difference in [0,180] between headings `a` and `b`
+     * degrees. Ported literally from the reference's Kotlin `%` normalization:
+     * Kotlin's `%` (like Java's) can return a negative remainder for a negative
+     * dividend, so the intermediate is folded back into [0,360) before taking
+     * the distance from 180.
+     */
+    private static double angleDiff180(double a, double b) {
+        double diff = ((a - b) + 180.0) % 360.0;
+        if (diff != 0.0 && Math.signum(diff) != Math.signum(360.0)) {
+            diff += 360.0;
+        }
+        return Math.abs(diff - 180.0);
+    }
+
+    /** Minimum perpendicular distance in meters from `point` to a polyline. */
+    private static double minDistToPolylineM(LatLon point, List<LatLon> points) {
+        if (points.isEmpty()) {
+            return Double.MAX_VALUE;
+        }
+        if (points.size() == 1) {
+            return pointToSegmentDistM(point, points.get(0), points.get(0));
+        }
+        double min = Double.MAX_VALUE;
+        for (int i = 0; i < points.size() - 1; i++) {
+            min = Math.min(min, pointToSegmentDistM(point, points.get(i), points.get(i + 1)));
+        }
+        return min;
+    }
+
+    /**
+     * Perpendicular distance in meters from `point` to the segment
+     * [segStart, segEnd], via an equirectangular meters projection local to
+     * the segment's average latitude (matches wzsabre 2.2
+     * GeoUtils.pointToSegmentDist, including its degenerate-segment fallback
+     * to a straight point-to-point distance when segStart == segEnd).
+     */
+    private static double pointToSegmentDistM(LatLon point, LatLon segStart, LatLon segEnd) {
+        double mPerDegLon = WazeConstants.mPerDegLon((segStart.lat + segEnd.lat) / 2.0);
+        double ax = segStart.lon * mPerDegLon;
+        double ay = segStart.lat * WazeConstants.M_PER_DEG_LAT;
+        double bx = segEnd.lon * mPerDegLon;
+        double by = segEnd.lat * WazeConstants.M_PER_DEG_LAT;
+        double px = point.lon * mPerDegLon;
+        double py = point.lat * WazeConstants.M_PER_DEG_LAT;
+
+        double dx = bx - ax;
+        double dy = by - ay;
+        double lenSq = (dx * dx) + (dy * dy);
+        if (lenSq == 0.0) {
+            return Math.sqrt(Math.pow(px - ax, 2.0) + Math.pow(py - ay, 2.0));
+        }
+        double rx = px - ax;
+        double ry = py - ay;
+        double t = clamp(((rx * dx) + (ry * dy)) / lenSq, 0.0, 1.0);
+        return Math.sqrt(Math.pow(rx - (dx * t), 2.0) + Math.pow(ry - (dy * t), 2.0));
+    }
+
+    private static double clamp(double v, double lo, double hi) {
+        return Math.max(lo, Math.min(hi, v));
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/waze/RoadSegment.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/RoadSegment.java
@@ -1,0 +1,24 @@
+package app.sabre.wzsabre.waze;
+
+import java.util.List;
+
+/**
+ * A road-graph segment decoded from a WZDF tile: two tile-local node indices
+ * and the polyline geometry between them. Ported from wzsabre 2.2
+ * wazemo.RoadSegment (point type adapted from Coord to our LatLon).
+ */
+final class RoadSegment {
+    public final long segmentId;
+    public final long fromNode;
+    public final long toNode;
+    public final int heading;
+    public final List<LatLon> points;
+
+    RoadSegment(long segmentId, long fromNode, long toNode, int heading, List<LatLon> points) {
+        this.segmentId = segmentId;
+        this.fromNode = fromNode;
+        this.toNode = toNode;
+        this.heading = heading;
+        this.points = points;
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/waze/SegmentMatch.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/SegmentMatch.java
@@ -1,0 +1,28 @@
+package app.sabre.wzsabre.waze;
+
+/**
+ * A road segment matched to a GPS position + heading, with the winning
+ * direction (forward vs reverse) resolved by RoadGeo.findMatchingSegment.
+ * Ported from wzsabre 2.2 wazemo.SegmentMatch (directional node accessors;
+ * distanceM is not carried here since our submitReport sequence does not
+ * need it, unlike the reference's UI use).
+ */
+final class SegmentMatch {
+    public final RoadSegment segment;
+    public final boolean reverse;
+
+    SegmentMatch(RoadSegment segment, boolean reverse) {
+        this.segment = segment;
+        this.reverse = reverse;
+    }
+
+    /** Node the report should list as the segment's "from" (direction-aware). */
+    long fromNodeDirectional() {
+        return reverse ? segment.toNode : segment.fromNode;
+    }
+
+    /** Node the report should list as the segment's "to" (direction-aware). */
+    long toNodeDirectional() {
+        return reverse ? segment.fromNode : segment.toNode;
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeHttpClient.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeHttpClient.java
@@ -78,6 +78,23 @@ final class WazeHttpClient {
         throw last;
     }
 
+    /** Ported from wzsabre 2.2 wazemo.WazeHttpClient.get: plain GET, no body. */
+    HttpResult get(String url, Map<String, String> headers) throws IOException {
+        Request.Builder rb = new Request.Builder()
+                .url(url)
+                .get();
+        if (headers != null) {
+            for (Map.Entry<String, String> e : headers.entrySet()) {
+                if (e.getValue() != null) rb.header(e.getKey(), e.getValue());
+            }
+        }
+        Request request = rb.build();
+        try (Response resp = client.newCall(request).execute()) {
+            byte[] b = resp.body() != null ? resp.body().bytes() : new byte[0];
+            return new HttpResult(resp.code(), b);
+        }
+    }
+
     /** Simple in-memory cookie jar scoped to one Waze session. */
     private static final class SessionCookieJar implements CookieJar {
         private final List<Cookie> cookies = new ArrayList<>();

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeReportCodec.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeReportCodec.java
@@ -1,0 +1,89 @@
+package app.sabre.wzsabre.waze;
+
+import app.sabre.wzsabre.AlertMapper;
+import app.sabre.wzsabre.ReportRequest;
+
+/**
+ * Assembles the Waze AddUserReportedAlertRequest protobuf from a user's HR report,
+ * and reads the response uuid/points. Pure WazeProto (no android.util.Base64), so
+ * it is JVM-testable; the Base64 line framing lives in WazeRtCodec.
+ */
+final class WazeReportCodec {
+    private WazeReportCodec() {}
+
+    static WazeProto.AddUserReportedAlertRequest buildRequest(
+            ReportRequest r, long nowMs, long fromNode, long toNode) {
+        AlertMapper.WazeReportSubtype sub = AlertMapper.wazeReportSubtype(r.type);
+        if (sub == null) return null;
+
+        WazeProto.CoordinateWithAlt coord = WazeProto.CoordinateWithAlt.newBuilder()
+                .setLonTimes1000000((int) Math.round(r.lon * 1_000_000.0))
+                .setLatTimes1000000((int) Math.round(r.lat * 1_000_000.0))
+                .setAltTimes1000000((int) Math.round(r.altitudeM * 1_000_000.0))
+                .build();
+        WazeProto.GpsPosition gps = WazeProto.GpsPosition.newBuilder()
+                .setCoordinate(coord)
+                .setHorizontalAccuracyMeters(10.0)
+                .setTimeEpochMs(nowMs)
+                .build();
+        WazeProto.UserPosition.Builder pos = WazeProto.UserPosition.newBuilder().setGpsPosition(gps);
+        if (fromNode != 0 || toNode != 0) {
+            pos.setSegmentNodes(WazeProto.SegmentNodes.newBuilder()
+                    .setFromNode(fromNode).setToNode(toNode).build());
+        }
+
+        WazeProto.AddUserReportedAlertRequest.Builder b =
+                WazeProto.AddUserReportedAlertRequest.newBuilder()
+                .setUserPosition(pos.build())
+                .setAzymuth((int) Math.round(r.headingDeg))
+                .setAlertDetails(buildDetails(sub))
+                .setSegmentDirection(r.isOpposite
+                        ? WazeProto.SegmentDirection.SEGMENT_DIRECTION_BACKWARD
+                        : WazeProto.SegmentDirection.SEGMENT_DIRECTION_FORWARD)
+                .setReportTime(WazeProto.Timestamp.newBuilder()
+                        .setSeconds((nowMs / 1000L) - r.timeDeltaS).build())
+                .setReportingManner(WazeProto.ReportingManner.REPORTING_MANNER_DEFAULT);
+        return b.build();
+    }
+
+    private static WazeProto.AlertDetails buildDetails(AlertMapper.WazeReportSubtype sub) {
+        WazeProto.AlertDetails.Builder d = WazeProto.AlertDetails.newBuilder();
+        switch (sub.kind) {
+            case POLICE:
+                d.setPolice(WazeProto.PoliceDetails.newBuilder()
+                        .setType(WazeProto.PoliceAlertSubType.forNumber(sub.subtypeNumber)));
+                break;
+            case CRASH:
+                d.setCrash(WazeProto.CrashDetails.newBuilder()
+                        .setType(WazeProto.CrashReportSubType.forNumber(sub.subtypeNumber)));
+                break;
+            case TRAFFIC:
+                d.setTraffic(WazeProto.TrafficDetails.newBuilder()
+                        .setType(WazeProto.TrafficReportSubType.forNumber(sub.subtypeNumber)));
+                break;
+            case HAZARD:
+                d.setHazardOnRoad(WazeProto.HazardOnRoadDetails.newBuilder()
+                        .setType(WazeProto.HazardReportSubType.forNumber(sub.subtypeNumber)));
+                break;
+        }
+        return d.build();
+    }
+
+    static String reportUuidFrom(WazeProto.Batch batch) {
+        for (WazeProto.Element el : batch.getElementList()) {
+            if (el.hasAddUserReportedAlertResponse()) {
+                String u = el.getAddUserReportedAlertResponse().getAlertUuid();
+                if (u != null && !u.isEmpty()) return u;
+            }
+        }
+        return null;
+    }
+
+    static int reportPointsFrom(WazeProto.Batch batch) {
+        for (WazeProto.Element el : batch.getElementList()) {
+            if (el.hasAddUserReportedAlertResponse())
+                return el.getAddUserReportedAlertResponse().getReceivedPointsCount();
+        }
+        return -1;
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeReportCodec.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeReportCodec.java
@@ -69,6 +69,27 @@ final class WazeReportCodec {
         return d.build();
     }
 
+    /**
+     * Live-Waze finding: a snapped report (with SegmentNodes) comes back with
+     * received_points_count > 0, status=STATUS_UNSPECIFIED (the default), and
+     * an EMPTY alert_uuid on anonymous accounts, while a position-only report
+     * (no SegmentNodes) gets no response element back at all. So the presence
+     * of an AddUserReportedAlertResponse element that isn't an explicit
+     * FAILURE is the acceptance signal, not a non-empty uuid.
+     */
+    static boolean reportAccepted(WazeProto.Batch batch) {
+        for (WazeProto.Element el : batch.getElementList()) {
+            if (el.hasAddUserReportedAlertResponse()) {
+                WazeProto.AddUserReportedAlertResponse.AddAlertStatus status =
+                        el.getAddUserReportedAlertResponse().getStatus();
+                if (status != WazeProto.AddUserReportedAlertResponse.AddAlertStatus.FAILURE) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     static String reportUuidFrom(WazeProto.Batch batch) {
         for (WazeProto.Element el : batch.getElementList()) {
             if (el.hasAddUserReportedAlertResponse()) {

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeReportCodec.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeReportCodec.java
@@ -32,10 +32,16 @@ final class WazeReportCodec {
                     .setFromNode(fromNode).setToNode(toNode).build());
         }
 
+        // Normalize to [0,360), matching WazeSession.submitReport's normalizeAngle360
+        // for the At command. HR omits heading by defaulting ReportRequest.headingDeg
+        // to the -720 sentinel, which must not be sent to Waze as-is.
+        int azymuth = (int) (Math.round(r.headingDeg) % 360);
+        if (azymuth < 0) azymuth += 360;
+
         WazeProto.AddUserReportedAlertRequest.Builder b =
                 WazeProto.AddUserReportedAlertRequest.newBuilder()
                 .setUserPosition(pos.build())
-                .setAzymuth((int) Math.round(r.headingDeg))
+                .setAzymuth(azymuth)
                 .setAlertDetails(buildDetails(sub))
                 .setSegmentDirection(r.isOpposite
                         ? WazeProto.SegmentDirection.SEGMENT_DIRECTION_BACKWARD

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeReporter.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeReporter.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
 
-import app.sabre.wzsabre.ConfirmDiscardRequest;
 import app.sabre.wzsabre.ReportRequest;
 
 /**

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeReporter.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeReporter.java
@@ -12,6 +12,15 @@ import app.sabre.wzsabre.ReportRequest;
  * read path (same SharedPreferences file/keys), so reporting doesn't register an
  * extra account, Waze caps anonymous accounts per day.
  *
+ * <p>This is a READ-ONLY consumer of that shared account: it never registers its
+ * own account (only {@link WazeProtocolSource}'s {@code canRegisterToday()}/
+ * {@code recordRegistration()} accounting is allowed to mint one) and never deletes
+ * the shared {@code community}/{@code secret} credentials (deleting them here would
+ * force the read path to re-register too). If no account has been minted yet,
+ * {@link #ensureSession} fails and the report is not sent to Waze; the HR echo pin
+ * still shows via {@link app.sabre.wzsabre.UserReportStore}, and once the read path
+ * mints an account on its next fetch, subsequent reports succeed.
+ *
  * <p>This runs a separate {@link WazeSession} from the read path but shares the
  * account. A login on one session can log the other out server-side; both sessions
  * re-login on {@code SessionExpiredException}, so this self-heals. Not redesigned
@@ -72,34 +81,33 @@ public final class WazeReporter {
         SharedPreferences p = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
         String community = p.getString("community", null);
         String secret = p.getString("secret", null);
-        WazeCredentials creds = (community != null && secret != null)
-                ? new WazeCredentials(community, secret) : null;
+        if (community == null || secret == null) {
+            // No shared account minted yet. The write path must never register one
+            // itself (only WazeProtocolSource's canRegisterToday()/recordRegistration()
+            // accounting is allowed to do that) - so fail gracefully. The HR echo pin
+            // still shows; the read path mints the account on its next fetch, after
+            // which reports succeed.
+            throw new WazeExceptions.WazeOperationException(
+                    "no shared Waze account yet; report not sent to Waze");
+        }
+        WazeCredentials creds = new WazeCredentials(community, secret);
         DeviceIdentity dev = new DeviceIdentity(
                 p.getString("dev_mfr", "Google"), p.getString("dev_model", "Pixel 8"),
                 p.getString("dev_os", "15-SDK35"),
                 p.getInt("dev_w", 1080), p.getInt("dev_h", 2400),
                 p.getString("dev_iid", java.util.UUID.randomUUID().toString()));
         WazeSession s = new WazeSession(region, dev, creds);
-        s.prepareForArea(lat, lon); // registers if needed + logs in + handshake
-        // Persist any newly minted account under the SAME keys as the read path.
-        WazeCredentials got = s.getCredentials();
-        if (got != null && (community == null || secret == null)) {
-            p.edit().putString("community", got.community).putString("secret", got.secret)
-             .putString("dev_mfr", dev.manufacturer).putString("dev_model", dev.model)
-             .putString("dev_os", dev.osVersion).putInt("dev_w", dev.screenW).putInt("dev_h", dev.screenH)
-             .putString("dev_iid", dev.installationId).apply();
-        }
+        s.prepareForArea(lat, lon); // creds are non-null, so this only logs in + handshake, never registers
         session = s;
         return s;
     }
 
     private void invalidateOnAuthError(Exception e) {
         if (e instanceof WazeExceptions.AccountRejectedException) {
+            // Drop only this reporter's in-memory session, not the shared credentials:
+            // WazeProtocolSource (the read path) owns the shared account's lifecycle, so
+            // deleting community/secret here would force the read path to re-register too.
             session = null;
-            // Only drop the credentials, leave reg_count/reg_window_start (rate-limit
-            // state) and device keys alone, matching WazeProtocolSource's contract.
-            ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()
-               .remove("community").remove("secret").apply();
         } else if (e instanceof WazeExceptions.SessionExpiredException && session != null) {
             session.invalidateSession();
         }

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeReporter.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeReporter.java
@@ -1,0 +1,118 @@
+package app.sabre.wzsabre.waze;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import app.sabre.wzsabre.ConfirmDiscardRequest;
+import app.sabre.wzsabre.ReportRequest;
+
+/**
+ * Owns a Waze RT session for the WRITE path (report/confirm/discard). Reuses the
+ * SAME persisted anonymous account that {@link WazeProtocolSource} mints for the
+ * read path (same SharedPreferences file/keys), so reporting doesn't register an
+ * extra account, Waze caps anonymous accounts per day.
+ *
+ * <p>This runs a separate {@link WazeSession} from the read path but shares the
+ * account. A login on one session can log the other out server-side; both sessions
+ * re-login on {@code SessionExpiredException}, so this self-heals. Not redesigned
+ * to share a single session (see Task 8 brief).
+ */
+public final class WazeReporter {
+    private static final String TAG = "WazeRT";
+    private static final String PREFS = "waze_rt"; // must match WazeProtocolSource
+
+    private final Context ctx;
+    private WazeSession session;
+
+    public WazeReporter(Context ctx) { this.ctx = ctx.getApplicationContext(); }
+
+    /** Submit a new report. Runs on the caller's worker thread. Returns accepted. */
+    public synchronized boolean submit(ReportRequest r) {
+        try {
+            WazeSession s = ensureSession(r.lat, r.lon);
+            ReportResult res = s.submitReport(r, System.currentTimeMillis());
+            if (!res.accepted) Log.w(TAG, "Report not accepted: " + res.error);
+            return res.accepted;
+        } catch (Exception e) {
+            Log.w(TAG, "submit failed: " + e.getMessage());
+            invalidateOnAuthError(e);
+            return false;
+        }
+    }
+
+    /** Thumbs-up an existing Waze alert. */
+    public synchronized void confirm(double lat, double lon, long wazeId) {
+        if (wazeId < 0) return;
+        try {
+            WazeSession s = ensureSession(lat, lon);
+            s.prepareForArea(lat, lon);
+            s.confirmAlert(wazeId);
+        } catch (Exception e) {
+            Log.w(TAG, "confirm failed: " + e.getMessage());
+            invalidateOnAuthError(e);
+        }
+    }
+
+    /** Report an existing Waze alert as not there. */
+    public synchronized void discard(double lat, double lon, long wazeId) {
+        if (wazeId < 0) return;
+        try {
+            WazeSession s = ensureSession(lat, lon);
+            s.prepareForArea(lat, lon);
+            s.discardAlert(wazeId);
+        } catch (Exception e) {
+            Log.w(TAG, "discard failed: " + e.getMessage());
+            invalidateOnAuthError(e);
+        }
+    }
+
+    private WazeSession ensureSession(double lat, double lon) throws Exception {
+        if (session != null) return session;
+        String region = WazeProtocolSource.region(lat, lon);
+        SharedPreferences p = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+        String community = p.getString("community", null);
+        String secret = p.getString("secret", null);
+        WazeCredentials creds = (community != null && secret != null)
+                ? new WazeCredentials(community, secret) : null;
+        DeviceIdentity dev = new DeviceIdentity(
+                p.getString("dev_mfr", "Google"), p.getString("dev_model", "Pixel 8"),
+                p.getString("dev_os", "15-SDK35"),
+                p.getInt("dev_w", 1080), p.getInt("dev_h", 2400),
+                p.getString("dev_iid", java.util.UUID.randomUUID().toString()));
+        WazeSession s = new WazeSession(region, dev, creds);
+        s.prepareForArea(lat, lon); // registers if needed + logs in + handshake
+        // Persist any newly minted account under the SAME keys as the read path.
+        WazeCredentials got = s.getCredentials();
+        if (got != null && (community == null || secret == null)) {
+            p.edit().putString("community", got.community).putString("secret", got.secret)
+             .putString("dev_mfr", dev.manufacturer).putString("dev_model", dev.model)
+             .putString("dev_os", dev.osVersion).putInt("dev_w", dev.screenW).putInt("dev_h", dev.screenH)
+             .putString("dev_iid", dev.installationId).apply();
+        }
+        session = s;
+        return s;
+    }
+
+    private void invalidateOnAuthError(Exception e) {
+        if (e instanceof WazeExceptions.AccountRejectedException) {
+            session = null;
+            // Only drop the credentials, leave reg_count/reg_window_start (rate-limit
+            // state) and device keys alone, matching WazeProtocolSource's contract.
+            ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()
+               .remove("community").remove("secret").apply();
+        } else if (e instanceof WazeExceptions.SessionExpiredException && session != null) {
+            session.invalidateSession();
+        }
+    }
+
+    /** DEBUG-only: exercise the write path end to end. Logcat tag WazeRT. */
+    public static void selfTest(Context ctx, double lat, double lon, String type) {
+        try {
+            ReportRequest r = ReportRequest.fromJson(
+                "{\"lat\":" + lat + ",\"lon\":" + lon + ",\"type\":\"" + type + "\"}");
+            boolean ok = new WazeReporter(ctx).submit(r);
+            Log.d(TAG, "selfTest report accepted=" + ok);
+        } catch (Exception e) { Log.w(TAG, "selfTest failed: " + e.getMessage()); }
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java
@@ -117,10 +117,28 @@ final class WazeRtCodec {
                 + f6(lonMax) + "," + f6(latMin) + "," + f6(lonMin) + "," + f6(latMin);
     }
 
-    static String seeMeCommand()  { return "SeeMe,1,2,T,T,T,1,-1,1,7"; }
+    /** Default SeeMe level (matches the handshake's original no-arg behavior). */
+    static String seeMeCommand()  { return seeMeCommand(1); }
+
+    /** mode 1 = handshake SeeMe; mode 2 = the terse post-report SeeMe used to
+     *  close out the simulateDriving sequence (recon D step 9). */
+    static String seeMeCommand(int mode) {
+        return mode == 1 ? "SeeMe,1,2,T,T,T,1,-1,1,7" : "SeeMe," + mode;
+    }
+
     static String setMoodCommand(){ return "SetMood,1"; }
     static String locationCommand(double lon, double lat) {
         return "Location," + lon + "," + lat;
+    }
+
+    /**
+     * "At" position update carrying the road-snap result: fromNode/toNode are the
+     * tile-local directional node indices from a {@code SegmentMatch}, or -1/-1 when
+     * no segment matched. lon/lat formatted identically to {@link #locationCommand}
+     * (plain concatenation, not fixed-decimal), matching wazemo.WazeProto.atCommand.
+     */
+    static String atCommand(double lon, double lat, int heading, long fromNode, long toNode) {
+        return "At," + lon + "," + lat + ",0," + heading + ",1," + fromNode + "," + toNode + ",T,0,-1,-1,0";
     }
 
     /** Handshake = SeeMe + SetMood + Location + MapDisplayed, newline-joined, one POST. */

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java
@@ -25,6 +25,12 @@ final class WazeRtCodec {
         return "ProtoBase64," + Base64.encodeToString(batch.toByteArray(), Base64.NO_WRAP);
     }
 
+    /** One report line: ProtoBase64-framed AddUserReportedAlertRequest on an Element. */
+    static String reportPayload(WazeProto.AddUserReportedAlertRequest req) {
+        return protoBase64Line(WazeProto.Element.newBuilder()
+                .setAddUserReportedAlertRequest(req).build());
+    }
+
     // ── Request line builders ────────────────────────────────────────────────
 
     static String buildClientInfoLine(DeviceIdentity device, double lon, double lat) {

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java
@@ -120,10 +120,11 @@ final class WazeRtCodec {
     /** Default SeeMe level (matches the handshake's original no-arg behavior). */
     static String seeMeCommand()  { return seeMeCommand(1); }
 
-    /** mode 1 = handshake SeeMe; mode 2 = the terse post-report SeeMe used to
-     *  close out the simulateDriving sequence (recon D step 9). */
+    /** mode 1 = handshake SeeMe; mode 2 = the post-report SeeMe used to close
+     *  out the simulateDriving sequence (recon D step 9). Formula matches
+     *  wazemo.WazeProto.seeMeCommand(level): "SeeMe," + level + ",2,T,T,T,1,-1,1,7". */
     static String seeMeCommand(int mode) {
-        return mode == 1 ? "SeeMe,1,2,T,T,T,1,-1,1,7" : "SeeMe," + mode;
+        return "SeeMe," + mode + ",2,T,T,T,1,-1,1,7";
     }
 
     static String setMoodCommand(){ return "SetMood,1"; }

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
@@ -306,13 +306,13 @@ final class WazeSession {
             // best-effort, matches recon D step 9
         }
 
-        String uuid = WazeReportCodec.reportUuidFrom(batch);
-        int points = WazeReportCodec.reportPointsFrom(batch);
-        if (uuid != null) {
-            Log.d(TAG, "Report accepted: uuid=" + uuid + " pts=" + points);
+        if (WazeReportCodec.reportAccepted(batch)) {
+            String uuid = WazeReportCodec.reportUuidFrom(batch);
+            int points = WazeReportCodec.reportPointsFrom(batch);
+            Log.d(TAG, "Report accepted: pts=" + points + " uuid=" + (uuid != null ? uuid : ""));
             return ReportResult.ok(uuid, points);
         }
-        Log.w(TAG, "No report response in batch");
+        Log.w(TAG, "Report not accepted: no accepting response element in batch");
         return ReportResult.fail("no report response");
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
@@ -251,6 +251,51 @@ final class WazeSession {
         return command(WazeRtCodec.mapDisplayedCommand(bbox[0], bbox[1], bbox[2], bbox[3]));
     }
 
+    /**
+     * Submit a user report to Waze. Prepares the area (handshake), sends the
+     * AddUserReportedAlertRequest, and reads the response uuid/points. Position-only
+     * (no road-snap SegmentNodes) unless a future tile-snap step supplies nodes.
+     */
+    ReportResult submitReport(app.sabre.wzsabre.ReportRequest r, long nowMs) throws Exception {
+        WazeProto.AddUserReportedAlertRequest req =
+                WazeReportCodec.buildRequest(r, nowMs, 0L, 0L);
+        if (req == null) return ReportResult.fail("unreportable type: " + r.type);
+        prepareForArea(r.lat, r.lon);
+        WazeProto.Batch batch = command(WazeRtCodec.reportPayload(req));
+        String uuid = WazeReportCodec.reportUuidFrom(batch);
+        int points = WazeReportCodec.reportPointsFrom(batch);
+        if (uuid != null) {
+            Log.d(TAG, "Report accepted: uuid=" + uuid + " pts=" + points);
+            return ReportResult.ok(uuid, points);
+        }
+        Log.w(TAG, "No report response in batch");
+        return ReportResult.fail("no report response");
+    }
+
+    /** Thumbs-up an existing Waze alert by its numeric id. */
+    void confirmAlert(long id) throws Exception {
+        prepareForArealess();
+        command("ThumbsUp," + id);
+        Log.d(TAG, "Confirmed alert " + id);
+    }
+
+    /** Remove/deny an existing Waze alert by its numeric id ("not there"). */
+    void discardAlert(long id) throws Exception {
+        prepareForArealess();
+        command("ReportRmAlert," + id);
+        Log.d(TAG, "Discarded alert " + id);
+    }
+
+    /** Ensure logged in for a bare command that needs no MapDisplayed handshake. */
+    private void prepareForArealess() throws Exception {
+        // confirm/discard carry lat/lon in the HR payload; callers that have them
+        // should use prepareForArea. When absent, ensure the session is at least
+        // registered+logged-in using the last known position is not available here,
+        // so require the caller to have prepared. If no session, this throws, and the
+        // caller (WazeReporter) will have called prepareForArea first.
+        if (session == null) throw new WazeExceptions.SessionExpiredException("confirm/discard before login");
+    }
+
     /** Full flow for a single box: prepare + one query. Used by the debug selfTest. */
     List<WazeAlert> fetchArea(double lat, double lon, double radiusMeters) throws Exception {
         prepareForArea(lat, lon);

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
@@ -253,16 +253,59 @@ final class WazeSession {
     }
 
     /**
-     * Submit a user report to Waze. Prepares the area (handshake), sends the
-     * AddUserReportedAlertRequest, and reads the response uuid/points. Position-only
-     * (no road-snap SegmentNodes) unless a future tile-snap step supplies nodes.
+     * Submit a user report to Waze via the full road-snap command sequence
+     * (recon D): handshake, an initial SeeMe+Location+MapDisplayed, a tile
+     * fetch + nearest-segment snap, an At position update carrying the
+     * (possibly absent) directional SegmentNodes, a short simulated-driving
+     * camouflage sequence (only when a segment matched), the actual report,
+     * and a trailing SeeMe close-out. Only the report POST's response batch
+     * is parsed for the result; the rest are best-effort / fire-and-forget,
+     * mirroring the official client.
      */
     ReportResult submitReport(app.sabre.wzsabre.ReportRequest r, long nowMs) throws Exception {
-        WazeProto.AddUserReportedAlertRequest req =
-                WazeReportCodec.buildRequest(r, nowMs, 0L, 0L);
-        if (req == null) return ReportResult.fail("unreportable type: " + r.type);
         prepareForArea(r.lat, r.lon);
+
+        // Command A: SeeMe + Location + MapDisplayed around the report point.
+        double[] boxA = WazeRtCodec.circleToBox(r.lon, r.lat);
+        command(WazeRtCodec.seeMeCommand(1) + "\n" + WazeRtCodec.locationCommand(r.lon, r.lat)
+                + "\n" + WazeRtCodec.mapDisplayedCommand(boxA[0], boxA[1], boxA[2], boxA[3]));
+
+        List<RoadSegment> segs = fetchTileSegments(r.lat, r.lon);
+        int heading = normalizeAngle360(Math.round(r.headingDeg));
+        SegmentMatch m = RoadGeo.findMatchingSegment(
+                new LatLon(r.lat, r.lon), r.headingDeg, segs, 15.0, 50.0);
+        if (m != null) {
+            Log.d(TAG, "Snapped to road " + m.segment.segmentId + (m.reverse ? " REV" : " FWD"));
+        } else {
+            Log.d(TAG, "No road match (" + segs.size() + " candidates)");
+        }
+        long fromNode = m != null ? m.fromNodeDirectional() : -1;
+        long toNode   = m != null ? m.toNodeDirectional()   : -1;
+
+        // Command B: At position update carrying the (possibly absent) snap result.
+        double[] boxB = WazeRtCodec.circleToBox(r.lon, r.lat);
+        command(WazeRtCodec.atCommand(r.lon, r.lat, heading, fromNode, toNode) + "\n"
+                + WazeRtCodec.mapDisplayedCommand(boxB[0], boxB[1], boxB[2], boxB[3]));
+
+        if (m != null) {
+            simulateDriving(r.lat, r.lon, heading, fromNode, toNode);
+        }
+
+        // Command C: the actual report. SegmentNodes omitted (0/0) when no match.
+        WazeProto.AddUserReportedAlertRequest req = WazeReportCodec.buildRequest(
+                r, nowMs, m != null ? fromNode : 0, m != null ? toNode : 0);
+        if (req == null) return ReportResult.fail("unreportable type: " + r.type);
         WazeProto.Batch batch = command(WazeRtCodec.reportPayload(req));
+
+        // Command D: trailing SeeMe close-out (anti-abuse camouflage). Response
+        // discarded; a failure here must not turn an already-accepted report into
+        // a failure.
+        try {
+            command(WazeRtCodec.seeMeCommand(2));
+        } catch (Exception ignore) {
+            // best-effort, matches recon D step 9
+        }
+
         String uuid = WazeReportCodec.reportUuidFrom(batch);
         int points = WazeReportCodec.reportPointsFrom(batch);
         if (uuid != null) {
@@ -271,6 +314,42 @@ final class WazeSession {
         }
         Log.w(TAG, "No report response in batch");
         return ReportResult.fail("no report response");
+    }
+
+    /** Normalize a heading in degrees to [0, 360). */
+    private static int normalizeAngle360(long deg) {
+        int d = (int) (deg % 360);
+        if (d < 0) d += 360;
+        return d;
+    }
+
+    /**
+     * Best-effort "driving" camouflage sent after the At update (recon D step 6):
+     * three ~1s steps along {@code heading} at Waze's simulated driving speed
+     * (13.4 m/s), each POSTing an At + MapDisplayed pair for the stepped
+     * position. Mirrors the official client's simulateDriving; anti-abuse
+     * camouflage, so it must run (not be skippable) whenever a segment matched,
+     * but a failed step (network or sleep) must never abort the report itself.
+     */
+    private void simulateDriving(double lat, double lon, int heading, long fromNode, long toNode) {
+        double rad = Math.toRadians(heading);
+        for (int i = 0; i < 3; i++) {
+            lat += (Math.cos(rad) * 13.4) / WazeConstants.M_PER_DEG_LAT;
+            lon += (Math.sin(rad) * 13.4) / WazeConstants.mPerDegLon(lat);
+            try {
+                double[] box = WazeRtCodec.circleToBox(lon, lat);
+                command(WazeRtCodec.atCommand(lon, lat, heading, fromNode, toNode) + "\n"
+                        + WazeRtCodec.mapDisplayedCommand(box[0], box[1], box[2], box[3]));
+            } catch (Exception e) {
+                Log.w(TAG, "simulateDriving step " + i + " failed: "
+                        + e.getClass().getSimpleName() + ": " + e.getMessage());
+            }
+            try {
+                Thread.sleep(300L);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java
@@ -4,6 +4,7 @@ import android.os.SystemClock;
 import android.util.Log;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -270,6 +271,40 @@ final class WazeSession {
         }
         Log.w(TAG, "No report response in batch");
         return ReportResult.fail("no report response");
+    }
+
+    /**
+     * GETs and decodes the WZDF road-graph tile covering (lat,lon), for road-snap
+     * (Task R5). Requires a live session (uses {@code session.serverSessionId}/
+     * {@code session.secretKey} in the tile URL, matching how the official
+     * authenticates the tile GET). Best-effort: any failure (no session, HTTP
+     * error, empty body, decode error) returns an empty list rather than throwing,
+     * so a snap failure degrades to a position-only report instead of aborting it.
+     */
+    List<RoadSegment> fetchTileSegments(double lat, double lon) {
+        if (session == null) {
+            Log.w(TAG, "fetchTileSegments: no live session");
+            return new ArrayList<>();
+        }
+        try {
+            String tileHost = WazeConstants.tileHost(WazeProtocolSource.region(lat, lon));
+            int tileId = WazeTileCodec.coordToTileId(lon, lat);
+            String url = WazeTileCodec.buildTileUrl(tileHost, session.serverSessionId, session.secretKey, tileId);
+
+            Map<String, String> headers = new LinkedHashMap<>();
+            headers.put("User-Agent", WazeConstants.APP_VERSION);   // bare "5.17.1.0"
+            headers.put("if-modified-since", "Thu, 01 Jan 1970 00:00:00 GMT");
+
+            WazeHttpClient.HttpResult r = http.get(url, headers);
+            if (r.code >= 400 || r.body.length == 0) {
+                Log.w(TAG, "fetchTileSegments: tile GET HTTP " + r.code + " (" + r.body.length + "B)");
+                return new ArrayList<>();
+            }
+            return WazeTileParser.parse(r.body);
+        } catch (Exception e) {
+            Log.w(TAG, "fetchTileSegments failed: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+            return new ArrayList<>();
+        }
     }
 
     /** Thumbs-up an existing Waze alert by its numeric id. */

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeTileCodec.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeTileCodec.java
@@ -1,0 +1,29 @@
+package app.sabre.wzsabre.waze;
+
+/**
+ * Tile-id math and tile-server URL building for the Waze mobile-app "RT" protocol.
+ * Pure Java (no Android APIs) so it is plain-JVM testable.
+ * Ported from wzsabre 2.2 wazemo.WazeTileParser (buildTileUrl/coordToTileId).
+ */
+final class WazeTileCodec {
+    private WazeTileCodec() {}
+
+    /** Global tile id for a coordinate, using WazeConstants.TILE_NUM_ROWS row stride. */
+    static int coordToTileId(double lon, double lat) {
+        int lonTile = (((int) (lon * 1_000_000.0)) + 180_000_000) / 10000;
+        int latTile = (((int) (lat * 1_000_000.0)) + 90_000_000) / 10000;
+        return (lonTile * WazeConstants.TILE_NUM_ROWS) + latTile;
+    }
+
+    /**
+     * Tile-server multi-get URL for a single tile. When serverSessionId==0 or
+     * secretKey==null (not logged in yet), the session part is omitted.
+     */
+    static String buildTileUrl(String tileHost, long serverSessionId, String secretKey, int tileId) {
+        String sessionPart = (serverSessionId != 0 && secretKey != null)
+                ? "&sessionid=" + serverSessionId + "&cookie=" + secretKey
+                : "";
+        return "https://" + tileHost + "/TileServer/multi-get?reqtype=tileBatch&protocol=2"
+                + sessionPart + "&num=1&variation=PARTIAL_SIMPLIFICATION&t0=" + tileId + "&v0=0&p0=42";
+    }
+}

--- a/app/src/main/java/app/sabre/wzsabre/waze/WazeTileParser.java
+++ b/app/src/main/java/app/sabre/wzsabre/waze/WazeTileParser.java
@@ -1,0 +1,196 @@
+package app.sabre.wzsabre.waze;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
+
+/**
+ * Decoder for the Waze tile-server's binary "WZDF" tile format: the road-graph
+ * geometry (nodes + segments) used to snap a GPS point to a road segment before
+ * submitting a report. The tile response is NOT protobuf. Pure Java (no Android
+ * APIs), so it stays plain-JVM testable.
+ *
+ * Ported nearly line-for-line from wzsabre 2.2 wazemo.WazeTileParser (parse/
+ * parseSections/readU32/readU16/readI16/alignOffset/section), including the
+ * section-directory addressing scheme: each of the {@code numSections} u32
+ * values stored after the 8-byte header is the CUMULATIVE end offset (relative
+ * to the start of the section body) of that section, not a per-section length;
+ * a section's start is {@code alignOffset} of the previous section's end value.
+ * {@code findBytes} is re-expressed as a standard substring scan (see the R2
+ * report for why: the jadx decompilation of that helper has a control-flow
+ * artifact that doesn't reflect correct byte-search behavior).
+ */
+final class WazeTileParser {
+    private static final byte[] MAGIC = {87, 90, 68, 70, 1, 0, 0, 0, 0, 0, 3, 0}; // "WZDF" 01000000 00000300
+
+    private WazeTileParser() {}
+
+    /**
+     * Parses raw tile-server response bytes into road segments. Returns an empty
+     * list if the WZDF magic is absent or the tile has too few sections (index 26,
+     * the tile header, must exist). Throws if the magic is present but the payload
+     * is otherwise corrupt (matches the reference; the caller, WazeSession.fetchTileSegments,
+     * is expected to catch broadly around the whole GET+parse and fail soft).
+     */
+    static List<RoadSegment> parse(byte[] data) {
+        int magicAt = findBytes(data, MAGIC);
+        if (magicAt < 0) {
+            return new ArrayList<>();
+        }
+        int compressedLen = readU32(data, magicAt + 12);
+        int uncompressedLen = readU32(data, magicAt + 16);
+        Inflater inflater = new Inflater();
+        inflater.setInput(data, magicAt + 20, compressedLen);
+        byte[] sections = new byte[uncompressedLen];
+        int inflated;
+        try {
+            inflated = inflater.inflate(sections);
+        } catch (DataFormatException e) {
+            inflater.end();
+            throw new RuntimeException("WZDF inflate failed", e);
+        }
+        inflater.end();
+        if (inflated != uncompressedLen) {
+            throw new IllegalStateException("Decompressed " + inflated + " != expected " + uncompressedLen);
+        }
+        return parseSections(sections);
+    }
+
+    private static List<RoadSegment> parseSections(byte[] data) {
+        int numSections = readU32(data, 0);
+        int alignBits = readU32(data, 4);
+        if (numSections <= 26) {
+            return new ArrayList<>();
+        }
+
+        // Section directory: numSections u32 values read sequentially starting at
+        // byte 8. Each value is the cumulative end offset (relative to `base`, the
+        // byte right after the directory) of that section; a section's start is
+        // alignOffset() of the PREVIOUS section's end value (offset[0] = alignOffset(0)).
+        int[] sectionOffset = new int[numSections];
+        int[] sectionEnd = new int[numSections];
+        int cursor = 8;
+        int running = 0;
+        for (int i = 0; i < numSections; i++) {
+            sectionOffset[i] = alignOffset(running, alignBits);
+            int value = readU32(data, cursor);
+            cursor += 4;
+            sectionEnd[i] = value;
+            running = value;
+        }
+        int base = cursor;
+
+        // Section 26 = tile header: first u32 = tileId.
+        byte[] header = section(data, base, sectionOffset[26], sectionEnd[26]);
+        if (header.length < 12) {
+            return new ArrayList<>();
+        }
+        int tileId = readU32(header, 0);
+        int lonIdx = tileId / WazeConstants.TILE_NUM_ROWS;
+        int latIdx = tileId % WazeConstants.TILE_NUM_ROWS;
+
+        // Section 13 = NODES: 4 bytes/entry, u16 lonOff, u16 latOff.
+        byte[] nodesSection = section(data, base, sectionOffset[13], sectionEnd[13]);
+        List<LatLon> nodes = new ArrayList<>();
+        for (int off = 0; off + 4 <= nodesSection.length; off += 4) {
+            int lonOff = readU16(nodesSection, off);
+            int latOff = readU16(nodesSection, off + 2);
+            double lat = ((latIdx * 10000 - 90000000) + latOff) * 1.0e-6;
+            double lon = ((lonIdx * 10000 - 180000000) + lonOff) * 1.0e-6;
+            nodes.add(new LatLon(lat, lon));
+        }
+
+        // Section 8 = POINT DELTAS: 4 bytes/entry, signed i16 pair (dLon, dLat) microdegrees.
+        byte[] deltasSection = section(data, base, sectionOffset[8], sectionEnd[8]);
+        List<int[]> deltas = new ArrayList<>();
+        for (int off = 0; off + 4 <= deltasSection.length; off += 4) {
+            deltas.add(new int[]{readI16(deltasSection, off), readI16(deltasSection, off + 2)});
+        }
+
+        // Section 9 = SEGMENTS: 8 bytes/entry.
+        byte[] segmentsSection = section(data, base, sectionOffset[9], sectionEnd[9]);
+        List<RoadSegment> segments = new ArrayList<>();
+        int segIndex = 0;
+        for (int off = 0; off + 8 <= segmentsSection.length; off += 8) {
+            int fromIdx = readU16(segmentsSection, off) & 0x7FFF;
+            int toIdx = readU16(segmentsSection, off + 2) & 0x7FFF;
+            int ptRef = readU16(segmentsSection, off + 4);
+            // bytes off+6..off+7 unused
+            if (fromIdx < nodes.size() && toIdx < nodes.size()) {
+                List<LatLon> points = new ArrayList<>();
+                points.add(nodes.get(fromIdx));
+                double lon = nodes.get(fromIdx).lon;
+                double lat = nodes.get(fromIdx).lat;
+                if (ptRef != 0xFFFF && ptRef < deltas.size()) {
+                    int count = deltas.get(ptRef)[1]; // ptRef entry's second field = count
+                    int start = ptRef + 1;
+                    int end = Math.min(count + start, deltas.size());
+                    for (int k = start; k < end; k++) {
+                        lon += deltas.get(k)[0] * 1.0e-6;
+                        lat += deltas.get(k)[1] * 1.0e-6;
+                        points.add(new LatLon(lat, lon));
+                    }
+                }
+                points.add(nodes.get(toIdx));
+                // GeoUtils.computeHeading (Task R3's RoadGeo.computeHeading exposes the
+                // same formula publicly for the segment-snap geometry); inlined here
+                // since it is self-contained (no other GeoUtils dependency).
+                int heading = computeHeading(points.get(0), points.get(points.size() - 1));
+                segments.add(new RoadSegment(
+                        ((long) tileId) * 100000L + (long) segIndex,
+                        fromIdx, toIdx, heading, points));
+            }
+            segIndex++;
+        }
+        return segments;
+    }
+
+    /** Ported from wzsabre 2.2 wazemo.GeoUtils.computeHeading. Bearing in [0,360) degrees. */
+    private static int computeHeading(LatLon from, LatLon to) {
+        double bearing = Math.toDegrees(Math.atan2(
+                (to.lon - from.lon) * Math.cos(Math.toRadians((from.lat + to.lat) / 2.0)),
+                to.lat - from.lat));
+        return (int) Math.round((bearing + 360.0) % 360.0);
+    }
+
+    private static int alignOffset(int value, int bits) {
+        int mask = (1 << bits) - 1;
+        return (~mask) & (value + mask);
+    }
+
+    private static int readU32(byte[] d, int o) {
+        return (d[o] & 0xFF) | ((d[o + 1] & 0xFF) << 8) | ((d[o + 2] & 0xFF) << 16) | ((d[o + 3] & 0xFF) << 24);
+    }
+
+    private static int readU16(byte[] d, int o) {
+        return (d[o] & 0xFF) | ((d[o + 1] & 0xFF) << 8);
+    }
+
+    private static int readI16(byte[] d, int o) {
+        int u16 = readU16(d, o);
+        return u16 >= 32768 ? u16 - 65536 : u16;
+    }
+
+    private static byte[] section(byte[] data, int base, int offset, int end) {
+        int start = offset + base;
+        int stop = base + end;
+        if (start >= data.length || stop > data.length || start >= stop) {
+            return new byte[0];
+        }
+        return Arrays.copyOfRange(data, start, stop);
+    }
+
+    private static int findBytes(byte[] haystack, byte[] needle) {
+        int limit = haystack.length - needle.length;
+        outer:
+        for (int i = 0; i <= limit; i++) {
+            for (int j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) continue outer;
+            }
+            return i;
+        }
+        return -1;
+    }
+}

--- a/app/src/main/proto/waze.proto
+++ b/app/src/main/proto/waze.proto
@@ -48,6 +48,8 @@ message Element {
   optional LoginSuccessful login_successful = 2225;
   optional AT at = 2384;
   optional AddAlertAction add_alert_action = 2708;
+  optional AddUserReportedAlertRequest add_user_reported_alert_request = 2737;
+  optional AddUserReportedAlertResponse add_user_reported_alert_response = 2738;
   optional LoginRequest login_request = 2744;
   optional LoginResponse login_response = 2745;
 }
@@ -462,3 +464,120 @@ message ServerError {
 message ResponseTimestamp {}
 message LoginSuccessful {}
 message AT {}
+
+// ---------------------------------------------------------------------------
+// Alert REPORTING (write) path. Field numbers from *_FIELD_NUMBER smali
+// constants cross-checked against generated writeTo() (plain int32/int64/enum/
+// double/message, no zig-zag). Built by WazeReportCodec.
+// ---------------------------------------------------------------------------
+
+message CoordinateWithAlt {
+  optional int32 lon_times1000000 = 101;
+  optional int32 lat_times1000000 = 102;
+  optional int32 alt_times1000000 = 103;
+}
+
+message SegmentNodes {
+  optional int64 from_node = 1;
+  optional int64 to_node = 2;
+}
+
+message GpsPosition {
+  optional CoordinateWithAlt coordinate = 1;
+  optional double horizontal_accuracy_meters = 2;
+  optional int64 time_epoch_ms = 3;
+}
+
+message UserPosition {
+  optional GpsPosition gps_position = 1;
+  optional SegmentNodes segment_nodes = 2;
+}
+
+message Timestamp {
+  optional int64 seconds = 1;
+  optional int32 nanos = 2;
+}
+
+enum ReportingManner {
+  REPORTING_MANNER_UNSPECIFIED = 0;
+  REPORTING_MANNER_DEFAULT = 1;
+  REPORTING_MANNER_VOICE = 2;
+  REPORTING_MANNER_VOICE_CONVERSATION = 3;
+}
+
+enum PoliceAlertSubType {
+  POLICE_UNSPECIFIED = 0;
+  POLICE_DEFAULT = 1;
+  POLICE_HIDDEN_REPORT = 2;
+  POLICE_MOBILE_CAMERA = 3;
+}
+message PoliceDetails { optional PoliceAlertSubType type = 1; }
+
+enum CrashReportSubType {
+  CRASH_REPORT_UNSPECIFIED = 0;
+  CRASH_REPORT_DEFAULT = 1;
+  CRASH_REPORT_PILE_UP = 2;
+  CRASH_REPORT_MAJOR = 3;
+  CRASH_REPORT_MINOR = 4;
+}
+message CrashDetails { optional CrashReportSubType type = 1; }
+
+enum TrafficReportSubType {
+  TRAFFIC_REPORT_UNSPECIFIED = 0;
+  TRAFFIC_REPORT_DEFAULT = 1;
+  TRAFFIC_REPORT_STANDSTILL = 2;
+  TRAFFIC_REPORT_LIGHT = 3;
+  TRAFFIC_REPORT_MODERATE = 4;
+  TRAFFIC_REPORT_HEAVY = 5;
+}
+message TrafficDetails { optional TrafficReportSubType type = 1; }
+
+enum HazardReportSubType {
+  HAZARD_REPORT_UNSPECIFIED = 0;
+  HAZARD_REPORT_DEFAULT = 1;
+  HAZARD_REPORT_CONSTRUCTION = 2;
+  HAZARD_REPORT_VEHICLE_STOPPED = 3;
+  HAZARD_REPORT_OBJECT_ON_ROAD = 4;
+  HAZARD_REPORT_POTHOLE = 5;
+  HAZARD_REPORT_BROKEN_TRAFFIC_LIGHT = 6;
+  HAZARD_REPORT_OIL = 7;
+  HAZARD_REPORT_ANIMALS = 8;
+  HAZARD_REPORT_MISSING_SIGN = 9;
+  HAZARD_REPORT_ROAD_KILL = 10;
+  HAZARD_REPORT_SHOULDER = 11;
+  HAZARD_REPORT_SHOULDER_VEHICLE_STOPPED = 12;
+  HAZARD_REPORT_EMERGENCY_VEHICLE = 13;
+}
+message HazardOnRoadDetails { optional HazardReportSubType type = 1; }
+
+message AlertDetails {
+  oneof details {
+    TrafficDetails traffic = 1;
+    PoliceDetails police = 2;
+    CrashDetails crash = 3;
+    HazardOnRoadDetails hazard_on_road = 4;
+  }
+}
+
+message AddUserReportedAlertRequest {
+  optional UserPosition user_position = 1;
+  optional int32 azymuth = 2;
+  optional AlertDetails alert_details = 3;
+  optional SegmentDirection segment_direction = 4;
+  optional Timestamp report_time = 5;
+  optional bool is_offline_delayed_report = 6;
+  optional ReportingManner reporting_manner = 7;
+}
+
+message AddUserReportedAlertResponse {
+  enum AddAlertStatus {
+    STATUS_UNSPECIFIED = 0;
+    SUCCESS = 1;
+    FAILURE = 2;
+  }
+  optional AddAlertStatus status = 1;
+  optional int32 received_points_count = 2;
+  optional int64 client_alert_id = 3;
+  optional AlertDetails alert_details = 4;
+  optional string alert_uuid = 5;
+}

--- a/app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java
@@ -188,4 +188,42 @@ public class AlertMapperTest {
         assertNull(AlertMapper.wazeRenderableType(null, null));
         assertNull(AlertMapper.wazeRenderableType("", ""));
     }
+
+    // ── renderableEchoType / wazeReportSubtype: HR report -> Waze report ─────────
+
+    @Test
+    public void renderableEchoType_keepsRenderablePrefixes() {
+        assertEquals("POLICE_VISIBLE", AlertMapper.renderableEchoType("POLICE_VISIBLE"));
+        assertEquals("ACCIDENT_MAJOR", AlertMapper.renderableEchoType("ACCIDENT_MAJOR"));
+        assertEquals("HAZARD_ON_ROAD_POT_HOLE", AlertMapper.renderableEchoType("HAZARD_ON_ROAD_POT_HOLE"));
+    }
+
+    @Test
+    public void renderableEchoType_remapsJamsToCongestion() {
+        assertEquals("HAZARD_ON_ROAD_CONGESTION", AlertMapper.renderableEchoType("JAM_HEAVY_TRAFFIC"));
+        assertEquals("HAZARD_ON_ROAD_CONGESTION", AlertMapper.renderableEchoType("ROAD_CLOSED"));
+    }
+
+    @Test
+    public void renderableEchoType_nullForUnusable() {
+        assertNull(AlertMapper.renderableEchoType(null));
+        assertNull(AlertMapper.renderableEchoType(""));
+    }
+
+    @Test
+    public void wazeReportSubtype_mapsKnownTypes() {
+        AlertMapper.WazeReportSubtype p = AlertMapper.wazeReportSubtype("POLICE_HIDDEN");
+        assertEquals(AlertMapper.WazeReportSubtype.Kind.POLICE, p.kind);
+        assertEquals(2, p.subtypeNumber); // POLICE_HIDDEN_REPORT
+        assertEquals(AlertMapper.WazeReportSubtype.Kind.CRASH, AlertMapper.wazeReportSubtype("ACCIDENT_MAJOR").kind);
+        assertEquals(5, AlertMapper.wazeReportSubtype("ACCIDENT_MAJOR").subtypeNumber == 3 ? 5 : AlertMapper.wazeReportSubtype("JAM_HEAVY_TRAFFIC").subtypeNumber);
+        assertEquals(AlertMapper.WazeReportSubtype.Kind.HAZARD, AlertMapper.wazeReportSubtype("HAZARD_ON_ROAD_CAR_STOPPED").kind);
+        assertEquals(3, AlertMapper.wazeReportSubtype("HAZARD_ON_ROAD_CAR_STOPPED").subtypeNumber);
+    }
+
+    @Test
+    public void wazeReportSubtype_nullForUnreportable() {
+        assertNull(AlertMapper.wazeReportSubtype("SOS_MEDICAL_HELP"));
+        assertNull(AlertMapper.wazeReportSubtype(null));
+    }
 }

--- a/app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java
@@ -216,7 +216,8 @@ public class AlertMapperTest {
         assertEquals(AlertMapper.WazeReportSubtype.Kind.POLICE, p.kind);
         assertEquals(2, p.subtypeNumber); // POLICE_HIDDEN_REPORT
         assertEquals(AlertMapper.WazeReportSubtype.Kind.CRASH, AlertMapper.wazeReportSubtype("ACCIDENT_MAJOR").kind);
-        assertEquals(5, AlertMapper.wazeReportSubtype("ACCIDENT_MAJOR").subtypeNumber == 3 ? 5 : AlertMapper.wazeReportSubtype("JAM_HEAVY_TRAFFIC").subtypeNumber);
+        assertEquals(3, AlertMapper.wazeReportSubtype("ACCIDENT_MAJOR").subtypeNumber);
+        assertEquals(5, AlertMapper.wazeReportSubtype("JAM_HEAVY_TRAFFIC").subtypeNumber);
         assertEquals(AlertMapper.WazeReportSubtype.Kind.HAZARD, AlertMapper.wazeReportSubtype("HAZARD_ON_ROAD_CAR_STOPPED").kind);
         assertEquals(3, AlertMapper.wazeReportSubtype("HAZARD_ON_ROAD_CAR_STOPPED").subtypeNumber);
     }

--- a/app/src/test/java/app/sabre/wzsabre/MainBroadcastReceiverTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/MainBroadcastReceiverTest.java
@@ -1,0 +1,25 @@
+package app.sabre.wzsabre;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class MainBroadcastReceiverTest {
+    @Test public void classifiesOfficialActions() {
+        assertEquals("REPORT",  MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.REPORT"));
+        assertEquals("CONFIRM", MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.CONFIRM"));
+        assertEquals("DISCARD", MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.DISCARD"));
+    }
+    @Test public void classifiesLegacyNames() {
+        assertEquals("REPORT",  MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.SUBMIT_REPORT"));
+        assertEquals("CONFIRM", MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.CONFIRM_REPORT"));
+        assertEquals("DISCARD", MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.DISCARD_REPORT"));
+    }
+    @Test public void ignoresFetchAndShutdownAndNull() {
+        assertNull(MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.REQUEST"));
+        assertNull(MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.FETCH_REQUEST"));
+        assertNull(MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.SHUTDOWN"));
+        assertNull(MainBroadcastReceiver.classifyReportAction(null));
+    }
+}

--- a/app/src/test/java/app/sabre/wzsabre/ReportRequestTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/ReportRequestTest.java
@@ -1,0 +1,51 @@
+package app.sabre.wzsabre;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONException;
+import org.junit.Test;
+
+public class ReportRequestTest {
+
+    @Test
+    public void parsesReportPayload() throws JSONException {
+        ReportRequest r = ReportRequest.fromJson(
+            "{\"lat\":37.8,\"lon\":-122.27,\"heading_deg\":90.0,\"altitude_m\":12.0," +
+            "\"type\":\"POLICE_VISIBLE\",\"is_opposite\":true,\"time_delta_s\":30}");
+        assertEquals(37.8, r.lat, 1e-9);
+        assertEquals(-122.27, r.lon, 1e-9);
+        assertEquals(90.0, r.headingDeg, 1e-9);
+        assertEquals("POLICE_VISIBLE", r.type);
+        assertTrue(r.isOpposite);
+        assertEquals(30, r.timeDeltaS);
+    }
+
+    @Test
+    public void reportDefaultsOptionalFields() throws JSONException {
+        ReportRequest r = ReportRequest.fromJson("{\"lat\":1.0,\"lon\":2.0,\"type\":\"ACCIDENT_MINOR\"}");
+        assertEquals(0, r.timeDeltaS);
+        assertFalse(r.isOpposite);
+    }
+
+    @Test(expected = JSONException.class)
+    public void reportRejectsMissingType() throws JSONException {
+        ReportRequest.fromJson("{\"lat\":1.0,\"lon\":2.0}");
+    }
+
+    @Test
+    public void confirmRecoversWazeId() throws JSONException {
+        ConfirmDiscardRequest c = ConfirmDiscardRequest.fromJson(
+            "{\"lat\":1.0,\"lon\":2.0,\"alert_id\":\"alert-123456/uuid-abc\",\"test\":false}");
+        assertEquals(123456L, c.wazeAlertId());
+        assertFalse(c.test);
+    }
+
+    @Test
+    public void confirmMalformedIdReturnsNegative() throws JSONException {
+        ConfirmDiscardRequest c = ConfirmDiscardRequest.fromJson(
+            "{\"lat\":1.0,\"lon\":2.0,\"alert_id\":\"userreport-99\"}");
+        assertEquals(-1L, c.wazeAlertId());
+    }
+}

--- a/app/src/test/java/app/sabre/wzsabre/ReportRequestTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/ReportRequestTest.java
@@ -48,4 +48,28 @@ public class ReportRequestTest {
             "{\"lat\":1.0,\"lon\":2.0,\"alert_id\":\"userreport-99\"}");
         assertEquals(-1L, c.wazeAlertId());
     }
+
+    @Test
+    public void reportAcceptsLatitudeLongitudeFallback() throws JSONException {
+        ReportRequest r = ReportRequest.fromJson(
+            "{\"latitude\":1.5,\"longitude\":-2.5,\"type\":\"POLICE_VISIBLE\"}");
+        assertEquals(1.5, r.lat, 1e-9);
+        assertEquals(-2.5, r.lon, 1e-9);
+    }
+
+    @Test
+    public void confirmAcceptsLatitudeLongitudeFallback() throws JSONException {
+        ConfirmDiscardRequest c = ConfirmDiscardRequest.fromJson(
+            "{\"latitude\":1.5,\"longitude\":-2.5,\"alert_id\":\"alert-7/u\"}");
+        assertEquals(1.5, c.lat, 1e-9);
+        assertEquals(-2.5, c.lon, 1e-9);
+        assertEquals(7L, c.wazeAlertId());
+    }
+
+    @Test
+    public void confirmAlertPrefixedNoSlashParses() throws JSONException {
+        ConfirmDiscardRequest c = ConfirmDiscardRequest.fromJson(
+            "{\"lat\":1.0,\"lon\":2.0,\"alert_id\":\"alert-654321\"}");
+        assertEquals(654321L, c.wazeAlertId());
+    }
 }

--- a/app/src/test/java/app/sabre/wzsabre/UserReportStoreTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/UserReportStoreTest.java
@@ -49,4 +49,31 @@ public class UserReportStoreTest {
         s.removeNear(37.8001, -122.2701, 1500L);
         assertTrue(s.activeAlerts(37.8, -122.27, 5000, 2000L).isEmpty());
     }
+
+    @Test
+    public void renderableButInvalidTypeFallsBackToValid() throws JSONException {
+        // HAZARD_ON_SHOULDER_CONSTRUCTION is renderable-prefixed (starts with HAZARD, so
+        // AlertMapper.renderableEchoType passes it through verbatim) but is NOT a member of
+        // SabreResponseBuilder.VALID_TYPES, unlike its siblings HAZARD_ON_SHOULDER_CAR_STOPPED /
+        // _ANIMALS / _MISSING_SIGN. Proves the fallback is doing real work.
+        String outOfSetType = "HAZARD_ON_SHOULDER_CONSTRUCTION";
+        assertTrue(!SabreResponseBuilder.isValidType(outOfSetType));
+
+        UserReportStore s = new UserReportStore();
+        ReportRequest r = ReportRequest.fromJson("{\"lat\":37.8,\"lon\":-122.27,\"type\":\"" +
+                outOfSetType + "\"}");
+        s.add(r, 1000L);
+        List<SabreAlert> out = s.activeAlerts(37.8, -122.27, 5000, 2000L);
+        assertEquals(1, out.size());
+        assertTrue(SabreResponseBuilder.isValidType(out.get(0).type));
+    }
+
+    @Test
+    public void validTypePassesThroughUnchanged() throws JSONException {
+        UserReportStore s = new UserReportStore();
+        s.add(police(37.8, -122.27), 1000L);
+        List<SabreAlert> out = s.activeAlerts(37.8, -122.27, 5000, 2000L);
+        assertEquals(1, out.size());
+        assertEquals("POLICE_VISIBLE", out.get(0).type);
+    }
 }

--- a/app/src/test/java/app/sabre/wzsabre/UserReportStoreTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/UserReportStoreTest.java
@@ -1,0 +1,52 @@
+package app.sabre.wzsabre;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONException;
+import org.junit.Test;
+
+import java.util.List;
+
+public class UserReportStoreTest {
+
+    private static ReportRequest police(double lat, double lon) throws JSONException {
+        return ReportRequest.fromJson("{\"lat\":" + lat + ",\"lon\":" + lon +
+                ",\"type\":\"POLICE_VISIBLE\"}");
+    }
+
+    @Test
+    public void addedReportAppearsInRadiusWithRenderableType() throws JSONException {
+        UserReportStore s = new UserReportStore();
+        s.add(police(37.8, -122.27), 1000L);
+        List<SabreAlert> out = s.activeAlerts(37.8, -122.27, 5000, 2000L);
+        assertEquals(1, out.size());
+        assertEquals("POLICE_VISIBLE", out.get(0).type);
+        assertEquals("waze", out.get(0).alertSource);
+        assertTrue(out.get(0).alertId.contains("userreport"));
+    }
+
+    @Test
+    public void expiredReportsAreDropped() throws JSONException {
+        UserReportStore s = new UserReportStore();
+        s.add(police(37.8, -122.27), 1000L);
+        long later = 1000L + UserReportStore.TTL_MS + 1;
+        assertTrue(s.activeAlerts(37.8, -122.27, 5000, later).isEmpty());
+    }
+
+    @Test
+    public void outOfRadiusReportsAreFiltered() throws JSONException {
+        UserReportStore s = new UserReportStore();
+        s.add(police(37.8, -122.27), 1000L);
+        // ~100km away
+        assertTrue(s.activeAlerts(38.7, -122.27, 5000, 2000L).isEmpty());
+    }
+
+    @Test
+    public void removeNearDropsMatchingReport() throws JSONException {
+        UserReportStore s = new UserReportStore();
+        s.add(police(37.8, -122.27), 1000L);
+        s.removeNear(37.8001, -122.2701, 1500L);
+        assertTrue(s.activeAlerts(37.8, -122.27, 5000, 2000L).isEmpty());
+    }
+}

--- a/app/src/test/java/app/sabre/wzsabre/waze/RoadGeoTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/RoadGeoTest.java
@@ -1,0 +1,74 @@
+package app.sabre.wzsabre.waze;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Pure geometry for the road-snap match: computeHeading and findMatchingSegment.
+ * Ported from wzsabre 2.2 wazemo.GeoUtils / SegmentMatch.
+ */
+public class RoadGeoTest {
+
+    private static RoadSegment eastWestSegment() {
+        List<LatLon> points = new ArrayList<>();
+        points.add(new LatLon(37.80, -122.28));
+        points.add(new LatLon(37.80, -122.26));
+        int heading = RoadGeo.computeHeading(points.get(0), points.get(1));
+        return new RoadSegment(1L, 100L, 200L, heading, points);
+    }
+
+    @Test
+    public void computeHeadingEastIsAbout90Degrees() {
+        int heading = RoadGeo.computeHeading(new LatLon(37.80, -122.28), new LatLon(37.80, -122.26));
+        assertTrue("expected heading near 90, got " + heading, Math.abs(heading - 90) <= 2);
+    }
+
+    @Test
+    public void findMatchingSegmentSnapsNearbyPointOnForwardHeading() {
+        RoadSegment segment = eastWestSegment();
+        LatLon pos = new LatLon(37.8001, -122.27); // ~11m north of the segment, midpoint
+
+        SegmentMatch match = RoadGeo.findMatchingSegment(
+                pos, 90.0, Collections.singletonList(segment), 15.0, 50.0);
+
+        assertNotNull(match);
+        assertEquals(segment.segmentId, match.segment.segmentId);
+        assertFalse(match.reverse);
+        assertEquals(segment.fromNode, match.fromNodeDirectional());
+        assertEquals(segment.toNode, match.toNodeDirectional());
+    }
+
+    @Test
+    public void findMatchingSegmentReturnsNullBeyondMaxDist() {
+        RoadSegment segment = eastWestSegment();
+        LatLon farPos = new LatLon(37.802, -122.27); // ~221m north: beyond 50m
+
+        SegmentMatch match = RoadGeo.findMatchingSegment(
+                farPos, 90.0, Collections.singletonList(segment), 15.0, 50.0);
+
+        assertNull(match);
+    }
+
+    @Test
+    public void findMatchingSegmentReverseHeadingSwapsDirectionalNodes() {
+        RoadSegment segment = eastWestSegment();
+        LatLon pos = new LatLon(37.8001, -122.27);
+
+        SegmentMatch match = RoadGeo.findMatchingSegment(
+                pos, 270.0, Collections.singletonList(segment), 15.0, 50.0);
+
+        assertNotNull(match);
+        assertTrue(match.reverse);
+        assertEquals(segment.toNode, match.fromNodeDirectional());
+        assertEquals(segment.fromNode, match.toNodeDirectional());
+    }
+}

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeReportCodecTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeReportCodecTest.java
@@ -50,6 +50,34 @@ public class WazeReportCodecTest {
         assertNull(WazeReportCodec.buildRequest(req("SOS_MEDICAL_HELP"), 1L, 0, 0));
     }
 
+    // Unknown heading defaults to the -720 sentinel (ReportRequest.fromJson); the
+    // azymuth sent to Waze must be normalized to [0,360), matching
+    // WazeSession.submitReport's normalizeAngle360 for the At command, not sent
+    // raw as an invalid -720 compass value.
+    @Test public void unknownHeadingNormalizesAzymuthToZero() throws JSONException {
+        ReportRequest noHeading = ReportRequest.fromJson("{\"lat\":37.8,\"lon\":-122.2712," +
+                "\"type\":\"POLICE_VISIBLE\",\"time_delta_s\":10}");
+        WazeProto.AddUserReportedAlertRequest r =
+                WazeReportCodec.buildRequest(noHeading, 1_700_000_000_000L, 0, 0);
+        assertEquals(0, r.getAzymuth());
+    }
+
+    @Test public void normalHeadingAzymuthUnchanged() throws JSONException {
+        ReportRequest h27 = ReportRequest.fromJson("{\"lat\":37.8,\"lon\":-122.2712," +
+                "\"heading_deg\":27.0,\"type\":\"POLICE_VISIBLE\",\"time_delta_s\":10}");
+        WazeProto.AddUserReportedAlertRequest r =
+                WazeReportCodec.buildRequest(h27, 1_700_000_000_000L, 0, 0);
+        assertEquals(27, r.getAzymuth());
+    }
+
+    @Test public void headingOver360WrapsAzymuth() throws JSONException {
+        ReportRequest h370 = ReportRequest.fromJson("{\"lat\":37.8,\"lon\":-122.2712," +
+                "\"heading_deg\":370.0,\"type\":\"POLICE_VISIBLE\",\"time_delta_s\":10}");
+        WazeProto.AddUserReportedAlertRequest r =
+                WazeReportCodec.buildRequest(h370, 1_700_000_000_000L, 0, 0);
+        assertEquals(10, r.getAzymuth());
+    }
+
     @Test public void parsesResponseUuidAndPoints() {
         WazeProto.Batch batch = WazeProto.Batch.newBuilder()
                 .addElement(WazeProto.Element.newBuilder()

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeReportCodecTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeReportCodecTest.java
@@ -1,6 +1,7 @@
 package app.sabre.wzsabre.waze;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -57,5 +58,58 @@ public class WazeReportCodecTest {
                 .build();
         assertEquals("uuid-xyz", WazeReportCodec.reportUuidFrom(batch));
         assertEquals(6, WazeReportCodec.reportPointsFrom(batch));
+    }
+
+    // Live-Waze finding: a snapped report (with SegmentNodes) comes back with
+    // received_points_count=6, status=STATUS_UNSPECIFIED (the default), and an
+    // EMPTY alert_uuid, on anonymous accounts. That is still an accepted report:
+    // acceptance must be keyed off the presence of the response element (and it
+    // not being an explicit FAILURE), not off a non-empty uuid.
+    @Test public void acceptedWithPointsAndEmptyUuid() {
+        WazeProto.Batch batch = WazeProto.Batch.newBuilder()
+                .addElement(WazeProto.Element.newBuilder()
+                        .setAddUserReportedAlertResponse(WazeProto.AddUserReportedAlertResponse.newBuilder()
+                                .setReceivedPointsCount(6)
+                                // status left unset -> defaults to STATUS_UNSPECIFIED
+                                .build()).build())
+                .build();
+        assertTrue(WazeReportCodec.reportAccepted(batch));
+        assertEquals(6, WazeReportCodec.reportPointsFrom(batch));
+        assertNull(WazeReportCodec.reportUuidFrom(batch));
+    }
+
+    @Test public void acceptedSuccessWithUuid() {
+        WazeProto.Batch batch = WazeProto.Batch.newBuilder()
+                .addElement(WazeProto.Element.newBuilder()
+                        .setAddUserReportedAlertResponse(WazeProto.AddUserReportedAlertResponse.newBuilder()
+                                .setStatus(WazeProto.AddUserReportedAlertResponse.AddAlertStatus.SUCCESS)
+                                .setAlertUuid("abc")
+                                .setReceivedPointsCount(0)
+                                .build()).build())
+                .build();
+        assertTrue(WazeReportCodec.reportAccepted(batch));
+        assertEquals("abc", WazeReportCodec.reportUuidFrom(batch));
+    }
+
+    @Test public void rejectedOnExplicitFailure() {
+        WazeProto.Batch batch = WazeProto.Batch.newBuilder()
+                .addElement(WazeProto.Element.newBuilder()
+                        .setAddUserReportedAlertResponse(WazeProto.AddUserReportedAlertResponse.newBuilder()
+                                .setStatus(WazeProto.AddUserReportedAlertResponse.AddAlertStatus.FAILURE)
+                                .build()).build())
+                .build();
+        assertFalse(WazeReportCodec.reportAccepted(batch));
+    }
+
+    @Test public void notAcceptedWhenNoResponseElement() {
+        // An empty batch (no elements at all) mirrors the confirmed contrast case:
+        // a position-only report (no SegmentNodes) gets no response element back.
+        WazeProto.Batch empty = WazeProto.Batch.newBuilder().build();
+        assertFalse(WazeReportCodec.reportAccepted(empty));
+
+        WazeProto.Batch unrelated = WazeProto.Batch.newBuilder()
+                .addElement(WazeProto.Element.newBuilder().setOldCommand("noop").build())
+                .build();
+        assertFalse(WazeReportCodec.reportAccepted(unrelated));
     }
 }

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeReportCodecTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeReportCodecTest.java
@@ -1,0 +1,61 @@
+package app.sabre.wzsabre.waze;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import app.sabre.wzsabre.ReportRequest;
+import org.json.JSONException;
+import org.junit.Test;
+
+public class WazeReportCodecTest {
+
+    private static ReportRequest req(String type) throws JSONException {
+        // lon = -122.2712 so getLonTimes1000000() == -122271200 below (matches the
+        // Task 1 WazeReportProtoTest fixture coordinate exactly).
+        return ReportRequest.fromJson("{\"lat\":37.8,\"lon\":-122.2712,\"heading_deg\":90.0," +
+                "\"type\":\"" + type + "\",\"time_delta_s\":10}");
+    }
+
+    @Test public void buildsPoliceRequestPositionOnly() throws JSONException {
+        WazeProto.AddUserReportedAlertRequest r =
+                WazeReportCodec.buildRequest(req("POLICE_VISIBLE"), 1_700_000_000_000L, 0, 0);
+        assertEquals(WazeProto.PoliceAlertSubType.POLICE_DEFAULT, r.getAlertDetails().getPolice().getType());
+        assertEquals(90, r.getAzymuth());
+        assertEquals(1_700_000_000L - 10, r.getReportTime().getSeconds());
+        assertEquals(WazeProto.ReportingManner.REPORTING_MANNER_DEFAULT, r.getReportingManner());
+        assertEquals(-122271200, r.getUserPosition().getGpsPosition().getCoordinate().getLonTimes1000000());
+        assertTrue(!r.getUserPosition().hasSegmentNodes()); // position-only
+    }
+
+    @Test public void buildsWithSegmentNodesWhenProvided() throws JSONException {
+        WazeProto.AddUserReportedAlertRequest r =
+                WazeReportCodec.buildRequest(req("HAZARD_ON_ROAD_POT_HOLE"), 1_700_000_000_000L, 111, 222);
+        assertEquals(111, r.getUserPosition().getSegmentNodes().getFromNode());
+        assertEquals(222, r.getUserPosition().getSegmentNodes().getToNode());
+        assertEquals(WazeProto.HazardReportSubType.HAZARD_REPORT_POTHOLE,
+                r.getAlertDetails().getHazardOnRoad().getType());
+    }
+
+    @Test public void oppositeDirectionSetsBackward() throws JSONException {
+        ReportRequest opp = ReportRequest.fromJson("{\"lat\":37.8,\"lon\":-122.27," +
+                "\"type\":\"ACCIDENT_MAJOR\",\"is_opposite\":true}");
+        WazeProto.AddUserReportedAlertRequest r = WazeReportCodec.buildRequest(opp, 1L, 0, 0);
+        assertEquals(WazeProto.SegmentDirection.SEGMENT_DIRECTION_BACKWARD, r.getSegmentDirection());
+        assertEquals(WazeProto.CrashReportSubType.CRASH_REPORT_MAJOR, r.getAlertDetails().getCrash().getType());
+    }
+
+    @Test public void nullForUnreportableType() throws JSONException {
+        assertNull(WazeReportCodec.buildRequest(req("SOS_MEDICAL_HELP"), 1L, 0, 0));
+    }
+
+    @Test public void parsesResponseUuidAndPoints() {
+        WazeProto.Batch batch = WazeProto.Batch.newBuilder()
+                .addElement(WazeProto.Element.newBuilder()
+                        .setAddUserReportedAlertResponse(WazeProto.AddUserReportedAlertResponse.newBuilder()
+                                .setAlertUuid("uuid-xyz").setReceivedPointsCount(6).build()).build())
+                .build();
+        assertEquals("uuid-xyz", WazeReportCodec.reportUuidFrom(batch));
+        assertEquals(6, WazeReportCodec.reportPointsFrom(batch));
+    }
+}

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeReportProtoTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeReportProtoTest.java
@@ -1,0 +1,60 @@
+package app.sabre.wzsabre.waze;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.junit.Test;
+
+/** Locks the report protobuf wire format: field numbers and round-trip. */
+public class WazeReportProtoTest {
+
+    @Test
+    public void requestEncodesAndRoundTrips() throws InvalidProtocolBufferException {
+        WazeProto.CoordinateWithAlt coord = WazeProto.CoordinateWithAlt.newBuilder()
+                .setLonTimes1000000(-122271200)
+                .setLatTimes1000000(37804400)
+                .setAltTimes1000000(0)
+                .build();
+        WazeProto.GpsPosition gps = WazeProto.GpsPosition.newBuilder()
+                .setCoordinate(coord).setHorizontalAccuracyMeters(10.0).setTimeEpochMs(1_700_000_000_000L)
+                .build();
+        WazeProto.AddUserReportedAlertRequest req = WazeProto.AddUserReportedAlertRequest.newBuilder()
+                .setUserPosition(WazeProto.UserPosition.newBuilder().setGpsPosition(gps).build())
+                .setAzymuth(90)
+                .setAlertDetails(WazeProto.AlertDetails.newBuilder()
+                        .setPolice(WazeProto.PoliceDetails.newBuilder()
+                                .setType(WazeProto.PoliceAlertSubType.POLICE_DEFAULT).build()).build())
+                .setSegmentDirection(WazeProto.SegmentDirection.SEGMENT_DIRECTION_FORWARD)
+                .setReportTime(WazeProto.Timestamp.newBuilder().setSeconds(1_700_000_000L).build())
+                .setReportingManner(WazeProto.ReportingManner.REPORTING_MANNER_DEFAULT)
+                .build();
+
+        byte[] bytes = req.toByteArray();
+        WazeProto.AddUserReportedAlertRequest back =
+                WazeProto.AddUserReportedAlertRequest.parseFrom(bytes);
+
+        assertEquals(-122271200, back.getUserPosition().getGpsPosition().getCoordinate().getLonTimes1000000());
+        assertEquals(90, back.getAzymuth());
+        assertEquals(WazeProto.PoliceAlertSubType.POLICE_DEFAULT, back.getAlertDetails().getPolice().getType());
+        assertEquals(WazeProto.ReportingManner.REPORTING_MANNER_DEFAULT, back.getReportingManner());
+    }
+
+    @Test
+    public void requestRidesOnElement2737() throws InvalidProtocolBufferException {
+        WazeProto.AddUserReportedAlertRequest req = WazeProto.AddUserReportedAlertRequest.newBuilder()
+                .setAzymuth(7).build();
+        WazeProto.Element el = WazeProto.Element.newBuilder()
+                .setAddUserReportedAlertRequest(req).build();
+        byte[] bytes = el.toByteArray();
+        WazeProto.Element back = WazeProto.Element.parseFrom(bytes);
+        assertEquals(7, back.getAddUserReportedAlertRequest().getAzymuth());
+        // Response parses from the 2738 member.
+        WazeProto.Element resp = WazeProto.Element.newBuilder()
+                .setAddUserReportedAlertResponse(WazeProto.AddUserReportedAlertResponse.newBuilder()
+                        .setAlertUuid("abc").setReceivedPointsCount(6).build()).build();
+        WazeProto.Element rback = WazeProto.Element.parseFrom(resp.toByteArray());
+        assertEquals("abc", rback.getAddUserReportedAlertResponse().getAlertUuid());
+        assertEquals(6, rback.getAddUserReportedAlertResponse().getReceivedPointsCount());
+    }
+}

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeRtCodecTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeRtCodecTest.java
@@ -28,4 +28,33 @@ public class WazeRtCodecTest {
         assertTrue(WazeRtCodec.parseRemovedAlertIds(
                 WazeProto.Batch.newBuilder().build()).isEmpty());
     }
+
+    // ── At / SeeMe command builders (Task R4) ──────────────────────────────
+
+    @Test
+    public void atCommandFormatsMatchedSegmentNodes() {
+        assertEquals("At,-122.2712,37.8044,0,90,1,111,222,T,0,-1,-1,0",
+                WazeRtCodec.atCommand(-122.2712, 37.8044, 90, 111, 222));
+    }
+
+    @Test
+    public void atCommandUsesMinusOneForNoMatch() {
+        assertEquals("At,-122.2712,37.8044,0,90,1,-1,-1,T,0,-1,-1,0",
+                WazeRtCodec.atCommand(-122.2712, 37.8044, 90, -1, -1));
+    }
+
+    @Test
+    public void seeMeCommandMode2IsTerse() {
+        assertEquals("SeeMe,2", WazeRtCodec.seeMeCommand(2));
+    }
+
+    @Test
+    public void seeMeCommandMode1MatchesExistingConstant() {
+        assertEquals("SeeMe,1,2,T,T,T,1,-1,1,7", WazeRtCodec.seeMeCommand(1));
+    }
+
+    @Test
+    public void noArgSeeMeCommandStillWorks() {
+        assertEquals("SeeMe,1,2,T,T,T,1,-1,1,7", WazeRtCodec.seeMeCommand());
+    }
 }

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeRtCodecTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeRtCodecTest.java
@@ -44,8 +44,8 @@ public class WazeRtCodecTest {
     }
 
     @Test
-    public void seeMeCommandMode2IsTerse() {
-        assertEquals("SeeMe,2", WazeRtCodec.seeMeCommand(2));
+    public void seeMeCommandMode2FollowsReferenceFormula() {
+        assertEquals("SeeMe,2,2,T,T,T,1,-1,1,7", WazeRtCodec.seeMeCommand(2));
     }
 
     @Test

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeTileCodecTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeTileCodecTest.java
@@ -1,0 +1,39 @@
+package app.sabre.wzsabre.waze;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Pure math for the Waze tile GET: tile-id computation and URL building.
+ * Ported from wzsabre 2.2 wazemo.WazeTileParser (buildTileUrl/coordToTileId).
+ */
+public class WazeTileCodecTest {
+
+    @Test
+    public void coordToTileIdMatchesExpectedLiteral() {
+        // lon=-122.2712 -> lon*1e6 = -122271200; +180000000 = 57728800; /10000 = 5772
+        // lat=37.8044   -> lat*1e6 =   37804400; +90000000  = 127804400; /10000 = 12780
+        // tileId = 5772*18000 + 12780 = 103896000 + 12780 = 103908780
+        assertEquals(103908780, WazeTileCodec.coordToTileId(-122.2712, 37.8044));
+    }
+
+    @Test
+    public void buildTileUrlIncludesSessionPartWhenLoggedIn() {
+        String url = WazeTileCodec.buildTileUrl("ctilesgcs-am.waze.com", 833, "abc", 12345);
+        assertEquals(
+                "https://ctilesgcs-am.waze.com/TileServer/multi-get?reqtype=tileBatch&protocol=2"
+                        + "&sessionid=833&cookie=abc&num=1&variation=PARTIAL_SIMPLIFICATION"
+                        + "&t0=12345&v0=0&p0=42",
+                url);
+    }
+
+    @Test
+    public void buildTileUrlOmitsSessionPartWhenNotLoggedIn() {
+        String url = WazeTileCodec.buildTileUrl("h", 0, null, 7);
+        assertEquals(
+                "https://h/TileServer/multi-get?reqtype=tileBatch&protocol=2"
+                        + "&num=1&variation=PARTIAL_SIMPLIFICATION&t0=7&v0=0&p0=42",
+                url);
+    }
+}

--- a/app/src/test/java/app/sabre/wzsabre/waze/WazeTileParserTest.java
+++ b/app/src/test/java/app/sabre/wzsabre/waze/WazeTileParserTest.java
@@ -1,0 +1,140 @@
+package app.sabre.wzsabre.waze;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.zip.Deflater;
+
+import org.junit.Test;
+
+/**
+ * WZDF binary tile decoder. Ported from wzsabre 2.2 wazemo.WazeTileParser.
+ * The full-decode fixture below hand-derives the section directory's
+ * (offset, cumulative-end) encoding directly from the byte layout in
+ * roadsnap-recon.md section B; it does not reuse WazeTileParser's own code.
+ */
+public class WazeTileParserTest {
+
+    private static final byte[] MAGIC = {87, 90, 68, 70, 1, 0, 0, 0, 0, 0, 3, 0};
+
+    private static void putU16LE(byte[] b, int off, int v) {
+        b[off] = (byte) (v & 0xFF);
+        b[off + 1] = (byte) ((v >> 8) & 0xFF);
+    }
+
+    private static void putU32LE(byte[] b, int off, int v) {
+        b[off] = (byte) (v & 0xFF);
+        b[off + 1] = (byte) ((v >> 8) & 0xFF);
+        b[off + 2] = (byte) ((v >> 16) & 0xFF);
+        b[off + 3] = (byte) ((v >> 24) & 0xFF);
+    }
+
+    private static byte[] deflate(byte[] raw) {
+        Deflater deflater = new Deflater();
+        deflater.setInput(raw);
+        deflater.finish();
+        byte[] buf = new byte[raw.length * 2 + 64];
+        int n = deflater.deflate(buf);
+        deflater.end();
+        return Arrays.copyOf(buf, n);
+    }
+
+    private static byte[] wrapWzdf(byte[] sections) {
+        byte[] compressed = deflate(sections);
+        byte[] tile = new byte[12 + 4 + 4 + compressed.length];
+        System.arraycopy(MAGIC, 0, tile, 0, 12);
+        putU32LE(tile, 12, compressed.length);
+        putU32LE(tile, 16, sections.length);
+        System.arraycopy(compressed, 0, tile, 20, compressed.length);
+        return tile;
+    }
+
+    @Test
+    public void parseReturnsEmptyWhenNoWzdfMagic() {
+        List<RoadSegment> segs = WazeTileParser.parse(new byte[]{0, 1, 2});
+        assertTrue(segs.isEmpty());
+    }
+
+    @Test
+    public void parseReturnsEmptyWhenNumSectionsAtOrBelow26() {
+        // Minimal sections payload: just the 8-byte header (numSections, alignBits).
+        // numSections<=26 must short-circuit before the directory/section reads.
+        byte[] sections = new byte[8];
+        putU32LE(sections, 0, 5);   // numSections
+        putU32LE(sections, 4, 0);  // alignBits
+        byte[] tile = wrapWzdf(sections);
+
+        List<RoadSegment> segs = WazeTileParser.parse(tile);
+        assertTrue(segs.isEmpty());
+    }
+
+    @Test
+    public void parseDecodesOneSegmentBetweenTwoNodes() {
+        // --- Hand-derive the section directory (recon B: alignOffset(v,bits) with
+        // bits=0 is the identity function, so directory "value" fields are simply
+        // the cumulative end-offset, relative to `base`, of each section in turn). ---
+        // Sections used: 8 (point deltas, empty), 9 (segments, 1 entry = 8 bytes),
+        // 13 (nodes, 2 entries = 8 bytes), 26 (tile header, 12 bytes). All others
+        // are zero-length. numSections must be 27 so index 26 exists.
+        final int numSections = 27;
+        final int alignBits = 0;
+        int[] dirValues = new int[numSections];
+        for (int i = 0; i <= 8; i++) dirValues[i] = 0;      // sections 0-8 empty
+        dirValues[9] = 8;                                    // segments: 0..8
+        for (int i = 10; i <= 12; i++) dirValues[i] = 8;     // 10-12 empty (stay at 8)
+        dirValues[13] = 16;                                  // nodes: 8..16
+        for (int i = 14; i <= 25; i++) dirValues[i] = 16;    // 14-25 empty (stay at 16)
+        dirValues[26] = 28;                                  // tile header: 16..28
+
+        int base = 8 + numSections * 4;
+        byte[] sections = new byte[base + 28];
+        putU32LE(sections, 0, numSections);
+        putU32LE(sections, 4, alignBits);
+        for (int i = 0; i < numSections; i++) {
+            putU32LE(sections, 8 + i * 4, dirValues[i]);
+        }
+
+        // Section 9: one segment, fromIdx=0, toIdx=1, ptRef=0xFFFF (no polyline deltas).
+        int segOff = base;
+        putU16LE(sections, segOff, 0);
+        putU16LE(sections, segOff + 2, 1);
+        putU16LE(sections, segOff + 4, 0xFFFF);
+        putU16LE(sections, segOff + 6, 0);
+
+        // Section 13: two nodes. node0 lonOff=0,latOff=0; node1 lonOff=20000,latOff=0.
+        int nodesOff = base + 8;
+        putU16LE(sections, nodesOff, 0);
+        putU16LE(sections, nodesOff + 2, 0);
+        putU16LE(sections, nodesOff + 4, 20000);
+        putU16LE(sections, nodesOff + 6, 0);
+
+        // Section 26: tile header, tileId only (remaining 8 bytes unused/zero).
+        int lonIdx = 5772, latIdx = 12780;
+        int tileId = lonIdx * 18000 + latIdx; // 103908780
+        int headerOff = base + 16;
+        putU32LE(sections, headerOff, tileId);
+
+        byte[] tile = wrapWzdf(sections);
+
+        List<RoadSegment> segs = WazeTileParser.parse(tile);
+        assertEquals(1, segs.size());
+        RoadSegment seg = segs.get(0);
+        assertEquals(0L, seg.fromNode);
+        assertEquals(1L, seg.toNode);
+        assertEquals((long) tileId * 100000L, seg.segmentId);
+        assertEquals(2, seg.points.size());
+
+        // Expected coords use the same decode formula as recon B (double math must
+        // match the implementation bit-for-bit since both compute it the same way).
+        double lon0 = ((lonIdx * 10000 - 180000000) + 0) * 1e-6;
+        double lat0 = ((latIdx * 10000 - 90000000) + 0) * 1e-6;
+        double lon1 = ((lonIdx * 10000 - 180000000) + 20000) * 1e-6;
+        double lat1 = ((latIdx * 10000 - 90000000) + 0) * 1e-6;
+        assertEquals(lat0, seg.points.get(0).lat, 1e-9);
+        assertEquals(lon0, seg.points.get(0).lon, 1e-9);
+        assertEquals(lat1, seg.points.get(1).lat, 1e-9);
+        assertEquals(lon1, seg.points.get(1).lon, 1e-9);
+    }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -124,6 +124,8 @@
       <p>
         Every source is fetched in parallel, filtered to the area Highway Radar asked
         about, de-duplicated across sources, and handed over as standard crowd alerts.
+        Reports go both ways too: when you report something in Highway Radar it shows on
+        your map and is submitted to Waze, over an anonymous session.
         Turn any of them off in the app.
       </p>
 

--- a/docs/superpowers/plans/2026-08-12-hr-reports-to-waze.md
+++ b/docs/superpowers/plans/2026-08-12-hr-reports-to-waze.md
@@ -1,0 +1,1497 @@
+# Bidirectional User Reports Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make reports a user creates in Highway Radar (HR) appear on HR's map and get submitted to Waze's live server, closing the gap between SABRE Plus and the original wzsabre.
+
+**Architecture:** HR fires `REPORT`/`CONFIRM`/`DISCARD` broadcasts at `MainBroadcastReceiver`; they are forwarded to `SabreService` like fetches are. A REPORT is (a) added to an in-memory `UserReportStore` that `handleFetchRequest` merges into every HR response for ~30 min (guarantees the HR pin) and (b) submitted to Waze via a new `WazeReporter` using the `AddUserReportedAlertRequest` protobuf. CONFIRM/DISCARD send Waze's `ThumbsUp,<id>` / `ReportRmAlert,<id>` text commands.
+
+**Tech Stack:** Java, Android, protobuf-javalite (`app/src/main/proto/waze.proto` -> `WazeProto`), OkHttp (`WazeHttpClient`), JUnit + org.json for JVM unit tests (no Robolectric).
+
+## Global Constraints
+
+- Target version at ship: `versionName = "1.10.0"`, `versionCode = 27` (from 1.9.6 / 26). Bump only at the ship task, after emulator validation.
+- No new Android permission. Reporting and any tile fetch use existing INTERNET only. (Hard constraint from project rules.)
+- No em dashes in any user-facing string (Toast/notification/CHANGELOG/release notes). Use colons/commas/periods.
+- No user attribution anywhere (CHANGELOG/commits/release notes): never "one user reported".
+- `alert_source` on any echoed alert MUST be one of the advertised ids: `chp`/`waze`/`lcs`/`fire`/`chains`. Echoed reports use `waze`.
+- An echoed alert's `type` MUST start with `POLICE`/`HAZARD`/`ACCIDENT` or HR's renderer silently drops it.
+- The HR fetch response is exactly 9 fields (locked by `SabreProtocolTest`). Do not change it; the echo store only adds `SabreAlert`s to the existing list.
+- Protobuf field numbers are a wire spec. Use EXACTLY the numbers below; a wrong number breaks silently.
+- JVM unit tests cannot use `android.util.Base64` (returns null under `unitTests.isReturnDefaultValues = true`). Keep Base64 framing out of unit-tested code paths; test proto assembly via generated `.toByteArray()`.
+
+## Exact Waze reporting wire spec (recovered from decompiled wzsabre 2.2)
+
+Element members: `add_user_reported_alert_request = 2737`, `add_user_reported_alert_response = 2738`.
+Confirm command: `ThumbsUp,<alertId>` (decimal long). Discard command: `ReportRmAlert,<alertId>`.
+HR report `type` string -> Waze detail message + subtype enum:
+
+| HR type (prefix) | AlertDetails member | subtype enum value |
+|---|---|---|
+| `POLICE_VISIBLE` | police | POLICE_DEFAULT (1) |
+| `POLICE_HIDDEN`/`POLICE_HIDING` | police | POLICE_HIDDEN (2) |
+| `ACCIDENT_MAJOR` | crash | CRASH_REPORT_MAJOR (3) |
+| `ACCIDENT_MINOR` (or other ACCIDENT) | crash | CRASH_REPORT_MINOR (4) |
+| `JAM_STAND_STILL_TRAFFIC` | traffic | TRAFFIC_REPORT_STANDSTILL (2) |
+| `JAM_LIGHT_TRAFFIC` | traffic | TRAFFIC_REPORT_LIGHT (3) |
+| `JAM_MODERATE_TRAFFIC` | traffic | TRAFFIC_REPORT_MODERATE (4) |
+| `JAM_HEAVY_TRAFFIC` (or other JAM) | traffic | TRAFFIC_REPORT_HEAVY (5) |
+| `HAZARD_ON_ROAD_CONSTRUCTION` | hazard_on_road | HAZARD_REPORT_CONSTRUCTION (2) |
+| `HAZARD_ON_ROAD_CAR_STOPPED` | hazard_on_road | HAZARD_REPORT_VEHICLE_STOPPED (3) |
+| `HAZARD_ON_ROAD_OBJECT` | hazard_on_road | HAZARD_REPORT_OBJECT_ON_ROAD (4) |
+| `HAZARD_ON_ROAD_POT_HOLE` | hazard_on_road | HAZARD_REPORT_POTHOLE (5) |
+| `HAZARD_ON_ROAD_TRAFFIC_LIGHT_FAULT` | hazard_on_road | HAZARD_REPORT_BROKEN_TRAFFIC_LIGHT (6) |
+| `HAZARD_ON_ROAD_OIL` | hazard_on_road | HAZARD_REPORT_OIL (7) |
+| `HAZARD_ON_SHOULDER_ANIMALS` | hazard_on_road | HAZARD_REPORT_ANIMALS (8) |
+| `HAZARD_ON_SHOULDER_MISSING_SIGN` | hazard_on_road | HAZARD_REPORT_MISSING_SIGN (9) |
+| `HAZARD_ON_ROAD_ROAD_KILL` | hazard_on_road | HAZARD_REPORT_ROAD_KILL (10) |
+| `HAZARD_ON_SHOULDER_CAR_STOPPED` | hazard_on_road | HAZARD_REPORT_SHOULDER_VEHICLE_STOPPED (12) |
+| `HAZARD_ON_SHOULDER` (bare) | hazard_on_road | HAZARD_REPORT_SHOULDER (11) |
+| any other `HAZARD*` | hazard_on_road | HAZARD_REPORT_DEFAULT (1) |
+| anything else | (reject Waze submit; echo still shows) | n/a |
+
+---
+
+## File Structure
+
+- `app/src/main/proto/waze.proto` — add reporting messages + 2 Element fields (Task 1).
+- `app/src/main/java/app/sabre/wzsabre/ReportRequest.java` — NEW, parsed REPORT payload (Task 3).
+- `app/src/main/java/app/sabre/wzsabre/ConfirmDiscardRequest.java` — NEW, parsed CONFIRM/DISCARD payload + Waze-id recovery (Task 3).
+- `app/src/main/java/app/sabre/wzsabre/UserReportStore.java` — NEW, echo store (Task 4).
+- `app/src/main/java/app/sabre/wzsabre/AlertMapper.java` — add `renderableEchoType` + `wazeReportSubtype` (Task 2).
+- `app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java` — `classifyReportAction` + dispatch (Task 5).
+- `app/src/main/java/app/sabre/wzsabre/waze/WazeReportCodec.java` — NEW, assemble `AddUserReportedAlertRequest` from a ReportRequest, returns proto (Task 6).
+- `app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java` — add `submitReport`/`confirmAlert`/`discardAlert` (Task 7).
+- `app/src/main/java/app/sabre/wzsabre/waze/WazeReporter.java` — NEW, session mgmt + selfTest (Task 8).
+- `app/src/main/java/app/sabre/wzsabre/SabreService.java` — dispatch + merge store (Task 9).
+- Tests under `app/src/test/java/app/sabre/wzsabre/` and `.../waze/`.
+
+---
+
+## Task 1: Reporting protobuf messages
+
+**Files:**
+- Modify: `app/src/main/proto/waze.proto` (add to `message Element`; append reporting messages at the reporting section)
+- Test: `app/src/test/java/app/sabre/wzsabre/waze/WazeReportProtoTest.java` (new)
+
+**Interfaces:**
+- Produces: generated `WazeProto.AddUserReportedAlertRequest`, `.AddUserReportedAlertResponse`, `.UserPosition`, `.GpsPosition`, `.CoordinateWithAlt`, `.SegmentNodes`, `.Timestamp`, `.ReportingManner`, `.AlertDetails`, `.PoliceDetails`, `.CrashDetails`, `.TrafficDetails`, `.HazardOnRoadDetails` and their subtype enums; `WazeProto.Element` gains `getAddUserReportedAlertRequest()`/`setAddUserReportedAlertRequest()`/`hasAddUserReportedAlertResponse()`/`getAddUserReportedAlertResponse()`.
+
+- [ ] **Step 1: Add the two Element members.** In `waze.proto`, inside `message Element { ... }`, after `optional AddAlertAction add_alert_action = 2708;` add:
+
+```proto
+  optional AddUserReportedAlertRequest add_user_reported_alert_request = 2737;
+  optional AddUserReportedAlertResponse add_user_reported_alert_response = 2738;
+```
+
+- [ ] **Step 2: Append the reporting messages** at the end of `waze.proto` (before EOF), copying this block verbatim (field numbers are the wire spec):
+
+```proto
+// ---------------------------------------------------------------------------
+// Alert REPORTING (write) path. Field numbers from *_FIELD_NUMBER smali
+// constants cross-checked against generated writeTo() (plain int32/int64/enum/
+// double/message, no zig-zag). Built by WazeReportCodec.
+// ---------------------------------------------------------------------------
+
+message CoordinateWithAlt {
+  optional int32 lon_times1000000 = 101;
+  optional int32 lat_times1000000 = 102;
+  optional int32 alt_times1000000 = 103;
+}
+
+message SegmentNodes {
+  optional int64 from_node = 1;
+  optional int64 to_node = 2;
+}
+
+message GpsPosition {
+  optional CoordinateWithAlt coordinate = 1;
+  optional double horizontal_accuracy_meters = 2;
+  optional int64 time_epoch_ms = 3;
+}
+
+message UserPosition {
+  optional GpsPosition gps_position = 1;
+  optional SegmentNodes segment_nodes = 2;
+}
+
+message Timestamp {
+  optional int64 seconds = 1;
+  optional int32 nanos = 2;
+}
+
+enum ReportingManner {
+  REPORTING_MANNER_UNSPECIFIED = 0;
+  REPORTING_MANNER_DEFAULT = 1;
+  REPORTING_MANNER_VOICE = 2;
+  REPORTING_MANNER_VOICE_CONVERSATION = 3;
+}
+
+enum PoliceAlertSubType {
+  POLICE_UNSPECIFIED = 0;
+  POLICE_DEFAULT = 1;
+  POLICE_HIDDEN_REPORT = 2;
+  POLICE_MOBILE_CAMERA = 3;
+}
+message PoliceDetails { optional PoliceAlertSubType type = 1; }
+
+enum CrashReportSubType {
+  CRASH_REPORT_UNSPECIFIED = 0;
+  CRASH_REPORT_DEFAULT = 1;
+  CRASH_REPORT_PILE_UP = 2;
+  CRASH_REPORT_MAJOR = 3;
+  CRASH_REPORT_MINOR = 4;
+}
+message CrashDetails { optional CrashReportSubType type = 1; }
+
+enum TrafficReportSubType {
+  TRAFFIC_REPORT_UNSPECIFIED = 0;
+  TRAFFIC_REPORT_DEFAULT = 1;
+  TRAFFIC_REPORT_STANDSTILL = 2;
+  TRAFFIC_REPORT_LIGHT = 3;
+  TRAFFIC_REPORT_MODERATE = 4;
+  TRAFFIC_REPORT_HEAVY = 5;
+}
+message TrafficDetails { optional TrafficReportSubType type = 1; }
+
+enum HazardReportSubType {
+  HAZARD_REPORT_UNSPECIFIED = 0;
+  HAZARD_REPORT_DEFAULT = 1;
+  HAZARD_REPORT_CONSTRUCTION = 2;
+  HAZARD_REPORT_VEHICLE_STOPPED = 3;
+  HAZARD_REPORT_OBJECT_ON_ROAD = 4;
+  HAZARD_REPORT_POTHOLE = 5;
+  HAZARD_REPORT_BROKEN_TRAFFIC_LIGHT = 6;
+  HAZARD_REPORT_OIL = 7;
+  HAZARD_REPORT_ANIMALS = 8;
+  HAZARD_REPORT_MISSING_SIGN = 9;
+  HAZARD_REPORT_ROAD_KILL = 10;
+  HAZARD_REPORT_SHOULDER = 11;
+  HAZARD_REPORT_SHOULDER_VEHICLE_STOPPED = 12;
+  HAZARD_REPORT_EMERGENCY_VEHICLE = 13;
+}
+message HazardOnRoadDetails { optional HazardReportSubType type = 1; }
+
+message AlertDetails {
+  oneof details {
+    TrafficDetails traffic = 1;
+    PoliceDetails police = 2;
+    CrashDetails crash = 3;
+    HazardOnRoadDetails hazard_on_road = 4;
+  }
+}
+
+message AddUserReportedAlertRequest {
+  optional UserPosition user_position = 1;
+  optional int32 azymuth = 2;
+  optional AlertDetails alert_details = 3;
+  optional SegmentDirection segment_direction = 4;
+  optional Timestamp report_time = 5;
+  optional bool is_offline_delayed_report = 6;
+  optional ReportingManner reporting_manner = 7;
+}
+
+message AddUserReportedAlertResponse {
+  enum AddAlertStatus {
+    STATUS_UNSPECIFIED = 0;
+    SUCCESS = 1;
+    FAILURE = 2;
+  }
+  optional AddAlertStatus status = 1;
+  optional int32 received_points_count = 2;
+  optional int64 client_alert_id = 3;
+  optional AlertDetails alert_details = 4;
+  optional string alert_uuid = 5;
+}
+```
+
+Note: enum constant names must be globally unique in proto2. `POLICE_HIDDEN` already exists in `AlertSubType` (value 202), so the police-report value is named `POLICE_HIDDEN_REPORT` here; likewise these report enums are new names and do not collide with the fetch-path `AlertSubType`. `SegmentDirection` is the enum already defined in this file (reused).
+
+- [ ] **Step 3: Write the failing test** `WazeReportProtoTest.java`:
+
+```java
+package app.sabre.wzsabre.waze;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.junit.Test;
+
+/** Locks the report protobuf wire format: field numbers and round-trip. */
+public class WazeReportProtoTest {
+
+    @Test
+    public void requestEncodesAndRoundTrips() throws InvalidProtocolBufferException {
+        WazeProto.CoordinateWithAlt coord = WazeProto.CoordinateWithAlt.newBuilder()
+                .setLonTimes1000000(-122271200)
+                .setLatTimes1000000(37804400)
+                .setAltTimes1000000(0)
+                .build();
+        WazeProto.GpsPosition gps = WazeProto.GpsPosition.newBuilder()
+                .setCoordinate(coord).setHorizontalAccuracyMeters(10.0).setTimeEpochMs(1_700_000_000_000L)
+                .build();
+        WazeProto.AddUserReportedAlertRequest req = WazeProto.AddUserReportedAlertRequest.newBuilder()
+                .setUserPosition(WazeProto.UserPosition.newBuilder().setGpsPosition(gps).build())
+                .setAzymuth(90)
+                .setAlertDetails(WazeProto.AlertDetails.newBuilder()
+                        .setPolice(WazeProto.PoliceDetails.newBuilder()
+                                .setType(WazeProto.PoliceAlertSubType.POLICE_DEFAULT).build()).build())
+                .setSegmentDirection(WazeProto.SegmentDirection.SEGMENT_DIRECTION_FORWARD)
+                .setReportTime(WazeProto.Timestamp.newBuilder().setSeconds(1_700_000_000L).build())
+                .setReportingManner(WazeProto.ReportingManner.REPORTING_MANNER_DEFAULT)
+                .build();
+
+        byte[] bytes = req.toByteArray();
+        WazeProto.AddUserReportedAlertRequest back =
+                WazeProto.AddUserReportedAlertRequest.parseFrom(bytes);
+
+        assertEquals(-122271200, back.getUserPosition().getGpsPosition().getCoordinate().getLonTimes1000000());
+        assertEquals(90, back.getAzymuth());
+        assertEquals(WazeProto.PoliceAlertSubType.POLICE_DEFAULT, back.getAlertDetails().getPolice().getType());
+        assertEquals(WazeProto.ReportingManner.REPORTING_MANNER_DEFAULT, back.getReportingManner());
+    }
+
+    @Test
+    public void requestRidesOnElement2737() throws InvalidProtocolBufferException {
+        WazeProto.AddUserReportedAlertRequest req = WazeProto.AddUserReportedAlertRequest.newBuilder()
+                .setAzymuth(7).build();
+        WazeProto.Element el = WazeProto.Element.newBuilder()
+                .setAddUserReportedAlertRequest(req).build();
+        byte[] bytes = el.toByteArray();
+        WazeProto.Element back = WazeProto.Element.parseFrom(bytes);
+        assertEquals(7, back.getAddUserReportedAlertRequest().getAzymuth());
+        // Response parses from the 2738 member.
+        WazeProto.Element resp = WazeProto.Element.newBuilder()
+                .setAddUserReportedAlertResponse(WazeProto.AddUserReportedAlertResponse.newBuilder()
+                        .setAlertUuid("abc").setReceivedPointsCount(6).build()).build();
+        WazeProto.Element rback = WazeProto.Element.parseFrom(resp.toByteArray());
+        assertEquals("abc", rback.getAddUserReportedAlertResponse().getAlertUuid());
+        assertEquals(6, rback.getAddUserReportedAlertResponse().getReceivedPointsCount());
+    }
+}
+```
+
+- [ ] **Step 4: Run and verify it fails to compile** (proto not yet generated with these types).
+
+Run: `./gradlew :app:testDebugUnitTest --tests "app.sabre.wzsabre.waze.WazeReportProtoTest"`
+Expected: FAIL (compile: symbols not found) before Step 1/2, PASS after. On Windows use `gradlew.bat`.
+
+- [ ] **Step 5: Build to regenerate proto and run the test.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "app.sabre.wzsabre.waze.WazeReportProtoTest"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add app/src/main/proto/waze.proto app/src/test/java/app/sabre/wzsabre/waze/WazeReportProtoTest.java
+git commit -m "Add Waze report protobuf messages (AddUserReportedAlertRequest)"
+```
+
+---
+
+## Task 2: AlertMapper report helpers
+
+**Files:**
+- Modify: `app/src/main/java/app/sabre/wzsabre/AlertMapper.java`
+- Test: `app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java` (add cases)
+
+**Interfaces:**
+- Produces:
+  - `static String renderableEchoType(String hrType)` — returns a type starting with POLICE/HAZARD/ACCIDENT (for the HR echo), or null if unusable.
+  - `static WazeReportSubtype wazeReportSubtype(String hrType)` — a small value object naming the AlertDetails member + enum, or null if the type cannot be reported to Waze. Defined as a public static nested class in AlertMapper.
+
+- [ ] **Step 1: Write the failing tests** (append to `AlertMapperTest.java`):
+
+```java
+    @Test
+    public void renderableEchoType_keepsRenderablePrefixes() {
+        assertEquals("POLICE_VISIBLE", AlertMapper.renderableEchoType("POLICE_VISIBLE"));
+        assertEquals("ACCIDENT_MAJOR", AlertMapper.renderableEchoType("ACCIDENT_MAJOR"));
+        assertEquals("HAZARD_ON_ROAD_POT_HOLE", AlertMapper.renderableEchoType("HAZARD_ON_ROAD_POT_HOLE"));
+    }
+
+    @Test
+    public void renderableEchoType_remapsJamsToCongestion() {
+        assertEquals("HAZARD_ON_ROAD_CONGESTION", AlertMapper.renderableEchoType("JAM_HEAVY_TRAFFIC"));
+        assertEquals("HAZARD_ON_ROAD_CONGESTION", AlertMapper.renderableEchoType("ROAD_CLOSED"));
+    }
+
+    @Test
+    public void renderableEchoType_nullForUnusable() {
+        assertNull(AlertMapper.renderableEchoType(null));
+        assertNull(AlertMapper.renderableEchoType(""));
+    }
+
+    @Test
+    public void wazeReportSubtype_mapsKnownTypes() {
+        AlertMapper.WazeReportSubtype p = AlertMapper.wazeReportSubtype("POLICE_HIDDEN");
+        assertEquals(AlertMapper.WazeReportSubtype.Kind.POLICE, p.kind);
+        assertEquals(2, p.subtypeNumber); // POLICE_HIDDEN_REPORT
+        assertEquals(AlertMapper.WazeReportSubtype.Kind.CRASH, AlertMapper.wazeReportSubtype("ACCIDENT_MAJOR").kind);
+        assertEquals(5, AlertMapper.wazeReportSubtype("ACCIDENT_MAJOR").subtypeNumber == 3 ? 5 : AlertMapper.wazeReportSubtype("JAM_HEAVY_TRAFFIC").subtypeNumber);
+        assertEquals(AlertMapper.WazeReportSubtype.Kind.HAZARD, AlertMapper.wazeReportSubtype("HAZARD_ON_ROAD_CAR_STOPPED").kind);
+        assertEquals(3, AlertMapper.wazeReportSubtype("HAZARD_ON_ROAD_CAR_STOPPED").subtypeNumber);
+    }
+
+    @Test
+    public void wazeReportSubtype_nullForUnreportable() {
+        assertNull(AlertMapper.wazeReportSubtype("SOS_MEDICAL_HELP"));
+        assertNull(AlertMapper.wazeReportSubtype(null));
+    }
+```
+
+(Add `import static org.junit.Assert.assertNull;` if absent.)
+
+- [ ] **Step 2: Run to verify failure.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "app.sabre.wzsabre.AlertMapperTest"`
+Expected: FAIL (methods/class not found).
+
+- [ ] **Step 3: Implement** in `AlertMapper.java` (append before the closing brace):
+
+```java
+    /**
+     * The render-safe SABRE type to echo a user's own HR report back as, so HR
+     * draws the pin. HR's `type` is already a SABRE type; keep it if it starts with
+     * POLICE/HAZARD/ACCIDENT, otherwise remap (e.g. JAM_* / ROAD_CLOSED ->
+     * HAZARD_ON_ROAD_CONGESTION). Null if unusable.
+     */
+    public static String renderableEchoType(String hrType) {
+        if (hrType == null || hrType.isEmpty()) return null;
+        String u = hrType.toUpperCase(Locale.US);
+        if (u.startsWith("POLICE") || u.startsWith("HAZARD") || u.startsWith("ACCIDENT")) return hrType;
+        String mapped = fromWazeType(topLevel(u), u); // reuse the fetch remap
+        return mapped != null ? mapped : null;
+    }
+
+    /** Best-effort top-level Waze type name from a subtype string, for reuse of fromWazeType. */
+    private static String topLevel(String u) {
+        if (u.startsWith("JAM")) return "JAM";
+        if (u.startsWith("ROAD_CLOSED")) return "ROAD_CLOSED";
+        if (u.startsWith("POLICE")) return "POLICE";
+        if (u.startsWith("ACCIDENT")) return "ACCIDENT";
+        return "HAZARD";
+    }
+
+    /** Which Waze AlertDetails member + subtype enum number a reported HR type maps to. */
+    public static WazeReportSubtype wazeReportSubtype(String hrType) {
+        if (hrType == null) return null;
+        String u = hrType.toUpperCase(Locale.US);
+        if (u.equals("POLICE_HIDDEN") || u.equals("POLICE_HIDING"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.POLICE, 2);
+        if (u.startsWith("POLICE"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.POLICE, 1);
+        if (u.equals("ACCIDENT_MAJOR"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.CRASH, 3);
+        if (u.startsWith("ACCIDENT"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.CRASH, 4);
+        if (u.equals("JAM_STAND_STILL_TRAFFIC"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.TRAFFIC, 2);
+        if (u.equals("JAM_LIGHT_TRAFFIC"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.TRAFFIC, 3);
+        if (u.equals("JAM_MODERATE_TRAFFIC"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.TRAFFIC, 4);
+        if (u.startsWith("JAM"))
+            return new WazeReportSubtype(WazeReportSubtype.Kind.TRAFFIC, 5);
+        if (u.startsWith("HAZARD")) {
+            int sub = hazardSubtypeNumber(u);
+            return new WazeReportSubtype(WazeReportSubtype.Kind.HAZARD, sub);
+        }
+        return null; // not reportable to Waze (SOS, weather-only, etc.)
+    }
+
+    private static int hazardSubtypeNumber(String u) {
+        if (u.equals("HAZARD_ON_ROAD_CONSTRUCTION")) return 2;
+        if (u.equals("HAZARD_ON_ROAD_CAR_STOPPED")) return 3;
+        if (u.equals("HAZARD_ON_ROAD_OBJECT")) return 4;
+        if (u.equals("HAZARD_ON_ROAD_POT_HOLE")) return 5;
+        if (u.equals("HAZARD_ON_ROAD_TRAFFIC_LIGHT_FAULT")) return 6;
+        if (u.equals("HAZARD_ON_ROAD_OIL")) return 7;
+        if (u.equals("HAZARD_ON_SHOULDER_ANIMALS")) return 8;
+        if (u.equals("HAZARD_ON_SHOULDER_MISSING_SIGN")) return 9;
+        if (u.equals("HAZARD_ON_ROAD_ROAD_KILL")) return 10;
+        if (u.equals("HAZARD_ON_SHOULDER_CAR_STOPPED")) return 12;
+        if (u.equals("HAZARD_ON_SHOULDER")) return 11;
+        return 1; // HAZARD_REPORT_DEFAULT
+    }
+
+    /** Names the Waze AlertDetails member and subtype enum number for a reported type. */
+    public static final class WazeReportSubtype {
+        public enum Kind { POLICE, CRASH, TRAFFIC, HAZARD }
+        public final Kind kind;
+        public final int subtypeNumber;
+        public WazeReportSubtype(Kind kind, int subtypeNumber) {
+            this.kind = kind; this.subtypeNumber = subtypeNumber;
+        }
+    }
+```
+
+- [ ] **Step 4: Run to verify pass.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "app.sabre.wzsabre.AlertMapperTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add app/src/main/java/app/sabre/wzsabre/AlertMapper.java app/src/test/java/app/sabre/wzsabre/AlertMapperTest.java
+git commit -m "Add report type mapping helpers to AlertMapper"
+```
+
+---
+
+## Task 3: Report payload parsers
+
+**Files:**
+- Create: `app/src/main/java/app/sabre/wzsabre/ReportRequest.java`, `.../ConfirmDiscardRequest.java`
+- Test: `app/src/test/java/app/sabre/wzsabre/ReportRequestTest.java` (new)
+
+**Interfaces:**
+- Produces:
+  - `ReportRequest.fromJson(String) -> ReportRequest` with fields `double lat, lon, headingDeg, altitudeM; String type; boolean isOpposite; int timeDeltaS;` throws `org.json.JSONException` on missing lat/lon/type.
+  - `ConfirmDiscardRequest.fromJson(String) -> ConfirmDiscardRequest` with `double lat, lon; String alertId; boolean test;` and `long wazeAlertId()` returning the numeric Waze id parsed from `alertId` (strip `alert-`, split `/`, parse element 0), or `-1` if not parseable.
+
+- [ ] **Step 1: Write the failing tests** `ReportRequestTest.java`:
+
+```java
+package app.sabre.wzsabre;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONException;
+import org.junit.Test;
+
+public class ReportRequestTest {
+
+    @Test
+    public void parsesReportPayload() throws JSONException {
+        ReportRequest r = ReportRequest.fromJson(
+            "{\"lat\":37.8,\"lon\":-122.27,\"heading_deg\":90.0,\"altitude_m\":12.0," +
+            "\"type\":\"POLICE_VISIBLE\",\"is_opposite\":true,\"time_delta_s\":30}");
+        assertEquals(37.8, r.lat, 1e-9);
+        assertEquals(-122.27, r.lon, 1e-9);
+        assertEquals(90.0, r.headingDeg, 1e-9);
+        assertEquals("POLICE_VISIBLE", r.type);
+        assertTrue(r.isOpposite);
+        assertEquals(30, r.timeDeltaS);
+    }
+
+    @Test
+    public void reportDefaultsOptionalFields() throws JSONException {
+        ReportRequest r = ReportRequest.fromJson("{\"lat\":1.0,\"lon\":2.0,\"type\":\"ACCIDENT_MINOR\"}");
+        assertEquals(0, r.timeDeltaS);
+        assertFalse(r.isOpposite);
+    }
+
+    @Test(expected = JSONException.class)
+    public void reportRejectsMissingType() throws JSONException {
+        ReportRequest.fromJson("{\"lat\":1.0,\"lon\":2.0}");
+    }
+
+    @Test
+    public void confirmRecoversWazeId() throws JSONException {
+        ConfirmDiscardRequest c = ConfirmDiscardRequest.fromJson(
+            "{\"lat\":1.0,\"lon\":2.0,\"alert_id\":\"alert-123456/uuid-abc\",\"test\":false}");
+        assertEquals(123456L, c.wazeAlertId());
+        assertFalse(c.test);
+    }
+
+    @Test
+    public void confirmMalformedIdReturnsNegative() throws JSONException {
+        ConfirmDiscardRequest c = ConfirmDiscardRequest.fromJson(
+            "{\"lat\":1.0,\"lon\":2.0,\"alert_id\":\"userreport-99\"}");
+        assertEquals(-1L, c.wazeAlertId());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "app.sabre.wzsabre.ReportRequestTest"`
+Expected: FAIL (classes not found).
+
+- [ ] **Step 3: Implement `ReportRequest.java`:**
+
+```java
+package app.sabre.wzsabre;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/** A user-created report forwarded from HR (app.sabre.wzsabre.REPORT). */
+public final class ReportRequest {
+    public final double lat, lon, headingDeg, altitudeM;
+    public final String type;
+    public final boolean isOpposite;
+    public final int timeDeltaS;
+
+    private ReportRequest(double lat, double lon, double headingDeg, double altitudeM,
+                          String type, boolean isOpposite, int timeDeltaS) {
+        this.lat = lat; this.lon = lon; this.headingDeg = headingDeg; this.altitudeM = altitudeM;
+        this.type = type; this.isOpposite = isOpposite; this.timeDeltaS = timeDeltaS;
+    }
+
+    public static ReportRequest fromJson(String data) throws JSONException {
+        JSONObject o = new JSONObject(data);
+        double lat = o.has("lat") ? o.getDouble("lat") : o.getDouble("latitude");
+        double lon = o.has("lon") ? o.getDouble("lon") : o.getDouble("longitude");
+        String type = o.getString("type");
+        return new ReportRequest(lat, lon,
+                o.optDouble("heading_deg", -720.0),
+                o.optDouble("altitude_m", 0.0),
+                type,
+                o.optBoolean("is_opposite", false),
+                o.optInt("time_delta_s", 0));
+    }
+}
+```
+
+- [ ] **Step 4: Implement `ConfirmDiscardRequest.java`:**
+
+```java
+package app.sabre.wzsabre;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/** A confirm (thumbs-up) or discard (not-there) forwarded from HR. */
+public final class ConfirmDiscardRequest {
+    public final double lat, lon;
+    public final String alertId;
+    public final boolean test;
+
+    private ConfirmDiscardRequest(double lat, double lon, String alertId, boolean test) {
+        this.lat = lat; this.lon = lon; this.alertId = alertId; this.test = test;
+    }
+
+    public static ConfirmDiscardRequest fromJson(String data) throws JSONException {
+        JSONObject o = new JSONObject(data);
+        double lat = o.has("lat") ? o.getDouble("lat") : o.getDouble("latitude");
+        double lon = o.has("lon") ? o.getDouble("lon") : o.getDouble("longitude");
+        return new ConfirmDiscardRequest(lat, lon, o.optString("alert_id", null),
+                o.optBoolean("test", false));
+    }
+
+    /** Numeric Waze alert id embedded in alertId ("alert-<id>/<uuid>"), or -1. */
+    public long wazeAlertId() {
+        if (alertId == null) return -1L;
+        String s = alertId.startsWith("alert-") ? alertId.substring("alert-".length()) : alertId;
+        int slash = s.indexOf('/');
+        if (slash >= 0) s = s.substring(0, slash);
+        try { return Long.parseLong(s.trim()); } catch (NumberFormatException e) { return -1L; }
+    }
+}
+```
+
+- [ ] **Step 5: Run to verify pass.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "app.sabre.wzsabre.ReportRequestTest"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add app/src/main/java/app/sabre/wzsabre/ReportRequest.java app/src/main/java/app/sabre/wzsabre/ConfirmDiscardRequest.java app/src/test/java/app/sabre/wzsabre/ReportRequestTest.java
+git commit -m "Parse HR REPORT/CONFIRM/DISCARD payloads"
+```
+
+---
+
+## Task 4: UserReportStore (HR map echo)
+
+**Files:**
+- Create: `app/src/main/java/app/sabre/wzsabre/UserReportStore.java`
+- Test: `app/src/test/java/app/sabre/wzsabre/UserReportStoreTest.java` (new)
+
+**Interfaces:**
+- Consumes: `SabreAlert`, `AlertMapper.renderableEchoType`, `ReportRequest`.
+- Produces:
+  - `void add(ReportRequest r, long nowMs)`
+  - `List<SabreAlert> activeAlerts(double lat, double lon, double radiusM, long nowMs)`
+  - `void removeNear(double lat, double lon, long nowMs)` (for DISCARD)
+  - TTL constant `TTL_MS = 30 * 60 * 1000L`. Store keyed by generated id; radius filter uses simple equirectangular distance. Thread-safe (synchronized).
+
+- [ ] **Step 1: Write the failing tests** `UserReportStoreTest.java`:
+
+```java
+package app.sabre.wzsabre;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONException;
+import org.junit.Test;
+
+import java.util.List;
+
+public class UserReportStoreTest {
+
+    private static ReportRequest police(double lat, double lon) throws JSONException {
+        return ReportRequest.fromJson("{\"lat\":" + lat + ",\"lon\":" + lon +
+                ",\"type\":\"POLICE_VISIBLE\"}");
+    }
+
+    @Test
+    public void addedReportAppearsInRadiusWithRenderableType() throws JSONException {
+        UserReportStore s = new UserReportStore();
+        s.add(police(37.8, -122.27), 1000L);
+        List<SabreAlert> out = s.activeAlerts(37.8, -122.27, 5000, 2000L);
+        assertEquals(1, out.size());
+        assertEquals("POLICE_VISIBLE", out.get(0).type);
+        assertEquals("waze", out.get(0).alertSource);
+        assertTrue(out.get(0).alertId.contains("userreport"));
+    }
+
+    @Test
+    public void expiredReportsAreDropped() throws JSONException {
+        UserReportStore s = new UserReportStore();
+        s.add(police(37.8, -122.27), 1000L);
+        long later = 1000L + UserReportStore.TTL_MS + 1;
+        assertTrue(s.activeAlerts(37.8, -122.27, 5000, later).isEmpty());
+    }
+
+    @Test
+    public void outOfRadiusReportsAreFiltered() throws JSONException {
+        UserReportStore s = new UserReportStore();
+        s.add(police(37.8, -122.27), 1000L);
+        // ~100km away
+        assertTrue(s.activeAlerts(38.7, -122.27, 5000, 2000L).isEmpty());
+    }
+
+    @Test
+    public void removeNearDropsMatchingReport() throws JSONException {
+        UserReportStore s = new UserReportStore();
+        s.add(police(37.8, -122.27), 1000L);
+        s.removeNear(37.8001, -122.2701, 1500L);
+        assertTrue(s.activeAlerts(37.8, -122.27, 5000, 2000L).isEmpty());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "app.sabre.wzsabre.UserReportStoreTest"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `UserReportStore.java`:**
+
+```java
+package app.sabre.wzsabre;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Holds the user's own HR reports for a while so every HR fetch echoes them back
+ * and HR draws the pin, independent of whether Waze accepts the report. In-memory,
+ * thread-safe, entries expire after {@link #TTL_MS}.
+ */
+public final class UserReportStore {
+    public static final long TTL_MS = 30 * 60 * 1000L;
+    private static final double MATCH_RADIUS_M = 120.0;
+
+    private static final class Entry {
+        final SabreAlert alert;
+        final long addedMs;
+        Entry(SabreAlert a, long t) { alert = a; addedMs = t; }
+    }
+
+    private final List<Entry> entries = new ArrayList<>();
+
+    public synchronized void add(ReportRequest r, long nowMs) {
+        String type = AlertMapper.renderableEchoType(r.type);
+        if (type == null) return; // nothing HR would draw
+        String id = "alert-0/userreport-" + nowMs;
+        long reportTs = (nowMs / 1000L) - r.timeDeltaS;
+        SabreAlert a = new SabreAlert(id, SabreResponseBuilder.SOURCE_WAZE, type,
+                r.lat, r.lon, r.headingDeg, null, reportTs, null, 0);
+        entries.add(new Entry(a, nowMs));
+    }
+
+    public synchronized List<SabreAlert> activeAlerts(double lat, double lon,
+                                                      double radiusM, long nowMs) {
+        purge(nowMs);
+        List<SabreAlert> out = new ArrayList<>();
+        for (Entry e : entries) {
+            if (distanceM(lat, lon, e.alert.lat, e.alert.lon) <= radiusM) out.add(e.alert);
+        }
+        return out;
+    }
+
+    public synchronized void removeNear(double lat, double lon, long nowMs) {
+        purge(nowMs);
+        for (Iterator<Entry> it = entries.iterator(); it.hasNext(); ) {
+            Entry e = it.next();
+            if (distanceM(lat, lon, e.alert.lat, e.alert.lon) <= MATCH_RADIUS_M) it.remove();
+        }
+    }
+
+    private void purge(long nowMs) {
+        for (Iterator<Entry> it = entries.iterator(); it.hasNext(); ) {
+            if (nowMs - it.next().addedMs > TTL_MS) it.remove();
+        }
+    }
+
+    private static double distanceM(double lat1, double lon1, double lat2, double lon2) {
+        double mPerDegLat = 110574.0;
+        double mPerDegLon = 111320.0 * Math.cos(Math.toRadians((lat1 + lat2) / 2.0));
+        double dy = (lat1 - lat2) * mPerDegLat;
+        double dx = (lon1 - lon2) * mPerDegLon;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "app.sabre.wzsabre.UserReportStoreTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add app/src/main/java/app/sabre/wzsabre/UserReportStore.java app/src/test/java/app/sabre/wzsabre/UserReportStoreTest.java
+git commit -m "Add UserReportStore for the HR map echo"
+```
+
+---
+
+## Task 5: Receiver action classification + dispatch
+
+**Files:**
+- Modify: `app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java`
+- Test: `app/src/test/java/app/sabre/wzsabre/MainBroadcastReceiverTest.java` (new)
+
+**Interfaces:**
+- Produces: `static String classifyReportAction(String action)` returning `"REPORT"`, `"CONFIRM"`, `"DISCARD"`, or `null`. Pure (no Android). Dispatch in `onReceive` forwards via `ForegroundServiceStarter.start(context, classified, intent.getStringExtra("data"))`.
+
+- [ ] **Step 1: Write the failing test** `MainBroadcastReceiverTest.java`:
+
+```java
+package app.sabre.wzsabre;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class MainBroadcastReceiverTest {
+    @Test public void classifiesOfficialActions() {
+        assertEquals("REPORT",  MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.REPORT"));
+        assertEquals("CONFIRM", MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.CONFIRM"));
+        assertEquals("DISCARD", MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.DISCARD"));
+    }
+    @Test public void classifiesLegacyNames() {
+        assertEquals("REPORT",  MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.SUBMIT_REPORT"));
+        assertEquals("CONFIRM", MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.CONFIRM_REPORT"));
+        assertEquals("DISCARD", MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.DISCARD_REPORT"));
+    }
+    @Test public void ignoresFetchAndShutdownAndNull() {
+        assertNull(MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.REQUEST"));
+        assertNull(MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.FETCH_REQUEST"));
+        assertNull(MainBroadcastReceiver.classifyReportAction("app.sabre.wzsabre.SHUTDOWN"));
+        assertNull(MainBroadcastReceiver.classifyReportAction(null));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "app.sabre.wzsabre.MainBroadcastReceiverTest"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `classifyReportAction`** in `MainBroadcastReceiver.java` (add method; note order — CONFIRM/DISCARD before REPORT so `CONFIRM_REPORT`/`DISCARD_REPORT` do not match the REPORT branch):
+
+```java
+    /**
+     * Classify an HR report-channel action to a normalized label, or null if the
+     * action is not a report/confirm/discard. CONFIRM/DISCARD are checked before
+     * REPORT so the legacy CONFIRM_REPORT/DISCARD_REPORT names do not fall into the
+     * REPORT branch (all three end in "REPORT").
+     */
+    static String classifyReportAction(String action) {
+        if (action == null) return null;
+        if (action.contains("CONFIRM")) return "CONFIRM";
+        if (action.contains("DISCARD")) return "DISCARD";
+        if (action.endsWith("REPORT"))  return "REPORT";
+        return null;
+    }
+```
+
+- [ ] **Step 4: Wire dispatch into `onReceive`.** Insert a branch AFTER the `endsWith("REQUEST")` branch and BEFORE the `contains("SHUTDOWN")` branch (a report action never ends with REQUEST, and SHUTDOWN never matches classifyReportAction, so ordering is safe; placing it here keeps fetch fast-pathed):
+
+```java
+            } else if (classifyReportAction(action) != null) {
+                String kind = classifyReportAction(action);
+                Log.d(TAG, "Report-channel action: " + action + " -> " + kind);
+                ForegroundServiceStarter.start(context, kind, intent.getStringExtra("data"));
+```
+
+- [ ] **Step 5: Run tests + build.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "app.sabre.wzsabre.MainBroadcastReceiverTest"`
+Expected: PASS. Then `./gradlew :app:assembleDebug` to confirm it compiles.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java app/src/test/java/app/sabre/wzsabre/MainBroadcastReceiverTest.java
+git commit -m "Dispatch HR REPORT/CONFIRM/DISCARD to the service"
+```
+
+Note: `ForegroundServiceStarter.start(context, kind, data)` puts `kind` as the `action` extra and `data` as the `data` extra; `SabreService.onStartCommand` handles them in Task 9. Until Task 9, these forwards are harmless no-ops (the service just re-arms its idle timer).
+
+---
+
+## Task 6: WazeReportCodec (proto assembly, testable)
+
+**Files:**
+- Create: `app/src/main/java/app/sabre/wzsabre/waze/WazeReportCodec.java`
+- Test: `app/src/test/java/app/sabre/wzsabre/waze/WazeReportCodecTest.java` (new)
+
+**Interfaces:**
+- Consumes: `ReportRequest`, `AlertMapper.wazeReportSubtype`, `WazeProto`.
+- Produces:
+  - `static WazeProto.AddUserReportedAlertRequest buildRequest(ReportRequest r, long nowMs, long fromNode, long toNode)` — builds the full request; if `fromNode`/`toNode` are both 0, omits `SegmentNodes` (position-only). Returns null if the type is not reportable (`wazeReportSubtype` null).
+  - `static String reportUuidFrom(WazeProto.Batch batch)` — response `alert_uuid` or null.
+  - `static int reportPointsFrom(WazeProto.Batch batch)` — response `received_points_count` or -1.
+
+This is `WazeProto`-only (no `android.util.Base64`), so it is fully JVM-testable. Base64 framing stays in `WazeRtCodec.protoBase64Line` and is exercised on the emulator.
+
+- [ ] **Step 1: Write the failing test** `WazeReportCodecTest.java`:
+
+```java
+package app.sabre.wzsabre.waze;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import app.sabre.wzsabre.ReportRequest;
+import org.json.JSONException;
+import org.junit.Test;
+
+public class WazeReportCodecTest {
+
+    private static ReportRequest req(String type) throws JSONException {
+        return ReportRequest.fromJson("{\"lat\":37.8,\"lon\":-122.27,\"heading_deg\":90.0," +
+                "\"type\":\"" + type + "\",\"time_delta_s\":10}");
+    }
+
+    @Test public void buildsPoliceRequestPositionOnly() throws JSONException {
+        WazeProto.AddUserReportedAlertRequest r =
+                WazeReportCodec.buildRequest(req("POLICE_VISIBLE"), 1_700_000_000_000L, 0, 0);
+        assertEquals(WazeProto.PoliceAlertSubType.POLICE_DEFAULT, r.getAlertDetails().getPolice().getType());
+        assertEquals(90, r.getAzymuth());
+        assertEquals(1_700_000_000L - 10, r.getReportTime().getSeconds());
+        assertEquals(WazeProto.ReportingManner.REPORTING_MANNER_DEFAULT, r.getReportingManner());
+        assertEquals(-122271200, r.getUserPosition().getGpsPosition().getCoordinate().getLonTimes1000000());
+        assertTrue(!r.getUserPosition().hasSegmentNodes()); // position-only
+    }
+
+    @Test public void buildsWithSegmentNodesWhenProvided() throws JSONException {
+        WazeProto.AddUserReportedAlertRequest r =
+                WazeReportCodec.buildRequest(req("HAZARD_ON_ROAD_POT_HOLE"), 1_700_000_000_000L, 111, 222);
+        assertEquals(111, r.getUserPosition().getSegmentNodes().getFromNode());
+        assertEquals(222, r.getUserPosition().getSegmentNodes().getToNode());
+        assertEquals(WazeProto.HazardReportSubType.HAZARD_REPORT_POTHOLE,
+                r.getAlertDetails().getHazardOnRoad().getType());
+    }
+
+    @Test public void oppositeDirectionSetsBackward() throws JSONException {
+        ReportRequest opp = ReportRequest.fromJson("{\"lat\":37.8,\"lon\":-122.27," +
+                "\"type\":\"ACCIDENT_MAJOR\",\"is_opposite\":true}");
+        WazeProto.AddUserReportedAlertRequest r = WazeReportCodec.buildRequest(opp, 1L, 0, 0);
+        assertEquals(WazeProto.SegmentDirection.SEGMENT_DIRECTION_BACKWARD, r.getSegmentDirection());
+        assertEquals(WazeProto.CrashReportSubType.CRASH_REPORT_MAJOR, r.getAlertDetails().getCrash().getType());
+    }
+
+    @Test public void nullForUnreportableType() throws JSONException {
+        assertNull(WazeReportCodec.buildRequest(req("SOS_MEDICAL_HELP"), 1L, 0, 0));
+    }
+
+    @Test public void parsesResponseUuidAndPoints() {
+        WazeProto.Batch batch = WazeProto.Batch.newBuilder()
+                .addElement(WazeProto.Element.newBuilder()
+                        .setAddUserReportedAlertResponse(WazeProto.AddUserReportedAlertResponse.newBuilder()
+                                .setAlertUuid("uuid-xyz").setReceivedPointsCount(6).build()).build())
+                .build();
+        assertEquals("uuid-xyz", WazeReportCodec.reportUuidFrom(batch));
+        assertEquals(6, WazeReportCodec.reportPointsFrom(batch));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "app.sabre.wzsabre.waze.WazeReportCodecTest"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `WazeReportCodec.java`:**
+
+```java
+package app.sabre.wzsabre.waze;
+
+import app.sabre.wzsabre.AlertMapper;
+import app.sabre.wzsabre.ReportRequest;
+
+/**
+ * Assembles the Waze AddUserReportedAlertRequest protobuf from a user's HR report,
+ * and reads the response uuid/points. Pure WazeProto (no android.util.Base64), so
+ * it is JVM-testable; the Base64 line framing lives in WazeRtCodec.
+ */
+final class WazeReportCodec {
+    private WazeReportCodec() {}
+
+    static WazeProto.AddUserReportedAlertRequest buildRequest(
+            ReportRequest r, long nowMs, long fromNode, long toNode) {
+        AlertMapper.WazeReportSubtype sub = AlertMapper.wazeReportSubtype(r.type);
+        if (sub == null) return null;
+
+        WazeProto.CoordinateWithAlt coord = WazeProto.CoordinateWithAlt.newBuilder()
+                .setLonTimes1000000((int) Math.round(r.lon * 1_000_000.0))
+                .setLatTimes1000000((int) Math.round(r.lat * 1_000_000.0))
+                .setAltTimes1000000((int) Math.round(r.altitudeM * 1_000_000.0))
+                .build();
+        WazeProto.GpsPosition gps = WazeProto.GpsPosition.newBuilder()
+                .setCoordinate(coord)
+                .setHorizontalAccuracyMeters(10.0)
+                .setTimeEpochMs(nowMs)
+                .build();
+        WazeProto.UserPosition.Builder pos = WazeProto.UserPosition.newBuilder().setGpsPosition(gps);
+        if (fromNode != 0 || toNode != 0) {
+            pos.setSegmentNodes(WazeProto.SegmentNodes.newBuilder()
+                    .setFromNode(fromNode).setToNode(toNode).build());
+        }
+
+        WazeProto.AddUserReportedAlertRequest.Builder b =
+                WazeProto.AddUserReportedAlertRequest.newBuilder()
+                .setUserPosition(pos.build())
+                .setAzymuth((int) Math.round(r.headingDeg))
+                .setAlertDetails(buildDetails(sub))
+                .setSegmentDirection(r.isOpposite
+                        ? WazeProto.SegmentDirection.SEGMENT_DIRECTION_BACKWARD
+                        : WazeProto.SegmentDirection.SEGMENT_DIRECTION_FORWARD)
+                .setReportTime(WazeProto.Timestamp.newBuilder()
+                        .setSeconds((nowMs / 1000L) - r.timeDeltaS).build())
+                .setReportingManner(WazeProto.ReportingManner.REPORTING_MANNER_DEFAULT);
+        return b.build();
+    }
+
+    private static WazeProto.AlertDetails buildDetails(AlertMapper.WazeReportSubtype sub) {
+        WazeProto.AlertDetails.Builder d = WazeProto.AlertDetails.newBuilder();
+        switch (sub.kind) {
+            case POLICE:
+                d.setPolice(WazeProto.PoliceDetails.newBuilder()
+                        .setType(WazeProto.PoliceAlertSubType.forNumber(sub.subtypeNumber)));
+                break;
+            case CRASH:
+                d.setCrash(WazeProto.CrashDetails.newBuilder()
+                        .setType(WazeProto.CrashReportSubType.forNumber(sub.subtypeNumber)));
+                break;
+            case TRAFFIC:
+                d.setTraffic(WazeProto.TrafficDetails.newBuilder()
+                        .setType(WazeProto.TrafficReportSubType.forNumber(sub.subtypeNumber)));
+                break;
+            case HAZARD:
+                d.setHazardOnRoad(WazeProto.HazardOnRoadDetails.newBuilder()
+                        .setType(WazeProto.HazardReportSubType.forNumber(sub.subtypeNumber)));
+                break;
+        }
+        return d.build();
+    }
+
+    static String reportUuidFrom(WazeProto.Batch batch) {
+        for (WazeProto.Element el : batch.getElementList()) {
+            if (el.hasAddUserReportedAlertResponse()) {
+                String u = el.getAddUserReportedAlertResponse().getAlertUuid();
+                if (u != null && !u.isEmpty()) return u;
+            }
+        }
+        return null;
+    }
+
+    static int reportPointsFrom(WazeProto.Batch batch) {
+        for (WazeProto.Element el : batch.getElementList()) {
+            if (el.hasAddUserReportedAlertResponse())
+                return el.getAddUserReportedAlertResponse().getReceivedPointsCount();
+        }
+        return -1;
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass.**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "app.sabre.wzsabre.waze.WazeReportCodecTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add app/src/main/java/app/sabre/wzsabre/waze/WazeReportCodec.java app/src/test/java/app/sabre/wzsabre/waze/WazeReportCodecTest.java
+git commit -m "Assemble Waze report protobuf from an HR report"
+```
+
+---
+
+## Task 7: WazeSession report commands
+
+**Files:**
+- Modify: `app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java`
+- Modify: `app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java` (add `reportPayload` framing helper)
+
+**Interfaces:**
+- Consumes: `WazeReportCodec.buildRequest`, existing `command()`, `prepareForArea()`.
+- Produces (package-private on `WazeSession`):
+  - `ReportResult submitReport(ReportRequest r, long nowMs)` — prepares the area, sends the report, returns `ReportResult{boolean accepted; String uuid; int points; String error}`. Position-only for now (fromNode/toNode = 0); tile-snap deferred to Task 11.
+  - `void confirmAlert(long id)` — `command("ThumbsUp," + id)`.
+  - `void discardAlert(long id)` — `command("ReportRmAlert," + id)`.
+  - `ReportResult` is a small package-private static class in the `waze` package (new file `ReportResult.java`).
+
+This task's methods do network I/O, so they are validated on the emulator (Task 11), not by JVM unit tests. The unit-testable pieces (request assembly, response parse) are already covered in Task 6.
+
+- [ ] **Step 1: Add the Base64 framing helper** to `WazeRtCodec.java` (below `protoBase64Line`, keeping Base64 here):
+
+```java
+    /** One report line: ProtoBase64-framed AddUserReportedAlertRequest on an Element. */
+    static String reportPayload(WazeProto.AddUserReportedAlertRequest req) {
+        return protoBase64Line(WazeProto.Element.newBuilder()
+                .setAddUserReportedAlertRequest(req).build());
+    }
+```
+
+- [ ] **Step 2: Create `ReportResult.java`:**
+
+```java
+package app.sabre.wzsabre.waze;
+
+/** Outcome of a Waze report submission. */
+final class ReportResult {
+    final boolean accepted;
+    final String uuid;
+    final int points;
+    final String error;
+    private ReportResult(boolean a, String u, int p, String e) {
+        accepted = a; uuid = u; points = p; error = e;
+    }
+    static ReportResult ok(String uuid, int points) { return new ReportResult(true, uuid, points, null); }
+    static ReportResult fail(String error) { return new ReportResult(false, null, -1, error); }
+}
+```
+
+- [ ] **Step 3: Add the methods to `WazeSession.java`** (after `queryBox`):
+
+```java
+    /**
+     * Submit a user report to Waze. Prepares the area (handshake), sends the
+     * AddUserReportedAlertRequest, and reads the response uuid/points. Position-only
+     * (no road-snap SegmentNodes) unless a future tile-snap step supplies nodes.
+     */
+    ReportResult submitReport(app.sabre.wzsabre.ReportRequest r, long nowMs) throws Exception {
+        WazeProto.AddUserReportedAlertRequest req =
+                WazeReportCodec.buildRequest(r, nowMs, 0L, 0L);
+        if (req == null) return ReportResult.fail("unreportable type: " + r.type);
+        prepareForArea(r.lat, r.lon);
+        WazeProto.Batch batch = command(WazeRtCodec.reportPayload(req));
+        String uuid = WazeReportCodec.reportUuidFrom(batch);
+        int points = WazeReportCodec.reportPointsFrom(batch);
+        if (uuid != null) {
+            Log.d(TAG, "Report accepted: uuid=" + uuid + " pts=" + points);
+            return ReportResult.ok(uuid, points);
+        }
+        Log.w(TAG, "No report response in batch");
+        return ReportResult.fail("no report response");
+    }
+
+    /** Thumbs-up an existing Waze alert by its numeric id. */
+    void confirmAlert(long id) throws Exception {
+        prepareForArealess();
+        command("ThumbsUp," + id);
+        Log.d(TAG, "Confirmed alert " + id);
+    }
+
+    /** Remove/deny an existing Waze alert by its numeric id ("not there"). */
+    void discardAlert(long id) throws Exception {
+        prepareForArealess();
+        command("ReportRmAlert," + id);
+        Log.d(TAG, "Discarded alert " + id);
+    }
+
+    /** Ensure logged in for a bare command that needs no MapDisplayed handshake. */
+    private void prepareForArealess() throws Exception {
+        // confirm/discard carry lat/lon in the HR payload; callers that have them
+        // should use prepareForArea. When absent, ensure the session is at least
+        // registered+logged-in using the last known position is not available here,
+        // so require the caller to have prepared. If no session, this throws, and the
+        // caller (WazeReporter) will have called prepareForArea first.
+        if (session == null) throw new WazeExceptions.SessionExpiredException("confirm/discard before login");
+    }
+```
+
+Note: `WazeReporter` (Task 8) calls `prepareForArea(lat, lon)` before `confirmAlert`/`discardAlert` using the lat/lon from the CONFIRM/DISCARD payload, so `prepareForArealess` only guards against a missing session.
+
+- [ ] **Step 4: Build to confirm compilation.**
+
+Run: `./gradlew :app:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java app/src/main/java/app/sabre/wzsabre/waze/ReportResult.java
+git commit -m "Add Waze submitReport/confirmAlert/discardAlert to WazeSession"
+```
+
+---
+
+## Task 8: WazeReporter (session management + selfTest)
+
+**Files:**
+- Create: `app/src/main/java/app/sabre/wzsabre/waze/WazeReporter.java`
+
+**Interfaces:**
+- Consumes: `WazeSession`, `WazeProtocolSource`'s persistence pattern (SharedPreferences "waze_rt"), `ReportRequest`, `ConfirmDiscardRequest`.
+- Produces (public API used by `SabreService`):
+  - `WazeReporter(Context ctx)`
+  - `boolean submit(ReportRequest r)` — runs on the caller's worker thread; returns accepted.
+  - `void confirm(double lat, double lon, long wazeId)`
+  - `void discard(double lat, double lon, long wazeId)`
+  - `static void selfTest(Context ctx, double lat, double lon, String type)` — DEBUG helper.
+
+Reuse the read-path account: read the same persisted `community`/`secret`/device from SharedPreferences that `WazeProtocolSource` writes, so reporting shares the anonymous account instead of registering another (respects Waze's per-day cap). If none persisted, register a fresh session (and persist it under the same keys).
+
+- [ ] **Step 1: Read `WazeProtocolSource.ensureSession` and its PREFS constants** (`app/src/main/java/app/sabre/wzsabre/waze/WazeProtocolSource.java` around lines 320-360) to copy the exact SharedPreferences keys (`PREFS`, `community`, `secret`, `dev_mfr`, `dev_model`, ...). Match them so the account is shared.
+
+- [ ] **Step 2: Implement `WazeReporter.java`** using the same region() selection and persistence. Core shape:
+
+```java
+package app.sabre.wzsabre.waze;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import app.sabre.wzsabre.ConfirmDiscardRequest;
+import app.sabre.wzsabre.ReportRequest;
+
+/** Owns a Waze RT session for the WRITE path (report/confirm/discard). */
+public final class WazeReporter {
+    private static final String TAG = "WazeRT";
+    private static final String PREFS = "waze_rt"; // must match WazeProtocolSource
+
+    private final Context ctx;
+    private WazeSession session;
+
+    public WazeReporter(Context ctx) { this.ctx = ctx.getApplicationContext(); }
+
+    public synchronized boolean submit(ReportRequest r) {
+        try {
+            WazeSession s = ensureSession(r.lat, r.lon);
+            ReportResult res = s.submitReport(r, System.currentTimeMillis());
+            if (!res.accepted) Log.w(TAG, "Report not accepted: " + res.error);
+            return res.accepted;
+        } catch (Exception e) {
+            Log.w(TAG, "submit failed: " + e.getMessage());
+            invalidateOnAuthError(e);
+            return false;
+        }
+    }
+
+    public synchronized void confirm(double lat, double lon, long wazeId) {
+        if (wazeId < 0) return;
+        try { WazeSession s = ensureSession(lat, lon); s.prepareForArea(lat, lon); s.confirmAlert(wazeId); }
+        catch (Exception e) { Log.w(TAG, "confirm failed: " + e.getMessage()); invalidateOnAuthError(e); }
+    }
+
+    public synchronized void discard(double lat, double lon, long wazeId) {
+        if (wazeId < 0) return;
+        try { WazeSession s = ensureSession(lat, lon); s.prepareForArea(lat, lon); s.discardAlert(wazeId); }
+        catch (Exception e) { Log.w(TAG, "discard failed: " + e.getMessage()); invalidateOnAuthError(e); }
+    }
+
+    private WazeSession ensureSession(double lat, double lon) throws Exception {
+        if (session != null) return session;
+        String region = WazeProtocolSource.region(lat, lon);
+        SharedPreferences p = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+        String community = p.getString("community", null);
+        String secret = p.getString("secret", null);
+        WazeCredentials creds = (community != null && secret != null)
+                ? new WazeCredentials(community, secret) : null;
+        DeviceIdentity dev = new DeviceIdentity(
+                p.getString("dev_mfr", "Google"), p.getString("dev_model", "Pixel 8"),
+                p.getString("dev_os", "Android 15"),
+                p.getInt("dev_w", 1080), p.getInt("dev_h", 2400),
+                p.getString("dev_iid", java.util.UUID.randomUUID().toString()));
+        WazeSession s = new WazeSession(region, dev, creds);
+        s.prepareForArea(lat, lon); // registers if needed + logs in + handshake
+        // Persist any newly minted account under the SAME keys as the read path.
+        WazeCredentials got = s.getCredentials();
+        if (got != null && (community == null || secret == null)) {
+            p.edit().putString("community", got.community).putString("secret", got.secret)
+             .putString("dev_mfr", dev.manufacturer).putString("dev_model", dev.model)
+             .putString("dev_os", dev.osVersion).putInt("dev_w", dev.screenW).putInt("dev_h", dev.screenH)
+             .putString("dev_iid", dev.installationId).apply();
+        }
+        session = s;
+        return s;
+    }
+
+    private void invalidateOnAuthError(Exception e) {
+        if (e instanceof WazeExceptions.AccountRejectedException) {
+            session = null;
+            ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()
+               .remove("community").remove("secret").apply();
+        } else if (e instanceof WazeExceptions.SessionExpiredException && session != null) {
+            session.invalidateSession();
+        }
+    }
+
+    /** DEBUG-only: exercise the write path end to end. Logcat tag WazeRT. */
+    public static void selfTest(Context ctx, double lat, double lon, String type) {
+        try {
+            ReportRequest r = ReportRequest.fromJson(
+                "{\"lat\":" + lat + ",\"lon\":" + lon + ",\"type\":\"" + type + "\"}");
+            boolean ok = new WazeReporter(ctx).submit(r);
+            Log.d(TAG, "selfTest report accepted=" + ok);
+        } catch (Exception e) { Log.w(TAG, "selfTest failed: " + e.getMessage()); }
+    }
+}
+```
+
+- [ ] **Step 3: Adjust visibility as needed.** `WazeProtocolSource.region(...)` is currently `static` package-private (confirmed in source) so `WazeReporter` in the same package can call it. If `WazeCredentials`/`DeviceIdentity` constructors differ from the shape above, match the actual constructors (read `WazeCredentials.java`, `DeviceIdentity.java` before writing). This step is "read the two files, align the constructor calls."
+
+- [ ] **Step 4: Build.**
+
+Run: `./gradlew :app:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add app/src/main/java/app/sabre/wzsabre/waze/WazeReporter.java
+git commit -m "Add WazeReporter owning the write-path session"
+```
+
+---
+
+## Task 9: SabreService dispatch + fetch merge
+
+**Files:**
+- Modify: `app/src/main/java/app/sabre/wzsabre/SabreService.java`
+
+**Interfaces:**
+- Consumes: `UserReportStore`, `WazeReporter`, `ReportRequest`, `ConfirmDiscardRequest`.
+- Produces: service handles `action` values `REPORT`/`CONFIRM`/`DISCARD`; `handleFetchRequest` merges `userReportStore.activeAlerts(...)` into the response.
+
+- [ ] **Step 1: Add fields + init.** In `SabreService`, add:
+
+```java
+    private final UserReportStore userReportStore = new UserReportStore();
+    private WazeReporter wazeReporter;
+```
+
+and in `onCreate` (where sources are constructed): `wazeReporter = new WazeReporter(this);`
+
+- [ ] **Step 2: Dispatch in `onStartCommand`.** After the existing `FETCH_REQUEST` handling, add (each on the request executor so it never blocks the main thread):
+
+```java
+        if (action != null && action.equals("REPORT")) {
+            final String data = intent.getStringExtra("data");
+            requestExecutor.submit(() -> handleReport(data));
+        } else if (action != null && action.equals("CONFIRM")) {
+            final String data = intent.getStringExtra("data");
+            requestExecutor.submit(() -> handleConfirmDiscard(data, true));
+        } else if (action != null && action.equals("DISCARD")) {
+            final String data = intent.getStringExtra("data");
+            requestExecutor.submit(() -> handleConfirmDiscard(data, false));
+        }
+```
+
+- [ ] **Step 3: Add the handlers:**
+
+```java
+    private void handleReport(String data) {
+        try {
+            ReportRequest r = ReportRequest.fromJson(data);
+            // 1) Echo to the HR map immediately (guaranteed pin, independent of Waze).
+            userReportStore.add(r, System.currentTimeMillis());
+            // 2) Push to Waze (best-effort).
+            boolean ok = wazeReporter.submit(r);
+            Log.d(TAG, "Report handled: type=" + r.type + " wazeAccepted=" + ok);
+        } catch (Exception e) {
+            Log.w(TAG, "Bad REPORT payload: " + e.getMessage());
+        }
+    }
+
+    private void handleConfirmDiscard(String data, boolean confirm) {
+        try {
+            ConfirmDiscardRequest c = ConfirmDiscardRequest.fromJson(data);
+            if (c.test) { Log.d(TAG, "test " + (confirm ? "confirm" : "discard") + ", not sending"); return; }
+            long id = c.wazeAlertId();
+            if (confirm) {
+                wazeReporter.confirm(c.lat, c.lon, id);
+            } else {
+                wazeReporter.discard(c.lat, c.lon, id);
+                userReportStore.removeNear(c.lat, c.lon, System.currentTimeMillis()); // drop own echo if any
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Bad CONFIRM/DISCARD payload: " + e.getMessage());
+        }
+    }
+```
+
+- [ ] **Step 4: Merge the echo into the fetch response.** In `handleFetchRequest`, after all sources are collected into `allAlerts` and before dedupe/send, add:
+
+```java
+                allAlerts.addAll(userReportStore.activeAlerts(lat, lon, radius, System.currentTimeMillis()));
+```
+
+(Place it alongside the other `allAlerts.addAll(...)` calls, before the dedupe step near `SabreService.java:348`.)
+
+- [ ] **Step 5: Build + run the full unit suite** (nothing here is unit-tested directly, but confirm nothing else broke).
+
+Run: `./gradlew :app:testDebugUnitTest`
+Expected: PASS (all existing + new tests).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add app/src/main/java/app/sabre/wzsabre/SabreService.java
+git commit -m "Handle REPORT/CONFIRM/DISCARD and echo reports to the HR map"
+```
+
+---
+
+## Task 10: Debug broadcast harness
+
+**Files:**
+- Modify: `app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java` (add DEBUG-only `.REPORT_TEST`)
+
+**Interfaces:**
+- Produces: a DEBUG-only action `app.sabre.wzsabre.REPORT_TEST` that calls `WazeReporter.selfTest(context, lat, lon, type)` so the write path can be exercised via adb without HR.
+
+- [ ] **Step 1: Add the branch** in `onReceive` (alongside the existing DEBUG `.WAZE_TEST`):
+
+```java
+            } else if (BuildConfig.DEBUG && action != null && action.endsWith(".REPORT_TEST")) {
+                final double lat = numberExtra(intent, "lat", 37.8044);
+                final double lon = numberExtra(intent, "lon", -122.2712);
+                final String type = intent.hasExtra("type") ? intent.getStringExtra("type") : "POLICE_VISIBLE";
+                new Thread(() -> app.sabre.wzsabre.waze.WazeReporter.selfTest(context, lat, lon, type)).start();
+```
+
+- [ ] **Step 2: Build the debug APK.**
+
+Run: `./gradlew :app:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add app/src/main/java/app/sabre/wzsabre/MainBroadcastReceiver.java
+git commit -m "Add DEBUG REPORT_TEST broadcast for the Waze write path"
+```
+
+---
+
+## Task 11: Spike + emulator end-to-end validation (the risk-killer)
+
+This task decides the position-only vs tile-snap question and validates both guarantees on the A15 emulator against LIVE Waze and LIVE Highway Radar. No code is written until the spike result is known.
+
+- [ ] **Step 1: Boot the A15 emulator and install the debug APK** (per [[emulator_test_harness]]).
+
+Run: `./gradlew :app:installDebug`
+
+- [ ] **Step 2: Set the emulator GPS** to a real freeway location with live Waze activity (use `adb emu geo fix <lon> <lat>` or the extended controls).
+
+- [ ] **Step 3: Fire the position-only report spike:**
+
+```bash
+adb shell am broadcast -a app.sabre.wzsabre.REPORT_TEST \
+  -n app.sabre.wzsabre/.MainBroadcastReceiver \
+  --ef lat 37.8044 --ef lon -122.2712 --es type POLICE_VISIBLE
+```
+
+Then `adb logcat -s WazeRT` and look for either `Report accepted: uuid=... pts=...` (SUCCESS: position-only works, skip the tile-snap entirely) or a rejection / `No report response`.
+
+- [ ] **Step 4: Branch on the spike result.**
+  - **If accepted:** position-only is sufficient. No tile-snap needed. Proceed to Step 5.
+  - **If rejected/misplaced:** implement the tile-snap: port `fetchTileSegments` (Waze tile server GET) + a minimal `WazeTileParser` to recover `fromNode`/`toNode`, add an `At,...`/`MapDisplayed` step, and pass real nodes into `WazeReportCodec.buildRequest`. Reference: decompiled `WazeSession.smali` (`submitReport` ~5478, `fetchTileSegments` ~4598) and `WazeTileParser.smali`. This is a sub-plan of its own; write it as `docs/superpowers/plans/2026-08-12-waze-tile-snap.md` if reached, keeping this release's REPORT->Waze gated on it. (The HR echo + confirm/discard can still ship without it.)
+
+- [ ] **Step 5: Verify the report landed on live Waze.** Open the Waze app / live-map at the reported coordinate and confirm the pin appears (police icon). Record the observed uuid/points from logcat.
+
+- [ ] **Step 6: Verify the HR map echo (goal 1).** With HR installed and the plugin discovered, fire a real HR-shaped REPORT to our receiver:
+
+```bash
+adb shell am broadcast -a app.sabre.wzsabre.REPORT \
+  -n app.sabre.wzsabre/.MainBroadcastReceiver \
+  --es data '{"lat":37.8044,"lon":-122.2712,"heading_deg":90.0,"type":"POLICE_VISIBLE","is_opposite":false,"time_delta_s":0}'
+```
+
+Wait for HR's next fetch (~15s) and confirm the pin appears on HR's map. Confirm the same report also appears in the next fetch response JSON (logcat) with a `alert-0/userreport-*` id and a POLICE type.
+
+- [ ] **Step 7: Verify CONFIRM and DISCARD** against a real nearby Waze alert: read a live alert's id from a fetch response, then:
+
+```bash
+adb shell am broadcast -a app.sabre.wzsabre.CONFIRM -n app.sabre.wzsabre/.MainBroadcastReceiver --es data '{"lat":<lat>,"lon":<lon>,"alert_id":"alert-<id>/<uuid>","test":false}'
+adb shell am broadcast -a app.sabre.wzsabre.DISCARD -n app.sabre.wzsabre/.MainBroadcastReceiver --es data '{"lat":<lat>,"lon":<lon>,"alert_id":"alert-<id>/<uuid>","test":false}'
+```
+
+Confirm logcat shows "Confirmed alert <id>" / "Discarded alert <id>" and no session errors.
+
+- [ ] **Step 8: Record results** in the plan (check the boxes) and note the position-only-vs-tile-snap decision.
+
+---
+
+## Task 12: Ship v1.10.0 (only after Task 11 passes both guarantees)
+
+**Files:**
+- Modify: `app/build.gradle.kts` (version), `CHANGELOG` (find exact path/name in repo root), release notes.
+
+- [ ] **Step 1: Bump version.** In `app/build.gradle.kts`: `versionCode = 27`, `versionName = "1.10.0"`.
+
+- [ ] **Step 2: Add a CHANGELOG entry** for v1.10.0 (no em dashes, no attribution). Example copy:
+
+```
+## v1.10.0
+- Reports you make in Highway Radar now show on the map and are sent to Waze.
+- Confirming an alert (thumbs up) and marking one "not there" now reach Waze.
+```
+
+- [ ] **Step 3: Run the full suite + assemble release.**
+
+Run: `./gradlew :app:testDebugUnitTest` then `./gradlew :app:assembleRelease`
+Expected: PASS + BUILD SUCCESSFUL. Confirm total test count grew from 242.
+
+- [ ] **Step 4: Commit, then open a PR** (main is protected; do not push to main directly). Do NOT tag/release until the PR is merged and the user approves the release.
+
+```bash
+git add app/build.gradle.kts CHANGELOG
+git commit -m "v1.10.0: user reports reach the HR map and Waze"
+```
+
+- [ ] **Step 5: Push the branch and open the PR** with `gh pr create`, summarizing the two guarantees and the emulator validation evidence from Task 11.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Inbound REPORT/CONFIRM/DISCARD wired: Tasks 5, 9. ✓
+- HR map pin guarantee (echo store + merge): Tasks 4, 9. ✓
+- Waze write path (AddUserReportedAlertRequest + ThumbsUp/ReportRmAlert): Tasks 1, 6, 7, 8. ✓
+- Type mapping (render-safe echo + Waze subtype): Task 2. ✓
+- alert_id -> Waze id recovery: Task 3. ✓
+- Spike-first tile-snap decision: Task 11. ✓
+- Testing (unit + emulator) and ship gate: Tasks 11, 12. ✓
+- Constraints (no permission, no em dash, no attribution, 9-field response, source id): Global Constraints + enforced per task. ✓
+
+**Placeholder scan:** No TBD/TODO in code steps; all code blocks are concrete. Task 11 Step 4's tile-snap branch is intentionally conditional (a spike outcome), with a named follow-up plan file, not a placeholder in the shipped path.
+
+**Type consistency:** `WazeReportSubtype`/`.Kind` used consistently (Tasks 2, 6). `ReportResult` ok/fail used consistently (Tasks 7, 8). `ReportRequest`/`ConfirmDiscardRequest` field names match across Tasks 3, 6, 8, 9. `SabreResponseBuilder.SOURCE_WAZE` used for the echo source (Task 4) matches the existing waze source id. Proto enum name `POLICE_HIDDEN_REPORT` chosen to avoid collision with existing `AlertSubType.POLICE_HIDDEN`.

--- a/docs/superpowers/plans/2026-08-12-waze-roadsnap.md
+++ b/docs/superpowers/plans/2026-08-12-waze-roadsnap.md
@@ -1,0 +1,146 @@
+# Waze Road-Snap Port Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make user reports actually accepted by live Waze by porting the official app's GPS-to-road-segment snap (tile fetch + WZDF decode + segment match) and the full `submitReport` command sequence, so the report carries `SegmentNodes`.
+
+**Architecture:** Extend the existing `app.sabre.wzsabre.waze` package. Add a tile-server GET, a WZDF binary tile decoder, segment-snap geometry, and an `At`/`simulateDriving` command sequence; rewrite `WazeSession.submitReport` to snap the point and send directional `SegmentNodes`. No protobuf changes (the report proto tree already exists).
+
+**Tech Stack:** Java, protobuf-javalite (unchanged), OkHttp (WazeHttpClient), JUnit (JVM unit tests, no Robolectric).
+
+## Global Constraints
+- Port faithfully from the readable jadx reference `C:\Users\live\Documents\code\wzDecomp\wzsabre-2.2-jadx\sources\app\sabre\wzsabre\wazemo\`. The authoritative recon (exact wire formats, field offsets, URL params) is `.superpowers/sdd/2026-08-12-hr-reports-to-waze/roadsnap-recon.md` — read it first every task.
+- Reference package is `app.sabre.wzsabre.wazemo`; OUR package is `app.sabre.wzsabre.waze`. Adapt names to our existing classes (`WazeSession`, `WazeRtCodec`, `WazeConstants`, `WazeHttpClient`, `WazeProto`, `WazeReportCodec`).
+- No new Android permission (tile GET uses existing INTERNET). No new protobuf. No em dashes, no attribution.
+- Tile-local node indices (u16 & 0x7FFF) are what go on the wire as from_node/to_node — port section indexing EXACTLY.
+- All WZDF integers are little-endian. Reproduce `variation=PARTIAL_SIMPLIFICATION`, `p0=42`, `v0=0`, and the epoch `if-modified-since` literally.
+- Windows: run gradle via PowerShell with `$env:JAVA_HOME='C:\Program Files\Android\Android Studio\jbr'; .\gradlew.bat <task>`.
+
+---
+
+## Task R1: Tile constants, tile-id math, URL builder, HTTP GET
+
+**Files:**
+- Modify: `app/src/main/java/app/sabre/wzsabre/waze/WazeConstants.java` (add tile hosts + `TILE_NUM_ROWS`), `app/src/main/java/app/sabre/wzsabre/waze/WazeHttpClient.java` (add `get`)
+- Create: `app/src/main/java/app/sabre/wzsabre/waze/WazeTileCodec.java` (tile-id math + URL builder; pure)
+- Test: `app/src/test/java/app/sabre/wzsabre/waze/WazeTileCodecTest.java`
+
+**Interfaces:**
+- Produces: `WazeConstants.tileHost(String region)`; `WazeConstants.TILE_NUM_ROWS = 18000`; `WazeHttpClient.HttpResult get(String url, Map<String,String> headers)` (mirror the existing `post` return type); `WazeTileCodec.coordToTileId(double lon, double lat) -> int`; `WazeTileCodec.buildTileUrl(String tileHost, long serverSessionId, String secretKey, int tileId) -> String` (serverSessionId==0/secretKey==null => omit session part).
+
+- [ ] **Step 1: Read** `roadsnap-recon.md` section A, and jadx `WazeTileParser.java:35-50`, `WazeConstants.java:23,39-42`, `WazeHttpClient.java:65-71`.
+- [ ] **Step 2: Write failing tests** for `coordToTileId` and `buildTileUrl`:
+  - `coordToTileId(-122.2712, 37.8044)` equals `(((int)(-122.2712*1e6)+180000000)/10000)*18000 + (((int)(37.8044*1e6)+90000000)/10000)`. Compute the expected int literal and assert it.
+  - `buildTileUrl("ctilesgcs-am.waze.com", 833, "abc", 12345)` equals `https://ctilesgcs-am.waze.com/TileServer/multi-get?reqtype=tileBatch&protocol=2&sessionid=833&cookie=abc&num=1&variation=PARTIAL_SIMPLIFICATION&t0=12345&v0=0&p0=42`.
+  - `buildTileUrl("h",0,null,7)` omits the session part: `...&protocol=2&num=1&variation=...&t0=7&v0=0&p0=42`.
+- [ ] **Step 3: Run to verify failure.** `.\gradlew.bat :app:testDebugUnitTest --tests "app.sabre.wzsabre.waze.WazeTileCodecTest"`
+- [ ] **Step 4: Implement** `WazeConstants.tileHost`/`TILE_NUM_ROWS`, `WazeHttpClient.get` (port `WazeHttpClient.java:65-71`: `.url(url)` + header loop + `.get()`, returning the same `HttpResult{code, body}` the `post` path builds), and `WazeTileCodec` (coordToTileId + buildTileUrl per recon A).
+- [ ] **Step 5: Run to verify pass.** Same command → PASS.
+- [ ] **Step 6: Commit.** `Add Waze tile-id math, URL builder, and HTTP GET`
+
+---
+
+## Task R2: WZDF tile decoder + RoadSegment
+
+**Files:**
+- Create: `app/src/main/java/app/sabre/wzsabre/waze/RoadSegment.java`, `app/src/main/java/app/sabre/wzsabre/waze/WazeTileParser.java`
+- Test: `app/src/test/java/app/sabre/wzsabre/waze/WazeTileParserTest.java`
+
+**Interfaces:**
+- Consumes: a `Coord`-like point. Use a simple `double[]{lat,lon}` or a small `LatLon` value type — check if the package already has one; if not, create a minimal `LatLon` (fields `lat`, `lon`). Do NOT depend on Android.
+- Produces: `RoadSegment` (fields `long segmentId, long fromNode, long toNode, int heading, List<LatLon> points`); `WazeTileParser.parse(byte[] tileBytes) -> List<RoadSegment>` (empty list if no WZDF header / too few sections).
+
+- [ ] **Step 1: Read** `roadsnap-recon.md` section B and jadx `WazeTileParser.java:52-245`, `RoadSegment.java:83-90`. Port the byte-level logic VERBATIM (magic scan, inflate, alignOffset, section directory, sections 26/13/9/8, node/segment/polyline decode, `& 0x7FFF`, little-endian readers). Use `java.util.zip.Inflater`.
+- [ ] **Step 2: Write a structural failing test** (a real captured tile fixture may not exist yet, so test the decoder's guards deterministically):
+  - `parse(new byte[]{0,1,2})` returns empty list (no WZDF magic).
+  - Build a minimal valid buffer: `"WZDF"`+`01000000`+`00000300` header, then compressedLen/uncompressedLen for a deflate stream you construct in the test (use `java.util.zip.Deflater` to compress a hand-built sections buffer with `numSections<=26`), assert `parse` returns empty (the `numSections<=26` guard). This exercises magic-scan + inflate + the guard without needing a real tile.
+  - If time permits, construct a tiny full sections buffer (numSections=27, sections 26/13/9/8 populated for ONE segment between two nodes with no polyline deltas) and assert one RoadSegment with the expected from/to indices and endpoint coords. This is the highest-value test; include it.
+- [ ] **Step 3: Run to verify failure.**
+- [ ] **Step 4: Implement** `RoadSegment` + `WazeTileParser` per recon B (verbatim port). `LatLon` if needed.
+- [ ] **Step 5: Run to verify pass.**
+- [ ] **Step 6: Commit.** `Add WZDF Waze tile decoder and RoadSegment`
+
+---
+
+## Task R3: Segment-snap geometry (GeoUtils + SegmentMatch)
+
+**Files:**
+- Create: `app/src/main/java/app/sabre/wzsabre/waze/RoadGeo.java` (snap math; named RoadGeo to avoid clashing if a GeoUtils/GeoBoxes exists), `app/src/main/java/app/sabre/wzsabre/waze/SegmentMatch.java`
+- Test: `app/src/test/java/app/sabre/wzsabre/waze/RoadGeoTest.java`
+
+**Interfaces:**
+- Consumes: `RoadSegment`, `LatLon`.
+- Produces: `SegmentMatch` (fields `RoadSegment segment`, `boolean reverse`; methods `long fromNodeDirectional()` = reverse?segment.toNode:segment.fromNode, `long toNodeDirectional()` = reverse?segment.fromNode:segment.toNode); `RoadGeo.findMatchingSegment(LatLon pos, double heading, List<RoadSegment> segs, double maxAngleDiff, double maxDistM) -> SegmentMatch|null`; `RoadGeo.computeHeading(LatLon a, LatLon b) -> int`; helper `pointToSegmentDistM`.
+
+- [ ] **Step 1: Read** `roadsnap-recon.md` section C and jadx `GeoUtils.java:27-110`, `SegmentMatch.java:86-96`. Port the equirectangular-meters projection, `pointToSegmentDist`, `computeHeading`, and `findMatchingSegment` (nearest-by-distance among candidates within maxAngleDiff and maxDistM; `reverse = backAngleDiff < fwdAngleDiff`).
+- [ ] **Step 2: Write failing tests** (pure geometry, fully deterministic):
+  - A single east-west segment from (37.80,-122.28) to (37.80,-122.26); a point at (37.8001,-122.27) snaps to it with `dist` ~11m (< 50m) and returns a match; assert `match.segment.segmentId` and that `fromNodeDirectional/toNodeDirectional` match the non-reversed nodes when heading ~90°.
+  - A point 200m away (37.802,-122.27) returns null (beyond 50m).
+  - `computeHeading((37.80,-122.28),(37.80,-122.26))` is ~90° (east); assert within a degree or two.
+  - Reverse: heading ~270° selects `reverse=true` and swaps directional nodes.
+- [ ] **Step 3: Run to verify failure.**
+- [ ] **Step 4: Implement** `RoadGeo` + `SegmentMatch` per recon C.
+- [ ] **Step 5: Run to verify pass.**
+- [ ] **Step 6: Commit.** `Add Waze segment-snap geometry`
+
+---
+
+## Task R4: At/SeeMe command builders + fetchTileSegments
+
+**Files:**
+- Modify: `app/src/main/java/app/sabre/wzsabre/waze/WazeRtCodec.java` (add `atCommand`, `seeMeCommand(int)`), `app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java` (add `fetchTileSegments`)
+- Test: `app/src/test/java/app/sabre/wzsabre/waze/WazeRtCodecTest.java` (add cases)
+
+**Interfaces:**
+- Produces: `WazeRtCodec.atCommand(double lon,double lat,int heading,long fromNode,long toNode) -> String` = `At,{lon},{lat},0,{heading},1,{fromNode},{toNode},T,0,-1,-1,0` (lon/lat formatted like the existing Location command — match `WazeProto.java:186-189`; use `-1` for from/to when no match); `WazeRtCodec.seeMeCommand(int mode) -> String` (mode 1 => existing `SeeMe,1,2,T,T,T,1,-1,1,7`; mode 2 => `SeeMe,2`); package-private `WazeSession.fetchTileSegments(double lat,double lon) -> List<RoadSegment>` (builds the tile URL from the live session id/secret + region, GETs, parses via WazeTileParser; empty list on any failure, logged).
+
+- [ ] **Step 1: Read** `roadsnap-recon.md` sections A, D and jadx `WazeProto.java:186-205`, `WazeSession.java:599-668`.
+- [ ] **Step 2: Write failing tests** for the pure command builders in `WazeRtCodecTest`:
+  - `atCommand(-122.2712,37.8044,90,111,222)` equals `At,-122.2712,37.8044,0,90,1,111,222,T,0,-1,-1,0` (match the exact number formatting the existing `locationCommand` uses — verify against the current `WazeRtCodec.locationCommand`).
+  - `atCommand(...,-1,-1)` for the no-match case.
+  - `seeMeCommand(2)` equals `SeeMe,2`; `seeMeCommand(1)` equals the existing constant.
+- [ ] **Step 3: Run to verify failure.**
+- [ ] **Step 4: Implement** the builders, and `WazeSession.fetchTileSegments` (uses `WazeTileCodec.buildTileUrl` with `session.serverSessionId`/`session.secretKey`, `WazeConstants.tileHost(region)`, `http.get(...)`, then `WazeTileParser.parse`). `fetchTileSegments` is network I/O (no unit test); it just needs to compile and be covered by the live validation. Region: reuse `WazeProtocolSource.region(lat,lon)`.
+- [ ] **Step 5: Run tests + build.** focused WazeRtCodecTest PASS; `.\gradlew.bat :app:assembleDebug` SUCCESS.
+- [ ] **Step 6: Commit.** `Add At/SeeMe command builders and fetchTileSegments`
+
+---
+
+## Task R5: Rewrite submitReport to the full snap sequence
+
+**Files:**
+- Modify: `app/src/main/java/app/sabre/wzsabre/waze/WazeSession.java` (`submitReport`), possibly add a private `simulateDriving`
+
+**Interfaces:**
+- Consumes: `fetchTileSegments`, `RoadGeo.findMatchingSegment`, `WazeRtCodec.atCommand/seeMeCommand/handshake pieces`, `WazeReportCodec.buildRequest(r, nowMs, fromNode, toNode)` (already supports non-zero nodes -> SegmentNodes).
+- Produces: `submitReport(ReportRequest r, long nowMs)` now performs the recon-D sequence and returns `ReportResult.ok(uuid,points)` on acceptance, `fail(...)` otherwise.
+
+- [ ] **Step 1: Read** `roadsnap-recon.md` section D fully and jadx `WazeSession.java` submitReport orchestration + `WazeSession.smali:5478-7298` (for the exact command order).
+- [ ] **Step 2: Implement** `submitReport`:
+  1. `prepareForArea(r.lat, r.lon)` (ensures login + base handshake).
+  2. Command A: one `command()` POST of `seeMeCommand(1) + "\n" + locationCommand(lon,lat) + "\n" + mapDisplayedCommand(circleToBox(lon,lat))`.
+  3. `List<RoadSegment> segs = fetchTileSegments(r.lat, r.lon);`
+  4. `SegmentMatch m = RoadGeo.findMatchingSegment(new LatLon(r.lat,r.lon), r.headingDeg, segs, 15.0, 50.0);` heading int = `normalizeAngle360(round(r.headingDeg))` (add a small helper).
+  5. `long fromNode = m!=null ? m.fromNodeDirectional() : -1; long toNode = m!=null ? m.toNodeDirectional() : -1;`
+  6. Command B: one POST of `atCommand(lon,lat,heading,fromNode,toNode) + "\n" + mapDisplayedCommand(...)`.
+  7. If `m != null`: `simulateDriving(r.lat, r.lon, heading, m)` — 3 iterations, each steps the position ~1s along heading at 13.4 m/s (dLon=sin(rad)/mPerDegLon(lat)*13.4; dLat=cos(rad)/110574*13.4) and POSTs `atCommand(steppedLon,steppedLat,heading,fromNode,toNode) + "\n" + mapDisplayedCommand(stepped box)`. Do NOT Thread.sleep on a fresh emulator-blocking path longer than needed; a short (e.g. 200-1000ms) delay between steps is fine (responses unused). Wrap each in try/catch so a failed sim step does not abort the report.
+  8. Command C (the report): build `WazeProto.AddUserReportedAlertRequest req = WazeReportCodec.buildRequest(r, nowMs, m!=null?fromNode:0, m!=null?toNode:0);` (pass 0/0 when no match so SegmentNodes is omitted, matching current behavior; pass the directional nodes when matched). POST `WazeRtCodec.reportPayload(req)`; keep THIS response batch.
+  9. Command D: `command(seeMeCommand(2))` in a try/catch; ignore its result.
+  10. Parse the Command-C batch: `WazeReportCodec.reportUuidFrom` / `reportPointsFrom`; uuid non-null => `ReportResult.ok`, log "Report accepted: uuid=.. pts=.."; else `ReportResult.fail("no report response")`.
+  Log "Snapped to road {id} {FWD|REV} dist=" on match and "No road match ({n} candidates)" on null, mirroring the reference.
+- [ ] **Step 3: Build.** `.\gradlew.bat :app:assembleDebug` SUCCESS and `.\gradlew.bat :app:testDebugUnitTest` green (no regressions).
+- [ ] **Step 4: Commit.** `Rewrite submitReport to snap to a road segment before reporting`
+
+---
+
+## Task R6: Live emulator validation (manual — controller drives)
+
+- [ ] Rebuild + install debug APK on the A15 emulator. Warm the Waze read account (fetch until "Waze cache: N alerts" persists an account).
+- [ ] Fire ONE `HAZARD_ON_ROAD_POT_HOLE` report at a real road coordinate; confirm logcat shows "Snapped to road ..." then "Report accepted: uuid=.. pts=..". If accepted, retract via a DISCARD using the numeric id recovered from a follow-up fetch (or let it expire); confirm no crash.
+- [ ] If still "No report response", capture the raw tile GET bytes and the report POST for diagnosis (WZDF decode correctness / node-index assumption) before iterating.
+- [ ] Record the result in the ledger. Ship gate: only proceed to version bump/release once a real report is accepted by live Waze.
+
+## Self-Review
+- Coverage: tile GET+id (R1), WZDF decode (R2), snap (R3), commands+fetch (R4), submitReport sequence (R5), live gate (R6). ✓
+- No new proto / no new permission / port-verbatim constraints stated per task. ✓
+- Types: `LatLon`, `RoadSegment`, `SegmentMatch`, `WazeTileCodec`, `WazeTileParser`, `RoadGeo` names consistent across tasks. `WazeReportCodec.buildRequest(r,now,from,to)` reused (already exists). ✓

--- a/docs/superpowers/specs/2026-08-12-hr-reports-to-waze-design.md
+++ b/docs/superpowers/specs/2026-08-12-hr-reports-to-waze-design.md
@@ -1,0 +1,200 @@
+# Design: Bidirectional user reports (HR to plugin, plugin to Waze + HR map)
+
+Date: 2026-08-12
+Target version: v1.10.0 (versionCode 27), up from 1.9.6 (26)
+Status: approved design, pending spec review
+
+## Problem
+
+A user reports that reports they create inside Highway Radar (HR) do not reflect on
+the map, unlike the original SABRE (wzsabre) app.
+
+Root cause, confirmed by decompiling both apps:
+
+- The original wzsabre is **bidirectional**. When a user creates a report in HR, HR
+  fires `app.sabre.wzsabre.REPORT` (and `CONFIRM` / `DISCARD` for thumbs-up /
+  not-there) at the plugin's broadcast receiver. wzsabre handles all three and
+  **submits them to Waze's real RT server** (REPORT via the `AddUserReportedAlertRequest`
+  protobuf; CONFIRM via a `ThumbsUp,<id>` text command; DISCARD via `ReportRmAlert,<id>`).
+- SABRE Plus **declares** those actions in its manifest and even **advertises**
+  `report_action` / `confirm_action` / `discard_action` to HR in the handshake, so HR
+  believes the plugin accepts reports. But `MainBroadcastReceiver.onReceive` has no
+  branch for them: every REPORT/CONFIRM/DISCARD falls through and is silently dropped.
+  The Waze integration is also read-only (register/login/query); the reporting protobuf
+  messages are deliberately omitted from `waze.proto`.
+
+So the user's reports go nowhere: not to the HR map, not to Waze.
+
+## Goals
+
+1. **HR map pin — guaranteed.** A report the user makes in HR must appear as a pin on
+   HR's map. This is fully under our control and must be 100% reliable.
+2. **Push to Waze.** The report must be submitted to Waze's live RT server using the
+   same protocol the original uses, and verified to be accepted by live Waze before we
+   ship. (Bounded by Waze's own server behavior: anonymous-account caps, rate limits,
+   road-snap availability. We guarantee correct submission and verified acceptance on
+   the emulator, not that Waze never rate-limits a future report.)
+3. **Full parity:** handle REPORT, CONFIRM (thumbs up), and DISCARD (not there).
+
+## Non-goals
+
+- No new Android permission (report submission and tile fetch both use existing
+  INTERNET). This is a hard constraint.
+- No change to the existing read/fetch path except the merge in goal 1.
+- No user attribution and no em dashes in any user-facing string (Toast, CHANGELOG,
+  release notes).
+
+## Architecture
+
+Data flow added (control + write directions; the existing read path is unchanged):
+
+```
+HR  --REPORT/CONFIRM/DISCARD broadcast-->  MainBroadcastReceiver
+        --forward action+data-->  SabreService.onStartCommand (worker thread)
+              REPORT  -> UserReportStore.add (echo)  +  WazeReporter.submit
+              CONFIRM -> WazeReporter.confirm(alertId)
+              DISCARD -> UserReportStore.removeMatch  +  WazeReporter.discard(alertId)
+
+HR  --REQUEST (fetch)-->  SabreService.handleFetchRequest
+              merges UserReportStore entries into the alert list -> HR draws the pin
+```
+
+### 1. Inbound receiver (`MainBroadcastReceiver`)
+
+Add branches, checked in this order so legacy `*_REPORT` names disambiguate correctly:
+
+- `action.contains("CONFIRM")` -> forward as `"CONFIRM"` (covers `CONFIRM` and legacy `CONFIRM_REPORT`)
+- else `action.contains("DISCARD")` -> forward as `"DISCARD"` (covers `DISCARD` and legacy `DISCARD_REPORT`)
+- else `action.endsWith("REPORT")` -> forward as `"REPORT"` (covers `REPORT` and legacy `SUBMIT_REPORT`)
+
+These must be evaluated before nothing else swallows them; the existing
+`endsWith("REQUEST")` and `contains("SHUTDOWN")` branches do not match any of the three.
+Each branch calls `ForegroundServiceStarter.start(context, "<ACTION>", intent.getStringExtra("data"))`,
+identical to the FETCH_REQUEST path, so the Android 15/16 service-start hardening applies.
+
+### 2. Service dispatch (`SabreService.onStartCommand`)
+
+Add `action` cases `REPORT` / `CONFIRM` / `DISCARD`, each running on a worker thread
+(these do network I/O; must not block the main thread). They re-arm the idle timer like
+any other start. A new `ReportHandler` (or methods on the service) owns parsing + routing.
+
+### 3. Payload parsing
+
+- REPORT `data` JSON: `lat` (double), `lon` (double), `heading_deg` (double),
+  `altitude_m` (double), `type` (string), `is_opposite` (bool), `time_delta_s` (int).
+- CONFIRM / DISCARD `data` JSON: `lat` (double), `lon` (double), `alert_id` (string),
+  `test` (bool). `test=true` short-circuits the Waze network call (parity with original).
+
+Recover the numeric Waze alert id from `alert_id`: strip a leading `"alert-"`, split on
+`"/"`, take element 0 as a long. Our waze source already emits `alert_id = "alert-" + id + "/" + uuid`
+(`WazeProtocolSource.toSabreAlert`), so CONFIRM/DISCARD work with the ids we already send.
+
+### 4. HR map guarantee: `UserReportStore`
+
+- In-memory store (held by `SabreService`, or a singleton), thread-safe, TTL ~30 min.
+- On REPORT: build a synthetic `SabreAlert` immediately and add it:
+  - `alert_source = "waze"` (must be one of the advertised source ids).
+  - `type`: map the HR report `type` to a render-safe SABRE type via `AlertMapper`
+    (must start with POLICE/HAZARD/ACCIDENT or HR's renderer drops it).
+  - `alert_id`: a stable synthetic id, e.g. `alert-0/userreport-<epochMs>` so it never
+    collides with a real Waze id and so DISCARD can match it.
+  - `heading_deg`: the reported heading, or the -720 unknown sentinel.
+  - `report_ts`: now (minus `time_delta_s`).
+- `handleFetchRequest`: after collecting the five sources and before dedupe/send, add
+  `userReportStore.activeAlerts(lat, lon, radius)` (drops expired, filters to radius).
+  The pin then appears on HR's next poll (~15s) and persists up to the TTL.
+- On DISCARD: remove any store entry near the report coordinate (and, when the id maps
+  to a store entry, by id).
+
+### 5. Waze write path
+
+Extend `waze.proto` (reporting sub-tree, omitted today):
+
+- `AddUserReportedAlertRequest` with `UserPosition { GpsPosition { CoordinateWithAlt,
+  horizontalAccuracyMeters, timeEpochMs }, SegmentNodes { fromNode, toNode } }`,
+  `azymuth`, `alert_details` (AlertDetails), `segment_direction`, `report_time`
+  (Timestamp), `reporting_manner` (ReportingManner enum).
+- `AddUserReportedAlertResponse` with `alert_uuid` and `received_points_count`.
+- `AlertDetails` and the sub-detail messages actually used by the mapped types
+  (crash / traffic / hazard-on-road / police). Field numbers and wire types taken from
+  the decompiled `WazeProtocol` generated `writeTo` / `*_FIELD_NUMBER`, same method used
+  for the existing fetch messages.
+- The Element field numbers for the report request/response.
+
+`WazeSession` gains:
+
+- `confirmAlert(long id)` -> `command("ThumbsUp," + id)`.
+- `discardAlert(long id)` -> `command("ReportRmAlert," + id)`.
+- `submitReport(...)` -> the sequence the original uses: SeeMe/Location/MapDisplayed
+  handshake, optional road snap (see risk below), `buildReportLine`
+  (`AddUserReportedAlertRequest`), `command()` POST, then parse the response for
+  `alert_uuid` + `received_points_count` and log "Report accepted: uuid=… pts=…" (or a
+  specific failure). All three go through the existing single `command()` POST to
+  `/rtserver/distrib/command`, so no new endpoint or permission.
+
+Type mapping (HR `type` string -> Waze subtype), from the original's
+`WazeAlertReporter.buildAlertDetails`:
+`POLICE_VISIBLE`->POLICE_DEFAULT, `POLICE_HIDING`->POLICE_HIDDEN,
+`ACCIDENT_*`->CrashDetails, `JAM_*`->TrafficDetails,
+`HAZARD_ON_ROAD*` / `HAZARD_ON_SHOULDER*`->HazardOnRoadDetails. Unknown -> reject the
+Waze submit (the HR echo still shows, so the pin is never lost).
+
+A new `WazeReporter` (parallel to the read-path `WazeProtocolSource`) owns report
+sessions and reuses the persisted anonymous account + login where possible.
+
+### 6. The one real risk: road snap
+
+The original snaps the report's GPS point to a Waze road *segment* via a separate
+tile-server protocol (`fetchTileSegments` -> `WazeTileParser`, a large surface) and
+sends `SegmentNodes { fromNode, toNode }`.
+
+**Spike first, before porting any tile code.** Implement `submitReport` with a
+position-only `AddUserReportedAlertRequest` (no `SegmentNodes`) and test against live
+Waze on the emulator:
+
+- If Waze accepts the position-only report (returns `alert_uuid` + points), we skip the
+  entire tile-parser port. This is the preferred outcome (much smaller surface).
+- If Waze rejects it or misplaces it, port `fetchTileSegments` + `WazeTileParser` +
+  the At/MapDisplayed/simulateDriving steps and send full `SegmentNodes`.
+
+This decision is made empirically in implementation step 1, not now.
+
+## Testing / verification
+
+Unit (JVM, grow the 242-test suite):
+
+- Action disambiguation in the receiver (CONFIRM_REPORT -> confirm, SUBMIT_REPORT ->
+  report, etc.).
+- REPORT/CONFIRM/DISCARD JSON parsing incl. missing/renamed keys and `test=true`.
+- `alert_id` -> numeric Waze id recovery (and rejection of malformed ids).
+- HR type -> render-safe echo type, and HR type -> Waze subtype mapping.
+- `AddUserReportedAlertRequest` golden-bytes encoding against a fixture captured from
+  the decompiled builder (locks the wire format).
+- `UserReportStore` TTL expiry, radius filter, and DISCARD removal.
+
+End-to-end (A15 emulator, per the established harness):
+
+1. Fire a simulated HR report: `adb shell am broadcast -a app.sabre.wzsabre.REPORT
+   -n app.sabre.wzsabre/.MainBroadcastReceiver --es data '{...}'`.
+2. Confirm the next fetch response (logcat) includes the echoed pin (goal 1).
+3. Confirm logcat shows Waze accepting the report ("Report accepted: uuid=… pts=…").
+4. Confirm the pin on real Waze (live-map / Waze app) at that coordinate.
+5. Repeat for CONFIRM and DISCARD against a real nearby Waze alert.
+
+**Ship gate:** tag and release v1.10.0 only after goals 1 and 2 are both verified on the
+emulator against live Waze and live HR. If the position-only Waze path cannot be made to
+work and the tile-snap port is out of scope for this release, ship goal 1 (HR map pin,
+fully guaranteed) plus CONFIRM/DISCARD, and split the REPORT->Waze push into a follow-up
+rather than shipping something unverified.
+
+## Files touched (anticipated)
+
+- `MainBroadcastReceiver.java` — new REPORT/CONFIRM/DISCARD branches.
+- `SabreService.java` — dispatch + merge `UserReportStore` into fetch response.
+- New `ReportHandler.java` (or methods), `UserReportStore.java`.
+- New `waze/WazeReporter.java`; extend `waze/WazeSession.java`, `waze/WazeRtCodec.java`.
+- `app/src/main/proto/waze.proto` — reporting messages.
+- `AlertMapper.java` — HR type -> render-safe echo type + HR type -> Waze subtype (if not
+  already covered).
+- Tests under `app/src/test/java/app/sabre/wzsabre/`.
+- `CHANGELOG` / release notes / `build.gradle.kts` version bump at ship time.


### PR DESCRIPTION
## What this does

Restores the bidirectional reporting the original wzsabre had and SABRE Plus was missing. Before this, the plugin advertised to Highway Radar that it accepts reports but had no handler, so every report a user made in HR was silently dropped: it reached neither the HR map nor Waze.

**Now:**
- **Reports show on the HR map.** A report you make in HR is echoed into every fetch response for ~30 min as a render-safe pin, so it appears on your map immediately, independent of Waze.
- **Reports are submitted to Waze.** Ported the original app's road-snap: fetch the Waze map tile, decode its WZDF binary, snap the point to the nearest road in your direction of travel, and submit an `AddUserReportedAlertRequest` with the road's segment nodes.
- **Confirm (thumbs up) and discard (not there)** forward to Waze.

## Validation (Android 15 emulator vs live Waze + HR)

- HR-map echo verified in the actual fetch response JSON (9-field shape, `alert_source=waze`, render-safe type).
- A snapped report is accepted by live Waze: `Snapped to road … -> Report accepted: pts=6 -> wazeAccepted=true`. Position-only reports (no segment nodes) get no response element, confirming the road-snap is required and works.
- The WZDF decoder was verified against a live tile (nearest road decoded 4 m from the point).

## Safety / constraints

- No new Android permission (report + tile fetch use existing INTERNET).
- HR fetch response stays exactly 9 fields; the echo merges pre-dedupe.
- Report I/O runs on a dedicated executor, so it can never delay HR fetches.
- The reporter reuses the read path's anonymous Waze account read-only: it never mints or deletes accounts, protecting the existing fetch feature.

## Quality

- Built test-first, per-task peer review, two whole-branch reviews (final verdict: ready to merge).
- 293 unit tests, all green. Debug build clean.
- Design, plan, and the reverse-engineering recon are under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVaT1ohRYHkMsX2Y6eiUCS