### PR TITLE
v1.10.1: ship the Google-style UI wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project. This project adheres to [semantic-ish versioning](https://semver.org/); dates are release dates.
 
+## [1.10.1] - 2026-08-12
+
+### Changed
+- **Clearer, more consistent wording in the app.** Section headers and option labels now use sentence case ("CHP alert categories" rather than "CHP ALERT CATEGORIES", "Keep default" rather than "Keep Default"), visible labels spell out "and" instead of using an ampersand, the shared diagnostics report spells out "Highway Radar" instead of "HR", and the incident age setting no longer shows an internal field name. The README, this changelog, the privacy policy and the website were revised the same way. Nothing changed in how the plugin works, what it fetches, or what it sends to Highway Radar.
+
 ## [1.10.0] - 2026-08-12
 
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         // Highway Radar on Android 6.0 (API 23), so this drops no real users.
         minSdk = 24
         targetSdk = 35
-        versionCode = 27
-        versionName = "1.10.0"
+        versionCode = 28
+        versionName = "1.10.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Why

The `v1.10.0` release was built and published from `b2ff349` at 18:20 UTC. The writing-style pass (#41) merged at 19:58 UTC, about 97 minutes later. The tag never moved, so:

- The signed APK users download still has the old UI wording (`CHP ALERT CATEGORIES`, `Keep Default`, `We advertise to HR:`).
- `main` carried `versionCode 27 / 1.10.0`, the same version as the release but with different content, so two distinct builds both claimed to be 1.10.0.

## What this does

- Bumps to `versionCode = 28`, `versionName = "1.10.1"`.
- Adds the 1.10.1 CHANGELOG entry (the release workflow extracts notes by exact heading match, verified locally).

Tagging `v1.10.1` after merge builds the signed APK and publishes the release, which feeds Obtainium and the in-app update check.

## Scope

Text only. No functional change: no protocol strings, no source ids, no behavior. The six app files with the reworded strings already merged in #41; this release simply ships them.

Tests pass and `assembleDebug` succeeds locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVaT1ohRYHkMsX2Y6eiUCS