### PR TITLE
Adopt Google developer style across docs, website, and app text

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,4 +1,4 @@
-# Building from Source
+# Building from source
 
 ## Prerequisites
 
@@ -66,10 +66,10 @@ Current test suites:
 |-------|-------|----------------|
 | `AlertMapperTest` | 55 | CHP/Waze type → SABRE type (injury codes, locale independence, Waze coarse categories) |
 | `ChpConfigTest` | 42 | Category toggles, type overrides, age filter, LogTime parsing (both CHP feed formats) |
-| `SabreProtocolTest` | 38 | HR JSON schema, all 11 required alert fields, type whitelist, nullability, drop-bad-alert semantics |
+| `SabreProtocolTest` | 38 | HR JSON schema, all 11 required alert fields, type allowlist, nullability, drop-bad-alert semantics |
 | `LcsSourceTest` | 27 | Caltrans LCS parsing, 1097/1098/1022 state filtering, shoulder/aux skip, span pins, district selection |
-| `CHPSourceTest` | 18 | XML parsing (incl. entity refs + real feed shape), radius filter, coordinate parsing, haversine |
-| `WildfireSourceTest` | 7 | WFIGS ArcGIS JSON parse (incl. error body + RX filter), SABRE mapping |
+| `CHPSourceTest` | 18 | XML parsing (including entity refs + real feed shape), radius filter, coordinate parsing, haversine |
+| `WildfireSourceTest` | 7 | WFIGS ArcGIS JSON parse (including error body + RX filter), SABRE mapping |
 | `WinterSourceTest` | 7 | Chain-control parse, R-0 to R-3 active filtering, SABRE mapping |
 | `AlertDeduperTest` | 7 | Cross-source-only pin de-duplication (family + proximity, confirm-fold) |
 | `UpdateCheckerTest` | 4 | Version-comparison logic for the update check |
@@ -115,7 +115,7 @@ app/src/main/java/app/sabre/wzsabre/
 ## Key architecture decisions
 
 ### Package ID = `app.sabre.wzsabre`
-Highway Radar's SABRE discovery whitelists this package ID. Keeping the same ID means HR finds this plugin without requiring any HR-side changes.
+Highway Radar's SABRE discovery allowlists this package ID. Keeping the same ID means HR finds this plugin without requiring any HR-side changes.
 
 ### SABRE protocol: `SabreFetchResponseAlert` schema
 HR uses `kotlinx.serialization` with a bitmask that requires **all 11 fields** to be present on every alert object. Missing any field throws `MissingFieldException` in HR and crashes the crowdsourced-alert layer. `SabreResponseBuilder.buildAlert()` enforces this and rejects NaN coordinates and overflowing `report_ts` at build time.
@@ -139,8 +139,8 @@ deltas (adds upsert, removals soft-delete for 5 min) instead of replacing the ca
 what stops alerts from vanishing mid-drive. Each refresh queries a series of progressively
 smaller boxes (`GeoBoxes`, a shrinking-bbox scan) so the server doesn't thin out
 minor alerts near the driver; the session is pre-warmed at service start from the last known
