### PR TITLE
Apply Google style to the release notes header and bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,33 +5,33 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for the report! Most issues here are specific to an Android version or Highway Radar version, so the details below really help.
+        Thanks for the report. Most issues here are specific to an Android version or a Highway Radar version, so the details below help.
   - type: textarea
     id: what-happened
     attributes:
       label: What happened?
       description: What did you expect, and what did you see instead?
-      placeholder: e.g. "A stopped car was in Waze but never appeared in Highway Radar."
+      placeholder: "A stopped car was in Waze but never appeared in Highway Radar."
     validations:
       required: true
   - type: input
     id: android-version
     attributes:
       label: Android version
-      placeholder: e.g. Android 15 (Pixel 8)
+      placeholder: Android 15 (Pixel 8)
     validations:
       required: true
   - type: input
     id: hr-version
     attributes:
       label: Highway Radar version
-      placeholder: e.g. 3.2
+      placeholder: "3.2"
   - type: input
     id: plugin-version
     attributes:
       label: Plugin (SABRE Plus) version
       description: Shown on the app's settings screen and the release you installed.
-      placeholder: e.g. 1.5.1
+      placeholder: 1.10.1
     validations:
       required: true
   - type: dropdown
@@ -54,7 +54,7 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Logcat (optional but very helpful)
+      label: Logcat (optional, but it helps)
       description: |
         If you can, capture logs while reproducing:
         `adb logcat -s SABREService WazeRT CHPSource LcsSource FGSStarter`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,9 +95,9 @@ jobs:
           fi
           # Every release leads with a friendly, unmissable note for wzsabre users.
           printf '%s\n' \
-            "> **👋 Coming from the original wzsabre? Uninstall it first.**" \
+            "> **Coming from the original wzsabre? Uninstall it first.**" \
             ">" \
-            "> SABRE Plus replaces wzsabre and shares the plugin ID that Highway Radar looks for, so Android only allows one of them at a time. Uninstall the old **wzsabre** app (long-press its icon, then App info, then Uninstall), then install SABRE Plus below. Your Highway Radar setup stays exactly as it is. Never had wzsabre? Just install, you are all set. 🙂" \
+            "> SABRE Plus replaces wzsabre and uses the same plugin ID that Highway Radar discovers, so Android allows only one of them at a time. Uninstall the old **wzsabre** app (long-press its icon, then App info, then Uninstall), then install SABRE Plus below. Your Highway Radar setup stays exactly as it is. If you never had wzsabre, install SABRE Plus and you are all set." \
             "" > RELEASE_NOTES.md
           cat BODY.md >> RELEASE_NOTES.md
           echo "--- release notes ---"; cat RELEASE_NOTES.md


### PR DESCRIPTION
Two files hold user-facing copy that the earlier style pass (#41) did not cover, because it was scoped to docs, the website, and app strings:

- `.github/workflows/release.yml` builds the header prepended to **every** GitHub release.
- `.github/ISSUE_TEMPLATE/bug_report.yml` is the form shown to anyone filing a bug.

## Changes

**Release notes header**
- Removed the two prose emoji.
- "Never had wzsabre? Just install, you are all set." becomes "If you never had wzsabre, install SABRE Plus and you are all set." (drops the "just" filler).
- "the plugin ID that Highway Radar looks for" becomes "the same plugin ID that Highway Radar discovers" (less anthropomorphic).
- "Android only allows one of them" becomes "Android allows only one of them" (modifier placement).

**Bug report form**
- Dropped "e.g." from all four placeholders. A placeholder is already an example, so it just shows the example now.
- Removed the exclamation point and the "really" intensifier from the intro.
- "Logcat (optional but very helpful)" becomes "Logcat (optional, but it helps)".
- Refreshed the stale plugin-version placeholder from 1.5.1 to 1.10.1.

## Notes

- No version bump: neither file affects the app binary, so there is nothing to ship in a release.
- Both YAML files were validated to parse.
- The existing v1.10.0 and v1.10.1 release pages will be updated separately to use the corrected header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVaT1ohRYHkMsX2Y6eiUCS