-location; and Waze subtype names are passed through to HR verbatim (no remap/whitelist), since
-HR understands the full Waze vocabulary.
+location; and Waze subtype names are passed through to HR verbatim (no remap/allowlist), since
+HR accepts the full Waze vocabulary.
 
 ### Caltrans LCS closures
 Lane/road closures come from the per-district Caltrans Lane Closure System feeds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project. This project adheres to [semantic-ish versi
 ## [1.9.6] - 2026-08-04
 
 ### Added
-- **Better help when Highway Radar keeps using the old plugin.** Highway Radar remembers the plugin it first discovered, so after switching from wzsabre it can keep using the cached registration: it shows the old "WzSabre" name, and in some cases no alerts arrive at all. Restarting Highway Radar usually fixes it. When it does not, clearing Highway Radar's cache does. The Share diagnostics report, the README and the website now spell out both steps, in order, and warn to use "Clear cache" and not "Clear storage", which would erase your Highway Radar settings.
+- **Better help when Highway Radar keeps using the old plugin.** Highway Radar caches the plugin it first discovered, so after switching from wzsabre it can keep using the cached registration: it shows the old "WzSabre" name, and in some cases no alerts arrive at all. Restarting Highway Radar usually fixes it. When it does not, clearing Highway Radar's cache does. The Share diagnostics report, the README and the website now spell out both steps, in order, and warn to use "Clear cache" and not "Clear storage", which would erase your Highway Radar settings.
 - **The privacy policy now has its own web page**, at https://nicglazkov.github.io/highway-radar-sabre-plus/privacy.html. The Privacy button in the app opens that instead of a Markdown file on GitHub, so it is readable on a phone.
 
 ### Changed
@@ -36,7 +36,7 @@ All notable changes to this project. This project adheres to [semantic-ish versi
 ## [1.9.2] - 2026-07-10
 
 ### Fixed
-- **Fixes "plugin installed but no alerts" for anyone who used the original wzsabre first.** Highway Radar remembers a plugin by its ID and keeps the original wzsabre's cached setup even after you switch to SABRE Plus, so it kept asking for data using wzsabre's request name, which SABRE Plus did not answer (Highway Radar showed "Crowd-sourced alerts problems" and never sent a request). SABRE Plus now also answers the original wzsabre's request names, so Highway Radar starts receiving alerts immediately, with no need to re-detect the plugin.
+- **Fixes "plugin installed but no alerts" for anyone who used the original wzsabre first.** Highway Radar caches a plugin by its ID and keeps the original wzsabre's cached setup even after you switch to SABRE Plus, so it kept asking for data using wzsabre's request name, which SABRE Plus did not answer (Highway Radar showed "Crowd-sourced alerts problems" and never sent a request). SABRE Plus now also answers the original wzsabre's request names, so Highway Radar starts receiving alerts immediately, with no need to re-detect the plugin.
 
 ## [1.9.1] - 2026-07-10
 
@@ -56,7 +56,7 @@ All notable changes to this project. This project adheres to [semantic-ish versi
 ## [1.8.4] - 2026-07-09
 
 ### Fixed
-- **Highway Radar receives alert data again on the latest HR.** Highway Radar 3.2 tightened its plugin data format and removed two fields our alerts still sent (`user_id` and `confirm_count`). HR reads plugin responses strictly, so those extra fields made it silently reject every response: the plugin looked connected but no alerts appeared. Our alert and discovery payloads now match HR 3.2's format exactly.
+- **Highway Radar receives alert data again on the latest HR.** Highway Radar 3.2 tightened its plugin data format and removed two fields the plugin's alerts still sent (`user_id` and `confirm_count`). HR reads plugin responses strictly, so those extra fields made it silently reject every response: the plugin looked connected but no alerts appeared. The plugin's alert and discovery payloads now match HR 3.2's format exactly.
 
 ## [1.8.3] - 2026-07-06
 
@@ -93,7 +93,7 @@ All notable changes to this project. This project adheres to [semantic-ish versi
 Fix found from a real test drive.
 
 ### Fixed
-- **Chain controls stop hammering feeds that don't exist.** In regions with no mountain routes (e.g. the Bay Area), Caltrans returns "not found" for the chain-control feed. The plugin was re-requesting those every few seconds all drive and showing a false error in Diagnostics; it now treats "not found" as "no chain controls here" and caches it like any other result.
+- **Chain controls stop hammering feeds that don't exist.** In regions with no mountain routes (for example, the Bay Area), Caltrans returns "not found" for the chain-control feed. The plugin was re-requesting those every few seconds all drive and showing a false error in Diagnostics; it now treats "not found" as "no chain controls here" and caches it like any other result.
 
 ## [1.7] - 2026-07-02
 
@@ -128,7 +128,7 @@ New data source, in-app updates, and quality-of-life.
 - **Automated releases**: pushing a version tag builds a signed APK and publishes the GitHub release via CI.
 
 ### Changed
-- Duplicate pins reported by more than one source (e.g. a CHP and a Waze accident at the same spot) are now merged into one.
+- Duplicate pins reported by more than one source (for example, a CHP and a Waze accident at the same spot) are now merged into one.
 - CI actions updated; the debug/release build is unchanged.
 
 ## [1.5.1] - 2026-07-01

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -6,14 +6,14 @@ SABRE Plus is a free, open-source Highway Radar plugin. It has **no servers, no 
 
 ## The short version
 
-- The app runs entirely on your phone. There is no server of ours for your data to reach.
-- We do not use analytics, crash-reporting services, advertising, or trackers of any kind.
-- We do not create accounts, assign user IDs, or read your device's advertising ID.
-- We do not store your location history, and we never sell or share data.
+- The app runs entirely on your phone. There is no SABRE Plus server for your data to reach.
+- SABRE Plus uses no analytics, crash-reporting services, advertising, or trackers of any kind.
+- SABRE Plus does not create accounts, assign user IDs, or read your device's advertising ID.
+- SABRE Plus does not store your location history, and never sells or shares data.
 
 ## What is stored on your device
 
-All of this is kept locally in the app's private storage and never transmitted by us:
+All of this is kept locally in the app's private storage and never transmitted:
 
 - **Your settings** (which sources and categories are on, the age filter, wildfire size, and so on).
 - **An anonymous Waze session.** To use the Waze feature, the app registers an anonymous session with Waze (no name, email, phone, or account). A session token is cached on your device so it does not have to re-register every time.
@@ -22,19 +22,19 @@ All of this is kept locally in the app's private storage and never transmitted b
 
 ## What leaves your device
 
-To show you road conditions, the app fetches data from public and third-party sources. These requests go directly from your device to those services; they do not pass through any server of ours.
+To show you road conditions, the app fetches data from public and third-party sources. These requests go directly from your device to those services; they do not pass through any SABRE Plus server.
 
 | Service | What is requested | Is your location sent? |
 |---|---|---|
 | **California Highway Patrol** (`media.chp.ca.gov`) | The statewide incident feed | No. The whole-state feed is fetched and filtered on your device. |
 | **Caltrans** (`dot.ca.gov`) | Lane-closure and chain-control feeds for the districts near you | No. Which district feeds to fetch is worked out on your device; your coordinates are not sent. |
 | **Wildfire feed / NIFC** (`arcgis.com`) | Active California wildfires | No. All active California fires are fetched and filtered on your device. |
-| **Waze** (`waze.com`) | Nearby crowd-sourced alerts | **Yes.** To return alerts near you, the app sends your **approximate location** (a map area around you) to Waze over an anonymous session. |
+| **Waze** (`waze.com`) | Nearby crowdsourced alerts | **Yes.** To return alerts near you, the app sends your **approximate location** (a map area around you) to Waze over an anonymous session. |
 | **GitHub** (`api.github.com`) | A check for a newer version of the app | No. This is a standard version check and sends no location. |
 
 As with any app that uses the internet, each service you contact can see your device's public **IP address**, and their use of it is governed by their own privacy policies. The Waze feature is the only case where your approximate location leaves the device. If you prefer not to send any location to Waze, you can turn the Waze source off in Highway Radar's settings.
 
-## What we never do
+## What the app never does
 
 - No analytics or usage tracking.
 - No advertising or ad identifiers.

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ An open-source **Highway Radar SABRE plugin** for California, and a drop-in **wz
 
 > **Package ID: `app.sabre.wzsabre`** (the same as wzsabre), so Highway Radar discovers this plugin automatically without any reconfiguration.
 
-> ### 👋 Switching from wzsabre? One quick step first
+> ### Switching from wzsabre? One quick step first
 >
 > SABRE Plus is the new home for what wzsabre used to do, and Android only lets **one of them** be installed at a time (they share the plugin ID that Highway Radar looks for). So if the old **wzsabre** app is on your phone:
 >
 > 1. **Uninstall wzsabre** (long-press its icon, then App info, then Uninstall)
 > 2. **Install SABRE Plus** (see [Installation](#installation) below)
 >
-> Your Highway Radar settings stay exactly as they are, and it finds the plugin automatically. Never had wzsabre? You are all set, just install below. 🙂
+> Your Highway Radar settings stay exactly as they are, and it finds the plugin automatically. Never had wzsabre? You are all set, install below.
 
 ---
 
@@ -72,7 +72,7 @@ Reports work both ways, like the original wzsabre. When you report something in 
 
 > **Why the persistent notification?** Android requires a foreground-service notification while the plugin is feeding alerts. The plugin only runs while Highway Radar is open and stops itself shortly after you close HR, so it isn't running (or notifying) in the background the rest of the time.
 
-> **After a phone reboot:** Just open Highway Radar, the plugin starts automatically when HR sends its first request.
+> **After a phone reboot:** Open Highway Radar, the plugin starts automatically when HR sends its first request.
 
 ### Option B: Auto-update with Obtainium
 
@@ -88,7 +88,7 @@ See [BUILDING.md](BUILDING.md).
 
 Open the **SABRE Plus** app to access settings. All changes take effect immediately on the next HR map refresh, no restart needed.
 
-### Alert Categories
+### Alert categories
 
 Each CHP category has two controls:
 
@@ -101,12 +101,12 @@ Each CHP category has two controls:
 | Minor Accidents | Accident (Minor) | Non-injury collisions, hit-and-run |
 | Officer on Road | Police Visible | Traffic control, construction escorts |
 | Closures & Congestion | Road Closure | Road closures, traffic advisories |
-| Debris & Road Hazards | Road Debris | Debris, vehicle fires, misc. hazards |
+| Debris & Road Hazards | Road Debris | Debris, vehicle fires, and miscellaneous hazards |
 | Weather Hazards | *Natural* | Fog, wind, snow, ice, chain controls |
 
 **Tip:** If you find the police icon distracting, set *Officer on Road → Shows as → Road Closure* to get a neutral congestion icon instead.
 
-### Incident Age
+### Incident age
 
 Drops CHP alerts older than a configurable threshold using the incident's actual `LogTime` from the feed (not the time your phone fetched it). This prevents stale multi-hour incidents from cluttering the map.
 
@@ -122,7 +122,7 @@ If you already have wzsabre installed:
 2. Install this APK, it uses the same package ID (`app.sabre.wzsabre`) so HR picks it up without any changes to HR's settings.
 3. Open the new app once to start the service.
 
-> The package ID being identical to wzsabre is intentional: HR's plugin discovery whitelists `app.sabre.wzsabre`, and we reuse it so no HR-side changes are needed.
+> The package ID being identical to wzsabre is intentional: HR's plugin discovery allowlists `app.sabre.wzsabre`, and the plugin reuses that ID so no HR-side changes are needed.
 
 ---
 
@@ -142,14 +142,14 @@ If you already have wzsabre installed:
 
 **No alerts at all, or Highway Radar still shows "WzSabre"**
 
-Highway Radar remembers the plugin it discovered and keeps using that cached registration after you swap wzsabre for SABRE Plus. Work through these in order:
+Highway Radar caches the plugin it discovered and keeps using that cached registration after you swap wzsabre for SABRE Plus. Work through these in order:
 
 1. Confirm HR is using the correct plugin: HR → Settings → SABRE → should show "SABRE Plus".
 2. Check that the alert categories are not all turned off in the app settings.
 3. Fully close and reopen Highway Radar (swipe it away from recents, then launch it again). This makes HR re-run plugin discovery.
 4. **If it still does not work, clear Highway Radar's cache:** Android **Settings → Apps → Highway Radar → Storage → Clear cache**, then open Highway Radar again. This drops the stale registration and forces a fresh discovery.
 
-> ⚠️ Use **Clear cache**, not **Clear storage**. Clear storage would erase your Highway Radar settings.
+> Use **Clear cache**, not **Clear storage**. Clear storage would erase your Highway Radar settings.
 
 Tapping **Share diagnostics** in the SABRE Plus app tells you which of these applies: it reports whether HR has re-detected SABRE Plus or is still running off a cached registration.
 
@@ -222,11 +222,11 @@ flowchart TD
 </details>
 
 - **CHP**: fetches `https://media.chp.ca.gov/sa_xml/sa.xml`, filters by radius and incident age, applies your category settings.
-- **Waze**: emulates the Waze mobile app's binary "RT" protocol. It registers an anonymous Waze session, logs in, and queries crowd-sourced alerts over Waze's protobuf API (the older live-map/georss API is now blocked). The RT feed is session-stateful (each alert is sent once, then removed when it clears), so query results are merged into a persistent alert cache rather than replacing it, this keeps alerts from disappearing as you drive. A series of progressively smaller map viewports is queried so the server doesn't thin out minor alerts near you, the session is pre-warmed at start to cut first-load latency, and Waze alert subtypes (e.g. *car stopped on shoulder*, *heavy traffic*) are passed through to Highway Radar verbatim rather than flattened.
+- **Waze**: emulates the Waze mobile app's binary "RT" protocol. It registers an anonymous Waze session, logs in, and queries crowdsourced alerts over Waze's protobuf API (the older live-map/georss API is now blocked). The RT feed is session-stateful (each alert is sent once, then removed when it clears), so query results are merged into a persistent alert cache rather than replacing it, this keeps alerts from disappearing as you drive. A series of progressively smaller map viewports is queried so the server doesn't thin out minor alerts near you, the session is pre-warmed at start to cut first-load latency, and Waze alert subtypes (for example, *car stopped on shoulder*, *heavy traffic*) are passed through to Highway Radar verbatim rather than flattened.
 - **Caltrans LCS**: fetches the per-district lane-closure feeds (`https://cwwp2.dot.ca.gov/data/d<N>/lcs/lcsStatusD<NN>.xml`) for whichever districts cover your location. Only closures that are physically established (CHP code 1097 set, not picked up or canceled) are shown; shoulder-only closures are skipped. Closures longer than 2 km get a pin at each end. The feeds are large (1 MB to 16 MB per district, uncompressed by Caltrans), so they are parsed in the background and never delay a Highway Radar request. They are refreshed every 15 minutes, which is what keeps mobile data use down, and that matters most in districts with very large feeds. Each refresh is a conditional request, so a feed that has not changed downloads nothing. Measured on 2026-08-05, Caltrans rewrites these files roughly every 5 minutes even when the contents are identical, so in practice the conditional request usually still returns a full body; it costs nothing and pays off whenever a feed goes quiet.
 - **Wildfires**: active California wildfires from the interagency WFIGS "Current Wildland Fire Incident Locations" feed (NIFC-hosted ArcGIS), filtered to active wildfires in California. Each is shown as a road hazard at the fire's location with its name, size, and containment. Fires the feed still flags as active but that are fully contained, along with stale leftovers and non-incident records such as training exercises, are filtered out. Background-cached like the other sources. Optional minimum-size filter in settings.
 - **Chain controls**: Caltrans winter chain-control status from the per-district CWWP feeds (`https://cwwp2.dot.ca.gov/data/d<N>/cc/ccStatusD<NN>.xml`). Records at level R-1/R-2/R-3 (in service) are shown as slippery-road hazards; off-season the feed is all R-0 so nothing shows.
-- **SABRE protocol**: a broadcast-intent IPC protocol defined by Highway Radar. Our plugin responds to `FETCH_REQUEST` broadcasts with a JSON payload containing `SabreFetchResponseAlert` objects.
+- **SABRE protocol**: a broadcast-intent IPC protocol defined by Highway Radar. SABRE Plus responds to `FETCH_REQUEST` broadcasts with a JSON payload containing `SabreFetchResponseAlert` objects.
 
 ---
 
@@ -238,7 +238,7 @@ Pull requests welcome. Run the test suite before submitting:
 ./gradlew test
 ```
 
-293 unit tests cover the SABRE response format, alert type mapping (incl. Waze category filters and report type mapping), report parsing and the road-snap report path (tile decode, segment match, acceptance), the Waze alert cache (delta merge + soft-delete), in-band Waze error classification, shrinking-box geometry, crowd-confirmation tracking, CHP XML parsing, Caltrans LCS and chain-control parsing and filtering, wildfire (WFIGS) parsing, cross-source de-duplication, the update-check version compare, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup, and [CHANGELOG.md](CHANGELOG.md) for release history.
+293 unit tests cover the SABRE response format, alert type mapping (including Waze category filters and report type mapping), report parsing and the road-snap report path (tile decode, segment match, acceptance), the Waze alert cache (delta merge + soft-delete), in-band Waze error classification, shrinking-box geometry, crowd-confirmation tracking, CHP XML parsing, Caltrans LCS and chain-control parsing and filtering, wildfire (WFIGS) parsing, cross-source de-duplication, the update-check version compare, config filtering, and LogTime parsing. See [BUILDING.md](BUILDING.md) for full dev setup, and [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ---
 

--- a/app/src/main/java/app/sabre/wzsabre/ChpCategory.java
+++ b/app/src/main/java/app/sabre/wzsabre/ChpCategory.java
@@ -8,32 +8,32 @@ package app.sabre.wzsabre;
 public enum ChpCategory {
 
     MAJOR_ACCIDENT(
-            "Fatal & Injury Accidents",
+            "Fatal and injury accidents",
             "1179, 1141, sig alerts, fatal collisions",
             "ACCIDENT_MAJOR"),
 
     MINOR_ACCIDENT(
-            "Minor Accidents",
+            "Minor accidents",
             "Non-injury collisions, hit-and-run",
             "ACCIDENT_MINOR"),
 
     POLICE_ON_ROAD(
-            "Officer on Road",
+            "Officer on road",
             "Traffic control, construction/maintenance escort",
             "POLICE_VISIBLE"),
 
     CONGESTION(
-            "Closures & Congestion",
+            "Closures and congestion",
             "Road closures, traffic advisories",
             "HAZARD_ON_ROAD_CONGESTION"),
 
     DEBRIS(
-            "Debris & Road Hazards",
+            "Debris and road hazards",
             "Debris, vehicle fires, unrecognized incidents",
             "HAZARD_ON_ROAD_DEBRIS"),
 
     WEATHER(
-            "Weather Hazards",
+            "Weather hazards",
             "Fog, wind, snow, ice, chain controls",
             null);   // null = keep natural per-type mapping (fog→FOG, snow→SLIPPERY, etc.)
 

--- a/app/src/main/java/app/sabre/wzsabre/ChpConfig.java
+++ b/app/src/main/java/app/sabre/wzsabre/ChpConfig.java
@@ -184,15 +184,15 @@ public class ChpConfig {
 
     // ── Display type options for the UI spinner ───────────────────────────────
 
-    /** Human-readable labels for the type picker. Index 0 = "Keep Default". */
+    /** Human-readable labels for the type picker. Index 0 = "Keep default". */
     public static final String[] TYPE_LABELS = {
-        "Keep Default",
-        "Accident (Major)",
-        "Accident (Minor)",
-        "Police Visible",
-        "Road Closure",
-        "Road Debris",
-        "Slippery Road",
+        "Keep default",
+        "Accident (major)",
+        "Accident (minor)",
+        "Police visible",
+        "Road closure",
+        "Road debris",
+        "Slippery road",
     };
 
     /** SABRE type values matching TYPE_LABELS. null = keep default. */

--- a/app/src/main/java/app/sabre/wzsabre/DiagnosticsReport.java
+++ b/app/src/main/java/app/sabre/wzsabre/DiagnosticsReport.java
@@ -116,15 +116,15 @@ public final class DiagnosticsReport {
         sb.append("Recent request interval: ")
           .append(interval <= 0 ? "n/a" : (interval / 1000) + "s").append('\n');
         String fa = DebugLog.lastFetchAction();
-        sb.append("Fetch action HR uses: ").append(fa == null ? "none received" : fa).append('\n');
+        sb.append("Fetch action Highway Radar uses: ").append(fa == null ? "none received" : fa).append('\n');
         sb.append("Handshakes (discovery) this session: ").append(DebugLog.handshakeCount()).append('\n');
-        sb.append("HR registration: ");
+        sb.append("Highway Radar registration: ");
         if (DebugLog.sessionFetchCount() == 0 && DebugLog.handshakeCount() == 0) {
-            sb.append("HR has not contacted the plugin yet this session\n");
+            sb.append("Highway Radar has not contacted the plugin yet this session\n");
         } else if (DebugLog.handshakeCount() > 0) {
-            sb.append("HR re-detected SABRE Plus (registration is current)\n");
+            sb.append("Highway Radar re-detected SABRE Plus (registration is current)\n");
         } else {
-            sb.append("HR is using a cached registration from a previously-installed plugin "
+            sb.append("Highway Radar is using a cached registration from a previously installed plugin "
                     + "(it may still display an old name like \"WzSabre\"). Data still flows. "
                     + "To refresh it: fully close and reopen Highway Radar. If that does not "
                     + "work, or no alerts arrive at all, clear Highway Radar's cache in "
@@ -132,7 +132,7 @@ public final class DiagnosticsReport {
                     + "cache, NOT Clear storage: Clear storage would erase your Highway Radar "
                     + "settings.\n");
         }
-        sb.append("We advertise to HR: id=app.sabre.wzsabre, version=").append(BuildConfig.VERSION_NAME)
+        sb.append("Advertised to Highway Radar: id=app.sabre.wzsabre, version=").append(BuildConfig.VERSION_NAME)
           .append(", request_action=app.sabre.wzsabre.REQUEST, sources=[chp,waze,lcs,fire,chains]\n");
     }
 

--- a/app/src/main/java/app/sabre/wzsabre/MainActivity.java
+++ b/app/src/main/java/app/sabre/wzsabre/MainActivity.java
@@ -186,7 +186,7 @@ public class MainActivity extends Activity {
 
     private void buildWazeFilters() {
         LinearLayout c = findViewById(R.id.wazeFilterContainer);
-        addWazeToggle(c, "Police & cameras", config.wazePolice, v -> config.wazePolice = v);
+        addWazeToggle(c, "Police and cameras", config.wazePolice, v -> config.wazePolice = v);
         addWazeToggle(c, "Accidents",        config.wazeAccidents, v -> config.wazeAccidents = v);
         addWazeToggle(c, "Hazards",          config.wazeHazards, v -> config.wazeHazards = v);
         addWazeToggle(c, "Traffic jams",     config.wazeJams, v -> config.wazeJams = v);
@@ -386,7 +386,7 @@ public class MainActivity extends Activity {
 
     private void updateServiceStatus() {
         TextView tv = findViewById(R.id.serviceStatus);
-        tv.setText("Plugin ready, runs while Highway Radar is open");
+        tv.setText("Plugin ready. Runs while Highway Radar is open.");
     }
 
     // ── Category rows ─────────────────────────────────────────────────────────

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,7 +30,7 @@
                 android:id="@+id/serviceStatus"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Service starting..."
+                android:text="Starting the service"
                 android:textSize="13sp"
                 android:textColor="#BBDEFB"
                 android:layout_marginTop="4dp" />
@@ -68,7 +68,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="CHP ALERT CATEGORIES"
+            android:text="CHP alert categories"
             android:textSize="11sp"
             android:textStyle="bold"
             android:textColor="#757575"
@@ -90,7 +90,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="CALTRANS CLOSURES"
+            android:text="Caltrans closures"
             android:textSize="11sp"
             android:textStyle="bold"
             android:textColor="#757575"
@@ -117,7 +117,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Lane &amp; road closures (LCS)"
+                    android:text="Lane and road closures (LCS)"
                     android:textSize="14sp"
                     android:textColor="#212121" />
 
@@ -140,7 +140,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="WILDFIRES"
+            android:text="Wildfires"
             android:textSize="11sp"
             android:textStyle="bold"
             android:textColor="#757575"
@@ -214,7 +214,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="CHAIN CONTROLS"
+            android:text="Chain controls"
             android:textSize="11sp"
             android:textStyle="bold"
             android:textColor="#757575"
@@ -264,7 +264,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="INCIDENT AGE"
+            android:text="Incident age"
             android:textSize="11sp"
             android:textStyle="bold"
             android:textColor="#757575"
@@ -291,7 +291,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Drops stale CHP log entries using the incident's own LogTime"
+                android:text="Drops stale CHP entries based on the time the incident was logged"
                 android:textSize="12sp"
                 android:textColor="#757575"
                 android:layout_marginTop="2dp"
@@ -307,7 +307,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="WAZE FILTERS"
+            android:text="Waze filters"
             android:textSize="11sp"
             android:textStyle="bold"
             android:textColor="#757575"
@@ -332,7 +332,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="NOTIFICATIONS"
+            android:text="Notifications"
             android:textSize="11sp"
             android:textStyle="bold"
             android:textColor="#757575"
@@ -368,7 +368,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="DIAGNOSTICS"
+            android:text="Diagnostics"
             android:textSize="11sp"
             android:textStyle="bold"
             android:textColor="#757575"
@@ -398,7 +398,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="ABOUT"
+            android:text="About"
             android:textSize="11sp"
             android:textStyle="bold"
             android:textColor="#757575"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">caltransSABRE</string>
+    <string name="app_name">SABRE Plus</string>
 </resources>

--- a/docs/index.html
+++ b/docs/index.html
@@ -122,10 +122,10 @@
       <p class="label">What it adds</p>
       <h2>Five feeds, one map layer.</h2>
       <p>
-        Every source is fetched in parallel, filtered to the area Highway Radar asked
-        about, de-duplicated across sources, and handed over as standard crowd alerts.
-        Reports go both ways too: when you report something in Highway Radar it shows on
-        your map and is submitted to Waze, over an anonymous session.
+        SABRE Plus fetches every source in parallel, filters it to the area Highway Radar
+        requested, de-duplicates it across sources, and hands over the result as standard
+        crowd alerts. Reports go both ways too: when you report something in Highway Radar
+        it shows on your map and is submitted to Waze, over an anonymous session.
         Turn any of them off in the app.
       </p>
 
@@ -156,10 +156,10 @@
           <h3>Lane and road closures</h3>
           <p>
             Closures that are physically in place right now, from the Caltrans Lane
-            Closure System. Shoulder work is skipped, and a long closure gets a pin at
-            each end so you see where it starts and stops.
+            Closure System. The app skips shoulder work, and gives a long closure a pin
+            at each end so you see where it starts and stops.
           </p>
-          <p class="source__cadence">Cached, refreshed every 15 min</p>
+          <p class="source__cadence">Cached, refreshed every 15 minutes</p>
         </article>
 
         <article class="source">
@@ -170,7 +170,7 @@
             size and containment. Contained and stale records are filtered out, and you
             can hide anything under a size you choose.
           </p>
-          <p class="source__cadence">Cached, refreshed every 5 min</p>
+          <p class="source__cadence">Cached, refreshed every 5 minutes</p>
         </article>
 
         <article class="source">
@@ -180,7 +180,7 @@
             R-1, R-2 and R-3 chain requirements on the mountain routes, at the
             checkpoint where they are enforced. I-80, US-50, SR-88, SR-89 and US-395.
           </p>
-          <p class="source__cadence">Cached, refreshed every 5 min</p>
+          <p class="source__cadence">Cached, refreshed every 5 minutes</p>
         </article>
       </div>
     </div>
@@ -202,7 +202,7 @@
         <figure>
           <img src="screenshots/hr_state.png" width="1080" height="2400" loading="lazy"
                alt="Highway Radar's plugin settings showing SABRE Plus detected and selected.">
-          <figcaption>Highway Radar finds the plugin on its own. Nothing to configure.</figcaption>
+          <figcaption>Highway Radar detects the plugin automatically. Nothing to configure.</figcaption>
         </figure>
         <figure>
           <img src="screenshots/hr-map.png" width="1080" height="2400" loading="lazy"
@@ -313,8 +313,8 @@
         <details>
           <summary>I installed it but no alerts arrive, or Highway Radar still says "WzSabre"</summary>
           <p>
-            Highway Radar remembers the plugin it first discovered and keeps using that
-            cached registration after you switch. Fully close and reopen Highway Radar,
+            Highway Radar caches the plugin registration it first discovered and keeps
+            using it after you switch. Fully close and reopen Highway Radar,
             which makes it run discovery again. If that does not fix it, clear Highway
             Radar's cache: Android Settings, then Apps, then Highway Radar, then Storage,
             then Clear cache. Use <strong>Clear cache</strong>, not Clear storage, because

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -68,7 +68,7 @@
 
     <h2>The short version</h2>
     <ul>
-      <li>The app runs entirely on your phone. There is no server of ours for your data to reach.</li>
+      <li>The app runs entirely on your phone. This project runs no server for your data to reach.</li>
       <li>No analytics, crash-reporting services, advertising or trackers of any kind.</li>
       <li>No accounts, no user IDs, and no reading of your device's advertising ID.</li>
       <li>No location history is stored, and nothing is ever sold or shared.</li>
@@ -76,7 +76,7 @@
 
     <h2>What is stored on your device</h2>
     <p>
-      All of this is kept in the app's private storage and is never transmitted by us:
+      All of this stays in the app's private storage, and the app never transmits it:
     </p>
     <ul>
       <li>
@@ -96,7 +96,7 @@
         location, street names, alert IDs or personal data.
       </li>
       <li>
-        <strong>A local crash log.</strong> If the app crashes, a summary is written to a
+        <strong>A local crash log.</strong> If the app crashes, it writes a summary to a
         private file so you can include it in a bug report if you want to. It stays on
         your device unless you share it.
       </li>
@@ -106,7 +106,7 @@
     <p>
       To show you road conditions, the app fetches data from public and third-party
       sources. Those requests go straight from your device to those services. They do not
-      pass through any server of ours.
+      pass through any server this project runs.
     </p>
 
     <div class="tablewrap">
@@ -127,10 +127,10 @@
           <tr>
             <td><strong>Caltrans</strong><br><code>dot.ca.gov</code></td>
             <td>Lane-closure and chain-control feeds for the districts near you</td>
-            <td class="ans"><span class="ans-no">No.</span> Which districts to fetch is worked out on your device. Your coordinates are not sent.</td>
+            <td class="ans"><span class="ans-no">No.</span> The app works out which districts to fetch on your device. Your coordinates are not sent.</td>
           </tr>
           <tr>
-            <td><strong>Wildfire feed, NIFC</strong><br><code>arcgis.com</code></td>
+            <td><strong>Interagency WFIGS feed, NIFC</strong><br><code>arcgis.com</code></td>
             <td>Active California wildfires</td>
             <td class="ans"><span class="ans-no">No.</span> All active California fires are fetched, then filtered on your device.</td>
           </tr>


### PR DESCRIPTION
Brings the repo's user-facing writing in line with the [Google Developer Documentation Style Guide](https://developers.google.com/style) and, for the app UI, Material's writing guidance. Text only: no behavior, no protocol, no layout structure changes.

## What changed

**Inclusive language**
- `whitelist` / `whitelists` to `allowlist` / `allowlists` (BUILDING.md x3, README.md x1). This is the rule Google calls out explicitly.

**Voice: no first person for the project**
- 9 instances across README, CHANGELOG, and PRIVACY rewritten to name the product or use second person ("We do not use analytics" becomes "SABRE Plus uses no analytics").
- 3 more on the website's privacy page ("no server of ours", "by us").
- 1 in the app's shared diagnostics ("We advertise to HR:" becomes "Advertised to Highway Radar:").
- Every factual privacy claim keeps its exact meaning.

**Sentence case**
- Headings: README x2, BUILDING x1.
- App UI: nine ALL-CAPS section headers ("CHP ALERT CATEGORIES" and friends) and all Title-Case option labels ("Keep Default" becomes "Keep default", "Officer on Road" becomes "Officer on road").

**Word choice and clarity**
- Dropped "just"; "e.g." to "for example"; "incl." to "including"; "misc." to "miscellaneous"; "15 min" to "15 minutes".
- Settled on "crowdsourced" (closed form).
- Softened anthropomorphism ("remembers" to "caches", "understands" to "accepts", "asked about" to "requested").
- Active voice for the site's stacked passive chain in the sources intro.
- Ampersands spelled out as "and" in visible labels.
- De-jargoned the incident-age helper (dropped the internal `LogTime` field name).
- Removed 3 decorative emoji from README prose. Mermaid diagram glyphs kept: they are diagram iconography, not prose.

**Bug fixed along the way**
- `strings.xml` `app_name` was still `caltransSABRE`, contradicting the "SABRE Plus" name used everywhere else. Now correct. (It was unreferenced, so this is a latent-consistency fix.)

## Deliberately unchanged

- **Em dashes and middots remain banned.** Google permits em dashes; this project does not, and that house rule wins. Verified zero of either character across all changed surfaces.
- SABRE protocol strings: alert type constants, `TYPE_VALUES`, source ids, intent actions, package id, preferences keys. Verified byte-identical.
- The plugin name advertised to Highway Radar, and notification channel IDs.
- Verbatim quotes of Highway Radar's own UI ("Crowd-Sourced Alert Problems", the "WzSabre" label).
- CHANGELOG substance, versions, and dates: style-only edits.

## Verification

- 535 unit tests pass; `assembleDebug` succeeds.
- Confirmed by grep: no `whitelist`, no ALL-CAPS literal headers, no project-first-person, no em dash or middot.
- No test asserted on a changed display string, so no test expectations needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVaT1ohRYHkMsX2Y6eiUCS